### PR TITLE
Add telstate streams

### DIFF
--- a/katsdpgraphs/generator.py
+++ b/katsdpgraphs/generator.py
@@ -28,7 +28,7 @@ def build_physical_graph(beamformer_mode, cbf_channels, simulate, resources):
      # per stream sensor indicating type directly from the CBF
      # The .lower() is needed because CBF uses lower case in stream
      # specific sensor names, but reports stream names to CAM in mixed case.
-    if beamformer_mode not 'none':
+    if beamformer_mode != 'none':
         streams += ",beam_0x:beamformer,beam_0y:beamformer"
      # we also include a reference to the fengine stream so
      # we can get n_samples_between_spectra


### PR DESCRIPTION
In the bright and glorious future, we will be able to determine the types of each CBF stream in a particular subarray by subscribing to appropriate sensors.

Until this particular unicorn emerges, we effectively hardcode the list of desired streams and their types in the graph. This is then passed to cam2telstate to allow construction of fully qualified sensor names.

For now, we actually collapse these names when storing them in telstate to allow compatibility with the rest of the codebase. e.g.
data_1_cbf_corr_fengine_stream_n_samples_between_spectra 
becomes
cbf_ticks_between_spectra
through collapsing and renaming. Lovely isn't it...

Also snuck in adding the number of channels for timeplot to use.