### PR TITLE
Initial work towards supporting programme blocks with burndown

### DIFF
--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -356,6 +356,10 @@ class SDPSubarrayProductBase(object):
             try:
                 yield From(self._capture_done())
             except trollius.CancelledError:
+                # Our deconfigure has been preempted by another deconfigure.
+                # Just wipe out current_program_block so that we give up on
+                # trying to do a capture_done.
+                self.current_program_block = None
                 raise
             except Exception as error:
                 logger.error("Failed to issue capture-done during shutdown request. "


### PR DESCRIPTION
The framework has been added to the SDPSubarrayProductBase class, along
with a new ProgrammeBlock class. The base class provides a hook point
for subclasses to provide for monitoring the burndown cycle of a
programme block (postprocessing_impl), and to separate the return of
deconfigure from the final death of the subarray.

It's not yet wired up outside these classes: deregister_product waits
for full burndown, and SDPSubarrayProduct.deconfigure_impl still tears
it all down right away without waiting for katsdpcal.