### PR TITLE
Remove katsdpingest from list of dependent images

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -35,7 +35,6 @@ IMAGES = frozenset([
     'katsdpcal',
     'katsdpcam2telstate',
     'katsdpdisp',
-    'katsdpingest',
     'katsdpingest_titanx',
     'katsdpfilewriter',
     'katsdpmetawriter',


### PR DESCRIPTION
It was originally there for cam2telstate and bfingest, but they're now
in their own images.