### PR TITLE
Add --no-pull option to katsdpcontroller

### DIFF
--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -83,8 +83,10 @@ class ImageResolver(object):
     tag : str, optional
         If specified, images will use this tag instead of `latest`. It does
         not affect overrides, to allow them to specify their own tags.
+    pull : bool, optional
+        Whether to pull images from the `private_registry`.
     """
-    def __init__(self, private_registry=None, tag=None):
+    def __init__(self, private_registry=None, tag=None, pull=True):
         if private_registry is None:
             self._prefix = 'sdp/'
         else:
@@ -95,6 +97,7 @@ class ImageResolver(object):
             self._suffix = ':' + tag
         self._private_registry = private_registry
         self._overrides = {}
+        self.pull = pull
 
     def override(self, name, path):
         self._overrides[name] = path
@@ -104,7 +107,7 @@ class ImageResolver(object):
         log in to the explicitly specified private registry, and not any found
         in overrides.
         """
-        if self._private_registry is not None:
+        if self._private_registry is not None and self.pull:
             logger.debug("Docker login on host to private registry https://{}".format(self._private_registry))
             client.login('kat',password='kat',registry='https://{}'.format(self._private_registry))
 
@@ -114,7 +117,7 @@ class ImageResolver(object):
         registry, but images in other registries and specified by override are
         not pulled.
         """
-        return self._private_registry is not None and image.startswith(self._prefix)
+        return self._private_registry is not None and image.startswith(self._prefix) and self.pull
 
     def __call__(self, name):
         try:

--- a/scripts/sdp_master_controller.py
+++ b/scripts/sdp_master_controller.py
@@ -49,6 +49,8 @@ if __name__ == "__main__":
                       help='Override an image name lookup (default: none)')
     parser.add_option('--image-tag', dest='image_tag', type='string',
                       metavar='TAG', help='Image tag to use for resolving images')
+    parser.add_option('--no-pull', action='store_true', default=False,
+                      help='Skip pulling images from the registry')
     parser.add_option('-v', '--verbose', dest='verbose', default=False,
                       action='store_true', metavar='VERBOSE',
                       help='print verbose output (default: %default)')
@@ -78,7 +80,10 @@ if __name__ == "__main__":
     from katsdpcontroller import sdpcontroller
 
     logger.info("Starting SDP Controller...")
-    image_resolver = sdpcontroller.ImageResolver(opts.private_registry or None, opts.image_tag or None)
+    image_resolver = sdpcontroller.ImageResolver(
+            private_registry=opts.private_registry or None,
+            tag=opts.image_tag or None,
+            pull=not opts.no_pull)
     for override in opts.image_override:
         fields = override.split(':', 1)
         if len(fields) < 2:


### PR DESCRIPTION
This is intended for development/debugging, not production. For example,
it's handy for use on my laptop when I'm not in the office. It removes
the need for a connection to the registry.
