### PR TITLE
Remove support for timeplot data_port

### DIFF
--- a/katsdpgraphs/generator.py
+++ b/katsdpgraphs/generator.py
@@ -236,7 +236,7 @@ def build_logical_graph(beamformer_mode, simulate, develop, wrapper,
     # add a fixed amount since in very small arrays the 20% might not cover
     # the fixed-sized overheads.
     timeplot.mem = timeplot_buffer_mb * 1.2 + 256
-    timeplot.ports = ['spead_port', 'html_port', 'data_port']
+    timeplot.ports = ['spead_port', 'html_port']
     timeplot.wait_ports = ['html_port']
     timeplot.volumes = [config_vol]
     timeplot.gui_urls = [{


### PR DESCRIPTION
Since the Tornado-ified katsdpdisp has been active for a while now,
removing support for the old separate data_port from katsdpcontroller
and the haproxy wrapper script. The haproxy wrapper becomes a good deal
simpler because it no longer has to forward to two different ports.