### PR TITLE
Add new host class calib for cal node

### DIFF
--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -226,6 +226,8 @@ class SDPResources(object):
                                {'ip':'ingest1.local','host_class':'nvidia_gpu'},
                            'mc1':\
                                {'ip':'mc1.local', 'host_class':'generic'},
+                           'cal1':\
+                               {'ip':'cal1.local', 'host_class':'calib'},
                            'bf_ingest1':\
                                {'ip':'bf_ingest1.local', 'host_class':'bf_ingest'},
                            'ssd_pod1':

--- a/katsdpgraphs/generator.py
+++ b/katsdpgraphs/generator.py
@@ -92,7 +92,7 @@ def build_physical_graph(beamformer_mode, cbf_channels, simulate, resources):
         })
      # filewriter
 
-    G.add_node('sdp.cal.1',{'docker_image':r.get_image_path('katsdpcal'),'docker_host_class':'nvidia_gpu', 'docker_cmd':'run_cal.py',\
+    G.add_node('sdp.cal.1',{'docker_image':r.get_image_path('katsdpcal'),'docker_host_class':'calib', 'docker_cmd':'run_cal.py',\
                'docker_params': {"network":"host","volumes":"/var/kat/data",\
                  "binds": {"/var/kat/data":{"bind":"/var/kat/data","ro":False}}}, 'cbf_channels': cbf_channels, \
               })


### PR DESCRIPTION
Moving up plans to include dedicated cal node for AR1 work since ingest appears to be taking strain with the much larger heap sizes of 16A/32k mode.

Accepting myself since there is no one around (public holiday)
