### PR TITLE
Do capture-init/capture-done in parallel

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -24,7 +24,7 @@ CAM2TELSTATE_TYPE_MAP = {
     'cbf.antenna_channelised_voltage': 'fengine',
     'cbf.tied_array_channelised_voltage': 'beamformer'
 }
-CAPTURE_TRANSITIONS = {State.INITIALISED: 'capture-init', State.DONE: 'capture-done'}
+CAPTURE_TRANSITIONS = {State.INITIALISED: ['capture-init'], State.DONE: ['capture-done']}
 #: Docker images that may appear in the logical graph (used set to Docker image metadata)
 IMAGES = frozenset([
     'beamform',
@@ -347,6 +347,10 @@ def _make_baseline_correlation_products_simulator(g, config, name):
         sim.container.docker.parameters = [{"key": "ulimit", "value": "nofile=8192"}]
     sim.interfaces = [scheduler.InterfaceRequest('cbf', infiniband=ibv)]
     sim.interfaces[0].bandwidth_out = info.net_bandwidth
+    sim.transitions = {
+        State.INITIALISED: ['capture-start', name],
+        State.DONE: ['capture-stop', name]
+    }
     substreams = info.n_channels // info.n_channels_per_substream
     g.add_node(sim, config=lambda task, resolver: {
         'cbf_channels': info.n_channels,

--- a/katsdpcontroller/test/test_sdp_controller.py
+++ b/katsdpcontroller/test/test_sdp_controller.py
@@ -657,7 +657,8 @@ class TestSDPController(unittest.TestCase):
             mock.call(Message.request('configure-subarray-from-telstate')),
             mock.call(Message.request('capture-init'), timeout=mock.ANY),
             mock.call(Message.request('capture-init'), timeout=mock.ANY),
-            mock.call(Message.request('capture-start', 'i0_baseline_correlation_products'))
+            mock.call(Message.request(
+                'capture-start', 'i0_baseline_correlation_products'), timeout=mock.ANY)
         ])
 
     def test_capture_init_failed_req(self):


### PR DESCRIPTION
This will speed up capture-done when using multiple ingests. It also simplifies the handling of capture-start/stop for the simulator, which is now done as just another transition instead of a hand-coded case, because the transitions are serialised where strong dependencies exist in the graph.