### PR TITLE
Send an interface-changed after product removal

### DIFF
--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -1029,6 +1029,7 @@ class SDPControllerServer(DeviceServer):
                 del self.subarray_products[product.subarray_product_id]
                 self.sensors.discard(product.state_sensor)
                 self.sensors.discard(product.capture_block_sensor)
+                self.mass_inform('interface-changed', 'sensor-list')
                 logger.info("Deconfigured subarray product {}".format(product.subarray_product_id))
 
         if subarray_product_id in self.override_dicts:

--- a/katsdpcontroller/test/test_sdp_controller.py
+++ b/katsdpcontroller/test/test_sdp_controller.py
@@ -246,7 +246,7 @@ class TestSDPControllerInterface(BaseTestSDPController):
         # Deconfigure and check that the array sensors are gone
         with mock.patch.object(aiokatcp.Client, 'unhandled_inform', spec=True) as unhandled_inform:
             await self.client.request("product-deconfigure", SUBARRAY_PRODUCT1)
-            unhandled_inform.assert_called_once_with(self.client, interface_changed_msg)
+            unhandled_inform.assert_called_with(self.client, interface_changed_msg)
         await self.assert_sensors(EXPECTED_SENSOR_LIST)
 
     async def test_capture_done(self):


### PR DESCRIPTION
When a product is removed, some product-level sensors are removed from
the server, but this wasn't being advertised with interface-changed.