### PR TITLE
Remove attempts to put in cal configuration

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -909,13 +909,7 @@ def build_logical_graph(config):
     # Copy the config, because we make some changes to it as we go
     config = copy.deepcopy(config)
 
-    g = networkx.MultiDiGraph(config=lambda resolver: {
-        'cal_refant': '',
-        'cal_g_solint': 10,
-        'cal_bp_solint': 10,
-        'cal_k_solint': 10,
-        'cal_k_chan_sample': 10
-    })
+    g = networkx.MultiDiGraph(config=lambda resolver: {})
 
     # telstate node
     telstate = _make_telstate(g, config)

--- a/katsdpcontroller/test/test_sdp_controller.py
+++ b/katsdpcontroller/test/test_sdp_controller.py
@@ -567,7 +567,6 @@ class TestSDPController(BaseTestSDPController):
         # This is not a complete list of calls. It check that each category of stuff
         # is covered: base_params, per node, per edge
         ts.add.assert_any_call('subarray_product_id', SUBARRAY_PRODUCT4, immutable=True)
-        ts.add.assert_any_call('cal_bp_solint', 10, immutable=True)
         ts.add.assert_any_call('config.filewriter.sdp_l0', {
             'file_base': '/var/kat/data',
             'port': 20000,


### PR DESCRIPTION
The graph had some very old example code that attempted to provide some
cal configuration, but
(a) Most of it had no effect, because it used the wrong names e.g.
cal_g_solint whereas cal used to use cal_param_k_solint.
(b) It set cal_refant to '', which then broke new cal when it tried to
set it to something more useful and got an ImmutableKeyError.
(c) I'm moving cal to a model of taking incoming config via command
line, hence via config.cal rather than directly put into telstate.