### PR TITLE
Add cal port for dask diagnostics

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -740,7 +740,14 @@ def _make_cal(g, config, name, l0_name):
     cal.volumes = [DATA_VOL]
     cal.interfaces = [scheduler.InterfaceRequest('sdp_10g')]
     cal.interfaces[0].bandwidth_in = info.net_bandwidth
-    cal.ports = ['port']
+    cal.ports = ['port', 'dask_diagnostics']
+    cal.wait_ports = ['port']
+    cal.gui_urls = [{
+        'title': 'Cal diagnostics',
+        'description': 'Dask diagnostics for cal process on {0.subarray_product_id}',
+        'href': 'http://{0.host}:{0.ports[dask_diagnostics]}/status',
+        'category': 'Plot'
+    }]
     cal.transitions = CAPTURE_TRANSITIONS
     cal.deconfigure_wait = False
     g.add_node(cal, telstate_extra=telstate_extra, config=lambda task, resolver: {
@@ -750,7 +757,8 @@ def _make_cal(g, config, name, l0_name):
         'l0_spectral_name': l0_name,
         # cal should change to remove "spectral"; both are provided for now
         'l0_interface': task.interfaces['sdp_10g'].name,
-        'l0_name': l0_name
+        'l0_name': l0_name,
+        'dask_diagnostics': ('', task.ports['dask_diagnostics'])
     })
     src_multicast = find_node(g, 'multicast.' + l0_name)
     g.add_edge(cal, src_multicast, port='spead',

--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -225,7 +225,7 @@ class SDPConfigMixin:
     """Mixin class that takes config information from the graph and sets it in telstate."""
     async def resolve(self, resolver, graph, loop):
         await super().resolve(resolver, graph, loop)
-        config = graph.node[self].get('config', lambda task_, resolver_: {})(self, resolver)
+        config = {}
         for name, value in self.ports.items():
             config[name] = value
         for _src, trg, attr in graph.out_edges(self, data=True):
@@ -235,6 +235,7 @@ class SDPConfigMixin:
                 endpoint = Endpoint(trg.host, trg.ports[port])
             config.update(attr.get('config', lambda task_, resolver_, endpoint_: {})(
                 self, resolver, endpoint))
+        config.update(graph.node[self].get('config', lambda task_, resolver_: {})(self, resolver))
         overrides = resolver.service_overrides.get(self.logical_node.name, {}).get('config')
         if overrides:
             logger.warning('Overriding config for %s', self.name)


### PR DESCRIPTION
I'm busy switching cal to use dask.distributed, which provides a live
web UI. This plumbs it in by providing a port and a gui-url for it. It
should be safe even for existing cal (although the gui-url obviously
won't work).

I changed the order in which the task config is assembled so that
manually provided values override the automatics. This is needed so that
dask_diagnostics can be set to a host-port tuple instead of just a port.