### PR TITLE
Store more graph information in telstate

### DIFF
--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -602,6 +602,14 @@ class ImageResolver(object):
         else:
             self._auth = None
 
+    @property
+    def tag(self):
+        return self._tag
+
+    @property
+    def overrides(self):
+        return dict(self._overrides)
+
     def override(self, name, path):
         self._overrides[name] = path
 

--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -1222,6 +1222,18 @@ class SDPControllerServer(AsyncDeviceServer):
                 logger.error(ret_msg)
                 yield From(graph.shutdown())
                 raise FailReply(ret_msg)
+            # Record the TaskInfo for each task in telstate, as well as details
+            # about the image resolver.
+            details = {}
+            for task in graph.physical_graph:
+                if isinstance(task, scheduler.PhysicalTask):
+                    details[task.logical_node.name] = {
+                        'host': task.host,
+                        'taskinfo': task.taskinfo
+                    }
+            graph.telstate.add('sdp_task_details', details, immutable=True)
+            graph.telstate.add('sdp_image_tag', resolver.image_resolver.tag, immutable=True)
+            graph.telstate.add('sdp_image_overrides', resolver.image_resolver.overrides, immutable=True)
              # at this point telstate is up, nodes have been launched, katcp connections established
              # we can now safely expose this product for use in other katcp commands like ?capture-init
              # adding a product is also safe with regard to commands like ?capture-status


### PR DESCRIPTION
This adds several new telstate keys:
- sdp_task_details: replaces the old sdp_node_detail. For each task, it
  contains the TaskInfo struct passed to Mesos to launch the task. For
  convenience, it also contains the hostname of the agent used (the
  TaskInfo contains only the agent ID, which would require trawling
  through Mesos logs to match to a host).
- sdp_image_tag, sdp_image_overrides: the ImageResolver configuration in
  use at the time. This is useful because sdp_task_details typically
  contains image digests rather than tags, making it tricky to map back
  to a production tag to rerun.

This fixes SR-744.