### PR TITLE
Limit number of scan summaries buffered by cal

### DIFF
--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -258,6 +258,11 @@ def normalise(config):
                 }
                 config['outputs'][unique_name('sdp_l1_flags', config['outputs'])] = flags
 
+    # Update to 2.1
+    if config['version'] == '2.0':
+        # 2.1 is fully backwards-compatible
+        config['version'] = '2.1'
+
     # Fill in defaults
     for name, stream in config['inputs'].items():
         if stream['type'] in ['cbf.baseline_correlation_products',

--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -6,7 +6,7 @@
     "properties": {
         "version": {
             "type": "string",
-            "enum": ["1.0", "1.1", "2.0"]
+            "enum": ["1.0", "1.1", "2.0", "2.1"]
         }
     }
 }
@@ -363,6 +363,9 @@
                                             "type": "object",
                                             "additionalProperties": {"type": "string"}
                                         },
+{% if version >= "2.1" %}
+                                        "max_scans": {"$ref": "#/definitions/positive_integer"},
+{% endif %}
                                         "buffer_time": {"$ref": "#/definitions/positive_number"}
                                     },
                                     "required": ["src_streams"],

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -44,7 +44,7 @@ class TestValidate:
 
     def setup(self):
         self.config = {
-            "version": "2.0",
+            "version": "2.1",
             "inputs": {
                 "camdata": {
                     "type": "cam.http",


### PR DESCRIPTION
This introduces a version 2.1 of the API, with a max_scans argument to
the cal configuration. It defaults to 1000, and is passed to cal (see
ska-sa/katsdppipelines#290).