### PR TITLE
Fix for Mesos master crashes

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -823,4 +823,10 @@ def build_logical_graph(config):
             node.cpus = max(node.cpus, 0.01)
             for request in node.gpus:
                 request.compute = max(request.compute, 0.01)
+            # Bandwidths are typically large values, and having fractional
+            # parts seems to cause rounding problems for Mesos as well. We
+            # don't need sub-bps precision, so just round things off.
+            for request in node.interfaces:
+                request.bandwidth_in = round(request.bandwidth_in)
+                request.bandwidth_out = round(request.bandwidth_out)
     return g


### PR DESCRIPTION
The symptoms are similar to MESOS-7197, but I think are caused by having
too many decimal places in a resource requirement even after Mesos
truncates to 3 places after the decimal point. This can happen for
bandwidths, which have lots of places before the decimal point. I'm not
sure exactly why this is a problem (I still need to investigate the
Mesos code and file a bug), but rounding the bandwidths to integers
seems to help.