### PR TITLE
Change packet size for correlator simulation to 2K

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -345,11 +345,12 @@ def _make_cbf_simulator(g, config, name):
         if type_ == 'cbf.baseline_correlation_products':
             conf.update({
                 'cbf_int_time': info.int_time,
+                'max_packet_size': 2088
             })
         else:
             conf.update({
                 'beamformer-timesteps': info.raw['spectra_per_heap'],
-                'beamformer-bits': info.raw['beng_out_bits_per_sample'],
+                'beamformer-bits': info.raw['beng_out_bits_per_sample']
             })
         return conf
 

--- a/katsdpcontroller/test/test_sdp_controller.py
+++ b/katsdpcontroller/test/test_sdp_controller.py
@@ -736,6 +736,7 @@ class TestSDPController(unittest.TestCase):
             'cbf_int_time': 0.499,
             'cbf_sync_time': mock.ANY,
             'cbf_spead': '239.102.255.0+15:7148',
+            'max_packet_size': mock.ANY,
             'servers': mock.ANY
         }, immutable=True)
         # Check that the taskinfo override worked


### PR DESCRIPTION
This is to match the size used in the SKARAB correlator. It's been
tested with 64 antennas / 32K on site.