### PR TITLE
Make big-array branch ready for merge

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -878,7 +878,7 @@ def _make_filewriter(g, config, name):
     # Eventually it will be deleted entirely (1.95 instead of 2.0 since the
     # actual integration time is not exactly 2s).
     if info.n_vis / info.int_time > _N16_32 / 1.95:
-        logger.info('Disabling filewriter because data rate is too high')
+        logger.warning('Disabling filewriter because data rate is too high')
         return None
 
     filewriter = SDPLogicalTask('filewriter.' + name)


### PR DESCRIPTION
Adds back some old behaviour so that things that currently work on ROACH
continue to work the same way:

- Put back filewriter, but only if the data rate is no more than the
  worst case for ROACH (16A, 32K channels, 2s integrations)
- Use a single cal server for 4K, for the convenience of having a single
  cal report. The cal behaviour (particularly for flagging) is affected
  by the number of servers, so I wanted to make it independent of the
  number of antennas (behaviour is already different between 4K and 32K,
  so some variation on this axis is less of an issue).