### PR TITLE
Add a simple index page to haproxy_disp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN install-requirements.py --default-versions ~/docker-base/base-requirements.t
 # Install the current package
 COPY . /tmp/install/katsdpcontroller
 WORKDIR /tmp/install/katsdpcontroller
-RUN python ./setup.py clean && pip install --no-deps . && pip check
+RUN python ./setup.py clean && pip install --no-deps ".[haproxy_disp]" && pip check
 
 # Network setup
 EXPOSE 5001

--- a/katsdpcontroller/templates/index.html.j2
+++ b/katsdpcontroller/templates/index.html.j2
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Available signal displays</title>
+    </head>
+    <body>
+        <h1>Available signal displays</h1>
+{% if servers %}
+        <ul>
+{% for name in servers.keys() %}
+            <li><a href="/{{name|e}}">{{name|e}}</a></li>
+{% endfor %}
+        </ul>
+{% else %}
+        <p>No signal displays active</p>
+{% endif %}
+    </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 addict==2.1.1
 aiohttp==2.3.6
+aiohttp-jinja2==0.14.0
 aiokatcp==0.2
 async-timeout==2.0.0
 certifi                    # via requests
@@ -12,11 +13,13 @@ hiredis
 http-parser==0.8.3         # via pymesos
 idna==2.6                  # via requests
 ipaddress                  # via katsdptelstate
+jinja2==2.10               # via aiohttp-jinja2
 jsonschema==2.6.0
 katversion
 kazoo==2.4.0
 multidict==3.3.2           # via aiohttp, yarl
 manhole
+markupsafe                 # via jinja2
 netifaces
 networkx==2.0
 numpy

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup (
     description = "Service providing control and monitoring services for the MeerKAT Science Data Processor",
     author = "Simon Ratcliffe",
     packages = find_packages(),
-    package_data={'katsdpcontroller': ['static/*', 'schemas/*']},
+    package_data={'katsdpcontroller': ['static/*', 'schemas/*', 'templates/*']},
     include_package_data = True,
     scripts = [
         "scripts/sdp_master_controller.py",
@@ -38,6 +38,7 @@ setup (
     tests_require = tests_require,
     extras_require = {
         'agent': ['psutil', 'py3nvml', 'pycuda'],
+        'haproxy_disp': ['jinja2'],
         'test': tests_require
     },
     use_katversion = True,


### PR DESCRIPTION
If an URL is used that doesn't match one of the known subarrays, it
redirects to a trivial web server embedded in the script which provides
links to the available signal displays.