### PR TITLE
Add reconfigure command

### DIFF
--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -1100,7 +1100,9 @@ class SDPControllerServer(DeviceServer):
         self.subarray_products = {}
          # dict of currently configured SDP subarray_products
         self.subarray_product_msg = {}
-         # store calling arguments used to create subarray_products
+         # store calling arguments used to create a specified subarray_product
+         # this has either the current args or those most recently
+         # configured for this subarray_product
         self.ingest_ports = {}
         self.tasks = {}
          # dict of currently managed SDP tasks


### PR DESCRIPTION
Reconfigure essentially calls a deconfigure and then a data_product_configure using the most 
recently used calling arguments for the specified product_id.

Re-calling katcp methods is perhaps not ideal, but it avoids adding another code path for configure, and
makes sure that the user ends up with the same configuration they originally request.

@ludwigschwardt to review
