### PR TITLE
Add the SDP config dictionary to telstate

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -426,15 +426,15 @@ def _timeplot_frame_size(spectral_info, n_cont_channels):
 
 
 def _make_ingest(g, config, spectral_name, continuum_name):
+    develop = is_develop(config)
     # Number of ingest nodes.
     # TODO: adjust based on the number of channels requested
-    n_ingest = 4
+    n_ingest = 4 if not develop else 2
 
     spectral_info = L0Info(config, spectral_name)
     continuum_info = L0Info(config, continuum_name)
     src = spectral_info.raw['src_streams'][0]
     src_info = spectral_info.src_info
-    develop = is_develop(config)
 
     # Virtual ingest node which depends on the real ingest nodes, so that other
     # services can declare dependencies on ingest rather than individual nodes.

--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -228,6 +228,15 @@ class SDPGraph(object):
             'config', lambda resolver: {})(self.resolver)
         base_params['subarray_product_id'] = self.subarray_product_id
         base_params['sdp_config'] = self.config
+        # Provide attributes to describe the relationships between CBF streams
+        # and instruments. This could be extracted from sdp_config, but these
+        # specific sensors are easier to mock.
+        for name, stream in six.iteritems(self.config['inputs']):
+            if stream['type'].startswith('cbf.'):
+                prefix = 'cbf_' + name + '_'
+                for suffix in ['src_streams', 'instrument_dev_name']:
+                    if suffix in stream:
+                        base_params[prefix + suffix] = stream[suffix]
 
         logger.debug("Launching telstate. Base parameters {}".format(base_params))
         yield From(self.sched.launch(self.physical_graph, self.resolver, boot))
@@ -241,8 +250,8 @@ class SDPGraph(object):
 
         logger.debug("base params: %s", base_params)
          # set the configuration
-        for k,v in base_params.iteritems():
-            self.telstate.add(k,v, immutable=True)
+        for k, v in base_params.iteritems():
+            self.telstate.add(k, v, immutable=True)
 
     @trollius.coroutine
     def execute_graph(self, req):


### PR DESCRIPTION
This is mostly so that cam2telstate can find it, so that we don't have
to pass increasingly unwieldy arguments to cam2telstate.

It is also a good thing to have around for post-mortem debugging.