### PR TITLE
Detect broken sd links

### DIFF
--- a/katsdpcontroller/templates/rotate_sd.html.j2
+++ b/katsdpcontroller/templates/rotate_sd.html.j2
@@ -30,7 +30,6 @@
 
      function rotate()
      {
-      console.log("Attempting rotate...");
       if (arrays.length == 0) { set_content(no_content); return; }
       if (arrays.length == 1 && rotate_frame.src.startsWith(urls[arrays[0]])) { return; }
        // don't rotate if we have only one to display and are currently showing it

--- a/scripts/haproxy_disp.py
+++ b/scripts/haproxy_disp.py
@@ -137,7 +137,7 @@ def request_handler(request):
 
 
 async def websocket_handler(request):
-    ws = aiohttp.web.WebSocketResponse()
+    ws = aiohttp.web.WebSocketResponse(timeout=60, autoping=True, heartbeat=30)
     await ws.prepare(request)
 
     request.app['websockets'].add(ws)


### PR DESCRIPTION
Finally fix the issue with detecting if the loaded content for the signal display rotater is valid and avoid showing until it becomes valid. Requires CORS support in the signal displays which is in master since 390623a.

@ctgschollar - could you take a look at this ?