### PR TITLE
Detect and error out if speed is nonsense

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -823,9 +823,10 @@ def build_logical_graph(config):
             node.cpus = max(node.cpus, 0.01)
             for request in node.gpus:
                 request.compute = max(request.compute, 0.01)
-            # Bandwidths are typically large values, and having fractional
-            # parts seems to cause rounding problems for Mesos as well. We
-            # don't need sub-bps precision, so just round things off.
+            # Bandwidths are typically large values. If they get large enough
+            # then MESOS-8129 can bite (although this has only happened due to
+            # misconfiguration). We don't need sub-bps precision, so just round
+            # things off, which mitigates the problem.
             for request in node.interfaces:
                 request.bandwidth_in = round(request.bandwidth_in)
                 request.bandwidth_out = round(request.bandwidth_out)

--- a/scripts/agent_mkconfig.py
+++ b/scripts/agent_mkconfig.py
@@ -199,7 +199,12 @@ def attributes_resources(args):
         interfaces.append(config)
         try:
             with open('/sys/class/net/{}/speed'.format(interface)) as f:
-                speed = float(f.read().strip()) * 1e6  # /sys/class/net has speed in Mbps
+                speed = f.read().strip()
+                # This dummy value has been observed on a NIC which had been
+                # configured but had no cable attached.
+                if speed == '4294967295':
+                    raise ValueError('cable unplugged?')
+                speed = float(speed) * 1e6  # /sys/class/net has speed in Mbps
         except (IOError, OSError, ValueError) as error:
             if interface == 'lo':
                 # Loopback interface speed is limited only by CPU power. Just


### PR DESCRIPTION
This had been affecting bfi2, causing Mesos to think it had 4.2e15 bps
bandwidth available when in fact a NIC was not connected. That in turn
crashes the Mesos master due to MESOS-8129.