### PR TITLE
Increase capture-done timeout

### DIFF
--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -975,7 +975,7 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
             if self._state != 1:
                 logger.warning("Forcing capture_done on external request.")
                 try:
-                    self._issue_req('capture-done')
+                    self._issue_req('capture-done', timeout=300)
                 except RuntimeError:
                     pass # we gave it our best shot...
             self._deconfigure()
@@ -990,7 +990,7 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
          # issue shutdown commands for individual nodes via katcp
          # then terminate katcp connection
         try:
-            self._issue_req('capture-done',node_type='ingest')
+            self._issue_req('capture-done', node_type='ingest', timeout=300)
         except RuntimeError, e:
             logger.error("Failed to issue capture-done during shutdown request. Will continue with graph shutdown. Error was {}".format(e))
         self.graph.shutdown()


### PR DESCRIPTION
This is need when the array is deconfigured immediately after a
capture-done is issued. It takes some time to serialise the
telescope state into the HDF5 file, and capture-done is likely
to timeout on long runs (3hours +).

Needs to be revisited at some stage to remove all these damn
timeouts...

@bmerry to review
