### PR TITLE
Tune ingest launch options

### DIFF
--- a/katsdpgraphs/generator.py
+++ b/katsdpgraphs/generator.py
@@ -246,7 +246,11 @@ def build_logical_graph(beamformer_mode, simulate, develop, cbf_channels, l0_ant
             'cbf_channels': cbf_channels,
             'sd_spead_rate': 3e9,   # local machine, so crank it up a bit (TODO: no longer necessarily true)
             'cbf_interface': task.interfaces['cbf'].name,
-            'cbf_ibv': not develop,
+            # ibverbs is disabled in --develop because a developer's machine
+            # typically won't support it, and in --simulate because it doesn't
+            # currently work if the simulator and ingest run on the same
+            # machine (it will work if the simulator uses ibverbs).
+            'cbf_ibv': not develop and not simulate,
             'l0_spectral_interface': task.interfaces['sdp_10g'].name,
             'l0_continuum_interface': task.interfaces['sdp_10g'].name
         })


### PR DESCRIPTION
This adjusts the resource calculation for ingest and runs it with NUMA affinity. It also uses ibverbs in some cases. A sender not using ibverbs and a receiver using ibverbs can't communicate on the same host, so ibverbs is disabled when using the simulator.

Also reduces the cal memory allocation to 15 minutes so that 32A, 32K, 4s will fit.

Don't merge until after ska-sa/katsdpingest#176.