### PR TITLE
Beamformer HDF5 capture on only p4p1

### DIFF
--- a/katsdpgraphs/generator.py
+++ b/katsdpgraphs/generator.py
@@ -70,7 +70,7 @@ def build_physical_graph(beamformer_mode, cbf_channels, simulate, resources):
         for i in range(2):
             if beamformer_mode == 'hdf5_ram':
                 affinity = [[4, 6], [5, 7]][i]
-                interface = ['p5p1', 'p4p1'][i]
+                interface = 'p4p1'
                 file_base = '/mnt/ramdisk{}'.format(i)
                 host_class = 'bf_ingest'
                 devices = ['/dev/infiniband/rdma_cm', '/dev/infiniband/uverbs0', '/dev/infiniband/uverbs1']


### PR DESCRIPTION
The new C++ beamformer capture can handle dual-pol beamformer capture through one NIC. This will allow us to free up the second NIC (and a port on the switch), although the --devices specification will need to be updated when we do that (I'm not sure if there is a consistent mapping of the /dev/infiniband devices to NICs, so I've left it passing through both uverbs0 and uverbs1). The updates to digitiser capture also now only use one NIC, and the Swinburne pipeline has used a single NIC from the start.
