### PR TITLE
Update for interface changes on the simulator

### DIFF
--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -1128,13 +1128,9 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
                 rcode, rval = self._issue_req('configure-subarray-from-telstate', node_type='sdp.sim')
                  # instruct the simulator to rebuild its local config from the values in telstate
                 if rcode == 'ok':
-                    rcode, rval = self._issue_req('configure-product-from-telstate', args=[self.subarray_product_id], node_type='sdp.sim')
-                    if rcode == 'ok':
-                        rcode, rval = self._issue_req('capture-start', args=[self.subarray_product_id], node_type='sdp.sim')
-                    else:
-                        logger.error("SIMULATE: configure-product-from-telstate {} failed ({})".format(self.subarray_product_id,rval))
+                    rcode, rval = self._issue_req('capture-start', args=[self.subarray_product_id], node_type='sdp.sim')
                 else:
-                    logger.error("SIMULATE: configure-product-from-telstate failed ({})".format(rval))
+                    logger.error("SIMULATE: configure-subarray-from-telstate failed ({})".format(rval))
         if state_id == 5:
             if self.simulate:
                 logger.info("SIMULATE: Issuing a capture-stop to the simulator")

--- a/katsdpgraphs/generator.py
+++ b/katsdpgraphs/generator.py
@@ -147,10 +147,10 @@ def build_physical_graph(beamformer_mode, cbf_channels, simulate, resources):
      # calibration node
 
     if simulate:
-        # create-fx-product is passed on the command-line insteead of telstate
+        # create-fx-stream is passed on the command-line insteead of telstate
         # for now due to SR-462.
         G.add_node('sdp.sim.1',{'port': r.get_port('sdp_sim_1_katcp'), 'cbf_channels': cbf_channels,
-             'docker_image':r.get_image_path('katcbfsim'),'docker_host_class':'nvidia_gpu', 'docker_cmd':'cbfsim.py --create-fx-product ' + r.prefix,\
+             'docker_image':r.get_image_path('katcbfsim'),'docker_host_class':'nvidia_gpu', 'docker_cmd':'cbfsim.py --create-fx-stream ' + r.prefix,\
              'docker_params': {"network":"host", "devices":["/dev/nvidiactl:/dev/nvidiactl",\
                               "/dev/nvidia-uvm:/dev/nvidia-uvm","/dev/nvidia0:/dev/nvidia0"]}
             })


### PR DESCRIPTION
The simulator has renamed --create-fx-product to --create-fx-stream and
removed configure-product-from-telstate.

This should be merged together with ska-sa/katcbfsim#16, which implements the simulator API changes.