### PR TITLE
Fix for MKAIV-899 multicast addresses exhausted

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -64,8 +64,7 @@ class PhysicalMulticast(scheduler.PhysicalExternal):
             self.host = self.logical_node.endpoint.host
             self.ports = {'spead': self.logical_node.endpoint.port}
         else:
-            self.host = resolver.resources.get_multicast_ip(self.logical_node.name,
-                                                            self.logical_node.n_addresses)
+            self.host = resolver.resources.get_multicast_ip(self.logical_node.n_addresses)
             self.ports = {'spead': resolver.resources.get_port()}
 
 

--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -10,6 +10,7 @@ import json
 import signal
 import re
 import sys
+from collections import deque
 
 from tornado import gen
 import tornado.platform.asyncio
@@ -146,23 +147,10 @@ class MulticastIPResources(object):
 
 class SDPCommonResources(object):
     """Assigns multicast groups and ports across all subarrays."""
-    def __init__(self, safe_multicast_cidr, safe_port_range=xrange(30000,31000)):
-        self._ports = iter(safe_port_range)
+    def __init__(self, safe_multicast_cidr):
         logger.info("Using {} for multicast subnet allocation".format(safe_multicast_cidr))
-        multicast_subnets = ipaddress.ip_network(unicode(safe_multicast_cidr)).subnets(new_prefix=24)
-        self.multicast_resources = {}
-        self.multicast_resources_fallback = MulticastIPResources(next(multicast_subnets))
-        for name in ['l0_spectral_spead',
-                     'l0_continuum_spead',
-                     'l1_spectral_spead',
-                     'l1_continuum_spead']:
-            self.multicast_resources[name] = MulticastIPResources(next(multicast_subnets))
-
-    def get_port(self):
-        try:
-            return next(self._ports)
-        except StopIteration:
-            raise RuntimeError('Available ports exhausted')
+        self.multicast_subnets = deque(
+            ipaddress.ip_network(unicode(safe_multicast_cidr)).subnets(new_prefix=24))
 
 
 class SDPResources(object):
@@ -170,18 +158,26 @@ class SDPResources(object):
     def __init__(self, common, subarray_product_id):
         self.subarray_product_id = subarray_product_id
         self._common = common
+        try:
+            self._subnet = self._common.multicast_subnets.popleft()
+        except IndexError:
+            raise RuntimeError("Multicast subnets exhausted")
+        logger.info("Using {} for {}".format(self._subnet, subarray_product_id))
+        self._multicast_resources = MulticastIPResources(self._subnet)
 
-    def _qualify(self, name):
-        return "{}_{}".format(self.subarray_product_id, name)
-
-    def get_multicast_ip(self, group, n_addresses):
+    def get_multicast_ip(self, n_addresses):
         """Assign multicast addresses for a group."""
-        mr = self._common.multicast_resources.get(group, self._common.multicast_resources_fallback)
-        return mr.get_ip(n_addresses)
+        return self._multicast_resources.get_ip(n_addresses)
 
     def get_port(self):
         """Return an assigned port for a multicast group"""
-        return self._common.get_port()
+        return 7148
+
+    def close(self):
+        if self._subnet is not None:
+            self._common.multicast_subnets.append(self._subnet)
+            self._subnet = None
+            self._multicast_resources = None
 
 
 class SDPGraph(object):
@@ -251,7 +247,10 @@ class SDPGraph(object):
 
     @trollius.coroutine
     def shutdown(self):
-        yield From(self.sched.kill(self.physical_graph))
+        try:
+            yield From(self.sched.kill(self.physical_graph))
+        finally:
+            self.resolver.resources.close()
 
     def check_nodes(self):
         """Check that all requested nodes are actually running.
@@ -735,7 +734,6 @@ class SDPControllerServer(AsyncDeviceServer):
         resolver = scheduler.Resolver(self.image_resolver_factory(**resolver_factory_args),
                                       scheduler.TaskIDAllocator(subarray_product_id + '-'),
                                       self.sched.http_url if self.sched else '')
-        resolver.resources = SDPResources(self.resources, subarray_product_id)
         resolver.service_overrides = config['config'].get('service_overrides', {})
         resolver.telstate = None
 
@@ -753,6 +751,7 @@ class SDPControllerServer(AsyncDeviceServer):
             return
 
         try:
+            resolver.resources = SDPResources(self.resources, subarray_product_id)
             yield From(graph.launch_telstate())
              # launch the telescope state for this graph
             req.inform("Telstate launched. [{}]".format(graph.telstate_endpoint))


### PR DESCRIPTION
Previously, a /16 network was allocated for SDP, and it was split into
/24 subnets, with a subnet for each stream name. Thus, for example, all
L0 streams in SDP went into a single subnet. This design was chosen at a
time when I thought that kernel routing tables would control multicast
interface binding. However, to manage network interfaces fully with
Mesos, it was necessary to do interface selection at the application
level.

There was also no recycling of addresses. This meant that, once ingest
was split into 4 nodes, only 32 subarrays could be built (or attempted
to be built) before running out of addresses.

The new design is a lot simpler: it allocates each subarray product a
/24 subnet for its needs (which should be far more than enough). When a
subarray product is terminated, the subnet is added back to a deque of
available subnets, so that there is no limit on how many subarrays can
be built as long as there are no more than 254 at a time.