### PR TITLE
Pass timeplot data via multicast

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -720,7 +720,8 @@ def _make_ingest(g, config, spectral_name, continuum_name):
         ingest.physical_factory = IngestTask
         ingest.image = 'katsdpingest_titanx'
         ingest.command = ['ingest.py']
-        ingest.ports = ['port']
+        ingest.ports = ['port', 'aiomonitor_port', 'aioconsole_port']
+        ingest.wait_ports = ['port']
         ingest.gpus = [scheduler.GPURequest()]
         if not develop:
             ingest.gpus[-1].name = INGEST_GPU_NAME


### PR DESCRIPTION
Apart from using multicast, it also passes it via the sdp_10g network,
which should reduce congestion on the 1Gb control network; and it
includes the bandwidth for the stream in the bandwidth estimates.

The matching support for katsdpdisp has already been merged. For ingest
it will require an extra --sdisp-interface option, but it should
actually work without it as long as we have the routing tables correctly
set up.