### PR TITLE
Use a more appropriate redirect code in haproxy_disp

### DIFF
--- a/scripts/haproxy_disp.py
+++ b/scripts/haproxy_disp.py
@@ -153,7 +153,8 @@ async def main():
 
                 backend fallback
                     acl root path_reg '^/$'
-                    http-request redirect code 301 location / drop-query if !root
+                    acl favicon path_reg '^/favicon.ico$'
+                    http-request redirect code 303 location / drop-query if !root !favicon
                     server fallback_html_server 127.0.0.1:{port}
                 """.format(port=port))
             for array, server in sorted(servers.items()):


### PR DESCRIPTION
Redirect from an unknown (or not currently active) subarray was using
HTTP code 301, which is a permanent redirect and was being cached by
Chrome, making it stop working when the subarray comes back.

Now using 303 instead, which is a different sort of redirect and
isn't cached.

Also avoid redirecting favicon.ico so that it gets a 404 instead of
fetching /.