### PR TITLE
Take separate read and write keys for S3

### DIFF
--- a/katsdpcontroller/schemas/s3_config.json
+++ b/katsdpcontroller/schemas/s3_config.json
@@ -1,12 +1,23 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
+    "definitions": {
+        "key": {"type": "string"},
+        "key_pair": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "access_key": {"$ref": "#/definitions/key"},
+                "secret_key": {"$ref": "#/definitions/key"}
+            }
+        }
+    },
     "type": "object",
     "additionalProperties": false,
     "properties": {
-        "access_key": { "type": "string" },
-        "secret_key": { "type": "string" },
+        "read": {"$ref": "#/definitions/key_pair"},
+        "write": {"$ref": "#/definitions/key_pair"},
         "url": { "type": "string", "format": "uri" }
     },
-    "required": ["access_key", "secret_key", "url"]
+    "required": ["read", "write", "url"]
 }
 

--- a/katsdpcontroller/test/test_sdp_controller.py
+++ b/katsdpcontroller/test/test_sdp_controller.py
@@ -430,8 +430,14 @@ class TestSDPController(BaseTestSDPController):
         self.open_mock = self.create_patch('builtins.open', new_callable=open_file_mock.MockOpen)
         self.open_mock.set_read_data_for('s3_config.json', '''
             {
-                "access_key": "not-really-an-access-key",
-                "secret_key": "tellno1",
+                "read": {
+                    "access_key": "not-really-an-access-key",
+                    "secret_key": "tellno1"
+                },
+                "write": {
+                    "access_key": "another-fake-key",
+                    "secret_key": "s3cr3t"
+                },
                 "url": "http://s3.invalid/"
             }''')
         await self.setup_server(


### PR DESCRIPTION
There are now separate read and write sub-dictionaries.

Closes SR-1062.