### PR TITLE
Include subarray numeric ID in telstate config

### DIFF
--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -128,7 +128,7 @@ class GraphResolver(object):
         """
         matched_group = re.match(r'^\w+\_(\d+)\_[a-zA-Z0-9]+$',subarray_product_id)
          # should match the last underscore delimited group of digits
-        if matched_group: return matched_group.group(1)
+        if matched_group: return int(matched_group.group(1))
         return None
 
 class ImageResolver(object):


### PR DESCRIPTION
Parse out the numeric identifier for the specified subarray. This is needed for cam2telstate to pull the correct sensors for the subarray.

@bmerry to review
