### PR TITLE
Increase memory allocation to telstate (redis)

### DIFF
--- a/katsdpgraphs/generator.py
+++ b/katsdpgraphs/generator.py
@@ -147,7 +147,7 @@ def build_logical_graph(beamformer_mode, simulate, develop, cbf_channels, l0_ant
     # telstate node
     telstate = SDPLogicalTask('sdp.telstate')
     telstate.cpus = 0.1
-    telstate.mem = 1024 + bp_mb
+    telstate.mem = 8192 + bp_mb
     telstate.disk = telstate.mem
     telstate.image = 'redis'
     telstate.ports = ['telstate']


### PR DESCRIPTION
A recent 12 hour observation showed substantial memory pressure
on redis, which led to it being very unresponsive and timing out
on requests. Docker stats showed it was using pretty much the whole
allocation.

This is a temporary fix to get the telescope working again, a
more detailed review of memory needed will be done

@bmerry - FYI (accepting it myself to get observations running again)