### PR TITLE
Remove unused ingest options

### DIFF
--- a/katsdpgraphs/generator.py
+++ b/katsdpgraphs/generator.py
@@ -54,8 +54,6 @@ def build_physical_graph(beamformer_mode, cbf_channels, simulate, resources):
         'continuum_factor': 32,
         'sd_continuum_factor': cbf_channels // 256,
         'cbf_channels': cbf_channels,
-        'l0_continuum_spead_rate': 800e6,    # 1Gbps link
-        'l0_spectral_spead_rate': 800e6,     # 1Gbps link
         'sd_spead_rate': 3e9,                # local machine, so crank it up a bit
         'docker_image':r.get_image_path('katsdpingest_titanx'),
         'docker_host_class':'nvidia_gpu',


### PR DESCRIPTION
This was needed for the AR1 ingest, but is no longer needed now that the AR2 branch has been merged.

Possibly we should hold off on this until the AR2 ingest has been tested on site.
