### PR TITLE
Pass program block ID to capture-init of children

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -20,7 +20,7 @@ from katsdpcontroller.tasks import (
 
 INGEST_GPU_NAME = 'GeForce GTX TITAN X'
 CAPTURE_TRANSITIONS = {
-    (State.IDLE, State.CAPTURING): ['capture-init'],
+    (State.IDLE, State.CAPTURING): ['capture-init', '{program_block_id}'],
     (State.CAPTURING, State.IDLE): ['capture-done']
 }
 #: Docker images that may appear in the logical graph (used set to Docker image metadata)

--- a/katsdpcontroller/test/test_sdp_controller.py
+++ b/katsdpcontroller/test/test_sdp_controller.py
@@ -762,7 +762,7 @@ class TestSDPController(unittest.TestCase):
     def test_capture_init(self):
         """Checks that capture-init succeeds and sets appropriate state"""
         self._configure_subarray(SUBARRAY_PRODUCT4)
-        self.client.assert_request_succeeds("capture-init", SUBARRAY_PRODUCT4)
+        self.client.assert_request_succeeds("capture-init", SUBARRAY_PRODUCT4, "my_pb")
         # check that the subarray is in an appropriate state
         sa = self.controller.subarray_products[SUBARRAY_PRODUCT4]
         self.assertFalse(sa.async_busy)
@@ -775,7 +775,7 @@ class TestSDPController(unittest.TestCase):
         grouped_calls = [k for k, g in itertools.groupby(katcp_client.future_request.mock_calls)]
         expected_calls = [
             mock.call(Message.request('configure-subarray-from-telstate')),
-            mock.call(Message.request('capture-init'), timeout=mock.ANY),
+            mock.call(Message.request('capture-init', 'my_pb'), timeout=mock.ANY),
             mock.call(Message.request('capture-start', 'i0_baseline_correlation_products'),
                                       timeout=mock.ANY)
         ]


### PR DESCRIPTION
Also add the (currently optional) program block ID argument to the
top-level ?capture-init.