### PR TITLE
Added support for multicast ip notation and fixed exit conditions

### DIFF
--- a/scripts/sdp_master_controller.py
+++ b/scripts/sdp_master_controller.py
@@ -87,8 +87,6 @@ if __name__ == "__main__":
                 device.start()
                 logger.info("Started.")
     except KeyboardInterrupt:
-        pass
-    finally:
-        logger.info("Shutting down...")
+        server.handle_interrupt()
         server.stop()
         server.join()


### PR DESCRIPTION
Support for addressing in the <ip>[+<count>]:<port> format.

Cleaned up exit conditions so that even with configured data
products with active ingesters, everything will be shut down and
terminated as gracefully as possible.

@LauraRichter 
