### PR TITLE
Use jinja2 to template product config schema

### DIFF
--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -141,9 +141,6 @@ def validate(config):
                     raise ValueError(
                         'channels per endpoints ({}) not a multiple of n_chans_per_substream ({})'
                         .format(n_chans_per_endpoint, n_chans_per_substream))
-                if config['version'] == '1.0':
-                    if not isinstance(stream.get('simulate', False), bool):
-                        raise ValueError('simulate dict only supported from schema version 1.1')
         except ValueError as error:
             raise ValueError('{}: {}'.format(name, error)) from error
 
@@ -177,10 +174,6 @@ def validate(config):
                     raise ValueError(
                         'continuum channels ({}) not a multiple of number of ingests ({})'.format(
                             n_chans, n_ingest))
-
-            if output['type'] == 'sdp.cal':
-                if config['version'] == '1.0':
-                    raise ValueError('sdp.cal is only supported from schema version 1.1')
 
         except ValueError as error:
             raise ValueError('{}: {}'.format(name, error)) from error

--- a/katsdpcontroller/schemas/__init__.py
+++ b/katsdpcontroller/schemas/__init__.py
@@ -5,13 +5,55 @@ import codecs
 
 import pkg_resources
 import jsonschema
+import jinja2
+
+
+_env = jinja2.Environment(loader=jinja2.PackageLoader(__name__, '.'))
+
+
+def _make_validator(schema):
+    """Check a schema document and create a validator from it"""
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator_cls.check_schema(schema)
+    return validator_cls(schema, format_checker=jsonschema.FormatChecker())
+
+
+class MultiVersionValidator(object):
+    """Validation wrapper that supports a versioned schema.
+
+    The schema must have a top-level `version` key. It is defined by a Jinja2
+    template which takes a version parameter. It must define an argument-less
+    macro called ``validate_version`` that returns a mini version of the schema
+    that validates only the version number.
+    """
+
+    def __init__(self, name):
+        self._template = _env.get_template(name)
+        # Load the mini-schema that just validates the version
+        schema = json.loads(self._template.module.validate_version())
+        self._version_validator = _make_validator(schema)
+
+    def validate(self, doc):
+        self._version_validator.validate(doc)
+        schema = json.loads(self._template.render(version=doc["version"]))
+        validator = _make_validator(schema)
+        validator.validate(doc)
+
+    def iter_errors(self, doc):
+        try:
+            self._version_validator.validate(doc)
+        except jsonschema.ValidationError:
+            return self._version_validator.iter_errors(doc)
+        else:
+            schema = json.loads(self._template.render(version=doc["version"]))
+            validator = _make_validator(schema)
+            return validator.iter_errors(doc)
 
 
 for name in pkg_resources.resource_listdir(__name__, '.'):
     if name.endswith('.json'):
         reader = codecs.getreader('utf-8')(pkg_resources.resource_stream(__name__, name))
         schema = json.load(reader)
-        validator_cls = jsonschema.validators.validator_for(schema)
-        validator_cls.check_schema(schema)
-        validator = validator_cls(schema, format_checker=jsonschema.FormatChecker())
-        globals()[name[:-5].upper()] = validator
+        globals()[name[:-5].upper()] = _make_validator(schema)
+    elif name.endswith('.json.j2'):
+        globals()[name[:-8].upper()] = MultiVersionValidator(name)

--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -1,3 +1,17 @@
+{% macro validate_version() %}
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "required": ["version"],
+    "properties": {
+        "version": {
+            "type": "string",
+            "enum": ["1.0", "1.1"]
+        }
+    }
+}
+{% endmacro %}
+
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "definitions": {
@@ -41,6 +55,7 @@
             "items": {"$ref": "#/definitions/nonneg_integer"}
         },
         "simulate": {
+{% if version != "1.0" %}
             "oneOf": [
                 {"type": "boolean"},
                 {
@@ -59,6 +74,13 @@
                     "additionalProperties": false
                 }
             ],
+{% else %}
+            "type": "boolean",
+{% endif %}
+            "default": false
+        },
+        "simulate_bool": {
+            "type": "boolean",
             "default": false
         }
     },
@@ -201,7 +223,14 @@
                     "required": ["type"],
                     "properties": {
                         "type": {
-                            "enum": ["sdp.l0", "sdp.beamformer", "sdp.beamformer_engineering", "sdp.cal"]
+                            "enum": [
+                                "sdp.l0",
+{% if version != "1.0" %}
+                                "sdp.cal",
+{% endif %}
+                                "sdp.beamformer",
+                                "sdp.beamformer_engineering"
+                            ]
                         },
                         "src_streams": {"$ref": "#/definitions/src_streams"}
                     },
@@ -275,7 +304,9 @@
                                     }
                                 }
                             ]
-                        },
+                        }
+{% if version != "1.0" %}
+                        ,
                         {
                             "oneOf": [
                                 {
@@ -328,6 +359,7 @@
                                 }
                             ]
                         }
+{% endif %}
                     ]
                 }
             }
@@ -354,7 +386,7 @@
         },
         "version": {
             "type": "string",
-            "enum": ["1.0", "1.1"]
+            "enum": ["{{version}}"]
         }
     }
 }

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -225,7 +225,7 @@ class TestValidate:
 
     def test_v1_0_sdp_cal(self):
         self.config["version"] = "1.0"
-        with assert_raises(ValueError):
+        with assert_raises(jsonschema.ValidationError):
             product_config.validate(self.config)
 
     def test_v1_0_simulate_dict(self):
@@ -234,5 +234,5 @@ class TestValidate:
         # Confirm that this is now valid 1.0
         product_config.validate(self.config)
         self.config["inputs"]["i0_baseline_correlation_products"]["simulate"] = {}
-        with assert_raises(ValueError):
+        with assert_raises(jsonschema.ValidationError):
             product_config.validate(self.config)

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup (
         'async_timeout',
         'decorator',
         'docker',
+        'jinja2',
         'jsonschema',
         'rfc3987',           # Used by jsonschema to validate URLs
         'networkx>=2.0',
@@ -39,7 +40,6 @@ setup (
     tests_require = tests_require,
     extras_require = {
         'agent': ['psutil', 'py3nvml', 'pycuda'],
-        'haproxy_disp': ['jinja2'],
         'test': tests_require
     },
     use_katversion = True,


### PR DESCRIPTION
At the moment this adds code, but it should be more scalable for
updating the API as changes can be made just in the schema file without
having to add lots of special cases to the code. There is also the
possibility to add comments to the schema file in future (using Jinja2
comments), which hasn't been possible as JSON doesn't have comments, and
to simplify some of the constructs using macros.