### PR TITLE
Pass additional information to CBF simulator

### DIFF
--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -97,6 +97,17 @@ def validate(config):
     if len(cam_http) > 1:
         raise ValueError('Cannot have more than one cam.http stream')
 
+    for name, stream in six.iteritems(config['inputs']):
+        if stream['type'] in ['cbf.baseline_correlation_products',
+                              'cbf.tied_array_channelised_voltage']:
+            src_stream = stream['src_streams'][0]
+            n_chans = config['inputs'][src_stream]['n_chans']
+            n_chans_per_substream = stream['n_chans_per_substream']
+            if n_chans % n_chans_per_substream != 0:
+                raise ValueError(
+                    '{}: n_chans ({}) not a multiple of n_chans_per_substream ({})'.format(
+                        name, n_chans, n_chans_per_substream))
+
     for name, output in six.iteritems(config['outputs']):
         # Names of inputs and outputs must be disjoint
         if name in config['inputs']:

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -148,6 +148,12 @@ class TestValidate(object):
             product_config.validate(self.config)
         assert_in("have more than one cam.http", str(cm.exception))
 
+    def test_bad_n_chans_per_substream(self):
+        self.config["inputs"]["i0_baseline_correlation_products"]["n_chans_per_substream"] = 123
+        with assert_raises(ValueError) as cm:
+            product_config.validate(self.config)
+        assert_in("not a multiple of", str(cm.exception))
+
 
 class TestConvert(object):
     """Tests for :func:`~katsdpcontroller.product_config.convert`.
@@ -364,4 +370,3 @@ class TestConvert(object):
         with assert_raises(jsonschema.ValidationError):
             product_config.convert("c856M4k", self.stream_sources, self.antennas,
                                    0.5, False, False, "not a valid URL")
-

--- a/katsdpcontroller/test/test_sdp_controller.py
+++ b/katsdpcontroller/test/test_sdp_controller.py
@@ -578,6 +578,10 @@ class TestSDPController(unittest.TestCase):
             'antenna_mask': ANTENNAS,
             'cbf_ibv': True,
             'cbf_channels': 4096,
+            'cbf_substreams': 16,
+            'cbf_adc_sample_rate': 1712000000.0,
+            'cbf_bandwidth': 856000000.0,
+            'cbf_int_time': 0.499,
             'cbf_interface': 'em1',
             'port': 20000,
             'cbf_spead': '127.0.0.1:9000'


### PR DESCRIPTION
The config dict now contains enough information to compute
cbf_substreams, cbf_adc_sample_rate, cbf_bandwidth and cbf_int_time, so
they're passed through to provide a way for the simulator to be
configured.