### PR TITLE
Make sure unique SPEAD ports are used between ingest and timeplot

### DIFF
--- a/katsdpgraphs/bc856M4k_logical.py
+++ b/katsdpgraphs/bc856M4k_logical.py
@@ -64,7 +64,7 @@ def build_physical_graph(r):
               })
      # calibration node
 
-    G.add_node('sdp.timeplot.1',{'html_port': r.get_sdisp_port_pair('timeplot')[0],\
+    G.add_node('sdp.timeplot.1',{'spead_port': r.get_port('spead_sdisp'), 'html_port': r.get_sdisp_port_pair('timeplot')[0],\
          'capture_server': '{}:{}'.format('127.0.0.1', r.get_port('sdp_ingest_1_katcp')),\
          'config_base': '/var/kat/config/.katsdpdisp','data_port': r.get_sdisp_port_pair('timeplot')[1],\
          'docker_image':r.get_image_path('katsdpdisp'), 'docker_host_class':'nvidia_gpu', 'docker_cmd':'time_plot.py --rts',\
@@ -92,6 +92,9 @@ def build_physical_graph(r):
 
     G.add_edge('sdp.ingest.1','sdp.cal.1',{'l0_spectral_spead':'{}:{}'.format(r.get_multicast_ip('l0_spectral_spead'), r.get_port('l0_spectral_spead'))})
      # ingest to cal node transfers L0 visibility data (no calibration)
+
+    G.add_edge('sdp.ingest.1','sdp.timeplot.1',{'sdisp_spead':'127.0.0.1:{}'.format(r.get_port('spead_sdisp'))})
+     # cal to file writer transfers L1 visibility data (cal tables applied)
 
     G.add_edge('sdp.ingest.1','sdp.filewriter.1',{'l0_spectral_spead':'{}:{}'.format(r.get_multicast_ip('l0_spectral_spead'),r.get_port('l0_spectral_spead'))})
      # cal to file writer transfers L1 visibility data (cal tables applied)

--- a/katsdpgraphs/c856M32k_logical.py
+++ b/katsdpgraphs/c856M32k_logical.py
@@ -50,10 +50,10 @@ def build_physical_graph(r):
               })
      # calibration node
 
-    G.add_node('sdp.timeplot.1',{'html_port': r.get_sdisp_port_pair('timeplot')[0],\
+    G.add_node('sdp.timeplot.1',{'spead_port': r.get_port('spead_sdisp'), 'html_port': r.get_sdisp_port_pair('timeplot')[0],\
          'capture_server': '{}:{}'.format('127.0.0.1', r.get_port('sdp_ingest_1_katcp')),\
          'config_base': '/var/kat/config/.katsdpdisp','data_port': r.get_sdisp_port_pair('timeplot')[1],\
-	 'docker_image':r.get_image_path('katsdpdisp'), 'docker_host_class':'nvidia_gpu', 'docker_cmd':'time_plot.py --rts',\
+         'docker_image':r.get_image_path('katsdpdisp'), 'docker_host_class':'nvidia_gpu', 'docker_cmd':'time_plot.py --rts',\
          'docker_params': {"network":"host", "binds": {"/var/kat/config":{"bind":"/var/kat/config","ro":False}}}})
      # timeplot
 
@@ -72,6 +72,9 @@ def build_physical_graph(r):
 
     G.add_edge('sdp.ingest.1','sdp.cal.1',{'l0_spectral_spead':'{}:{}'.format(r.get_multicast_ip('l0_spectral_spead'), r.get_port('l0_spectral_spead'))})
      # ingest to cal node transfers L0 visibility data (no calibration)
+
+    G.add_edge('sdp.ingest.1','sdp.timeplot.1',{'sdisp_spead':'127.0.0.1:{}'.format(r.get_port('spead_sdisp'))})
+     # cal to file writer transfers L1 visibility data (cal tables applied)
 
     G.add_edge('sdp.ingest.1','sdp.filewriter.1',{'l0_spectral_spead':'{}:{}'.format(r.get_multicast_ip('l0_spectral_spead'),r.get_port('l0_spectral_spead'))})
      # cal to file writer transfers L1 visibility data (cal tables applied)

--- a/katsdpgraphs/c856M4k_logical.py
+++ b/katsdpgraphs/c856M4k_logical.py
@@ -50,7 +50,7 @@ def build_physical_graph(r):
               })
      # calibration node
 
-    G.add_node('sdp.timeplot.1',{'html_port': r.get_sdisp_port_pair('timeplot')[0],\
+    G.add_node('sdp.timeplot.1',{'spead_port': r.get_port('spead_sdisp'), 'html_port': r.get_sdisp_port_pair('timeplot')[0],\
          'capture_server': '{}:{}'.format('127.0.0.1', r.get_port('sdp_ingest_1_katcp')),\
          'config_base': '/var/kat/config/.katsdpdisp','data_port': r.get_sdisp_port_pair('timeplot')[1],\
 	 'docker_image':r.get_image_path('katsdpdisp'), 'docker_host_class':'nvidia_gpu', 'docker_cmd':'time_plot.py --rts',\
@@ -74,6 +74,9 @@ def build_physical_graph(r):
      # ingest to cal node transfers L0 visibility data (no calibration)
 
     G.add_edge('sdp.ingest.1','sdp.filewriter.1',{'l0_spectral_spead':'{}:{}'.format(r.get_multicast_ip('l0_spectral_spead'),r.get_port('l0_spectral_spead'))})
+     # cal to file writer transfers L1 visibility data (cal tables applied)
+
+    G.add_edge('sdp.ingest.1','sdp.timeplot.1',{'sdisp_spead':'127.0.0.1:{}'.format(r.get_port('spead_sdisp'))})
      # cal to file writer transfers L1 visibility data (cal tables applied)
 
     G.add_edge('sdp.cal.1','null',{'l1_spectral_spead':'{}:{}'.format(r.get_multicast_ip('l1_spectral_spead'),r.get_port('l1_spectral_spead'))})


### PR DESCRIPTION
Note: Simulation graphs don't need this for now (at some stage they need to be reconciled anew)

@ludwigschwardt to review
