### PR TITLE
Turn off verbs for the vis writer

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -564,6 +564,7 @@ def n_cal_nodes(config, name, l0_name):
     # Use single cal for 4K or less: it doesn't need the performance, and
     # a unified cal report is more convenient (revisit once split cal supports
     # a unified cal report).
+    return 1
     info = L0Info(config, l0_name)
     if is_develop(config):
         return 2

--- a/katsdpcontroller/test/test_sdp_controller.py
+++ b/katsdpcontroller/test/test_sdp_controller.py
@@ -621,7 +621,6 @@ class TestSDPController(BaseTestSDPController):
             'l0_spead': mock.ANY,
             'l0_interface': 'em1',
             'l0_name': 'sdp_l0',
-            'l0_ibv': False,
             's3_endpoint_url': 'http://s3.invalid/',
             'override_test': 'value'
         }, immutable=True)


### PR DESCRIPTION
It causes problems in the lab if it runs on the same machine as other
consumers of the L0 stream, because it steals the packets from under
them.