### PR TITLE
Improve unit test coverage of generator.py

### DIFF
--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -219,7 +219,8 @@ def convert(graph_name, stream_sources, antennas, dump_rate, simulate, develop, 
                     for src_name in stream_sources['cbf.antenna_channelised_voltage']
                 ]
                 cur['n_chans_per_substream'] = cbf_channels // len(endpoints)
-                cur['simulate'] = simulate
+                # simulation not yet supported for tied_array_channelised_voltage
+                cur['simulate'] = simulate and type_ != 'cbf.tied_array_channelised_voltage'
             if type_ == 'cbf.antenna_channelised_voltage':
                 cur['antennas'] = antennas
                 cur['n_chans'] = cbf_channels

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -331,8 +331,9 @@ class TestConvert(object):
                                         0.5, True, True, "http://invalid.com/wrapper")
         del self.expected_inputs["camdata"]
         self.expected_inputs["i0_baseline_correlation_products"]["simulate"] = True
-        self.expected_inputs["i0_tied_array_channelised_voltage_0x"]["simulate"] = True
-        self.expected_inputs["i0_tied_array_channelised_voltage_0y"]["simulate"] = True
+        # Disabled until simulation of tied-array-channelised-voltage is supported
+        # self.expected_inputs["i0_tied_array_channelised_voltage_0x"]["simulate"] = True
+        # self.expected_inputs["i0_tied_array_channelised_voltage_0y"]["simulate"] = True
         expected = {
             "config": {
                 "develop": True,


### PR DESCRIPTION
This should prevent a repeat of the problem where a beamformer could not
be configured due to a NameError in the generator code. The new API is
used to configuring an all-singing all-dancing product that has all
three flavours of beamformer at the same time, to check that the
code-paths don't crash.