### PR TITLE
Fix for failing unit tests

### DIFF
--- a/katsdpcontroller/test/test_sdp_controller.py
+++ b/katsdpcontroller/test/test_sdp_controller.py
@@ -428,6 +428,7 @@ class TestSDPController(BaseTestSDPController):
         # Mock TelescopeState, but preserve SEPARATOR in the mock
         separator = katsdptelstate.TelescopeState.SEPARATOR
         mock_getaddrinfo = self._create_patch('socket.getaddrinfo', side_effect=self._getaddrinfo)
+        # Workaround for Python bug that makes it think mocks are coroutines
         mock_getaddrinfo._is_coroutine = False
         self.telstate_class = self._create_patch('katsdptelstate.TelescopeState', autospec=True)
         self.telstate_class.SEPARATOR = separator


### PR DESCRIPTION
A recent change had added extra name resolution of agent hostnames, and
the tests were using made-up names that failed to resolve. I've added a
mock of getaddrinfo to return an arbitrary IP address instead.