### PR TITLE
Fix spurious error on shutdown

### DIFF
--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -866,9 +866,10 @@ class SDPControllerServer(AsyncDeviceServer):
             self._conf_future = None
         for subarray_product_id in self.subarray_products.keys():
             try:
-                rcode, rval = yield From(self.deregister_product(subarray_product_id,force=True))
+                yield From(self.deregister_product(subarray_product_id,force=True))
             except Exception as e:
-                logger.warning("Failed to deconfigure product %s during master controller exit. Forging ahead...", subarray_product_id)
+                logger.warning("Failed to deconfigure product %s during master controller exit. "
+                               "Forging ahead...", subarray_product_id, exc_info=True)
 
     @trollius.coroutine
     def async_stop(self):


### PR DESCRIPTION
If there was a subarray that had to be deconfigured on shutdown, a
Python syntax error was causing it to always report that it failed.

For good measure, the exception is now logged.