### PR TITLE
Unpin packages now provided by katsdpdockerbase

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ attrs==18.1.0              # via prometheus_async
 certifi                    # via requests
 chardet                    # via aiohttp, requests
 decorator
-docker-pycreds==0.2.1      # via docker
-docker==2.7.0
+docker-pycreds==0.3.0      # via docker
+docker==3.4.1
 fakeredis                  # via katsdptelstate
 hiredis
 http-parser==0.8.3         # via pymesos
@@ -35,7 +35,7 @@ pygelf                     # via katsdpservices
 pymesos==0.3.1
 pyparsing==2.2.0           # via pydotplus
 redis                      # via katsdptelstate
-requests==2.18.4           # via docker
+requests==2.19.1           # via docker
 rfc3987==1.3.7
 six                        # via docker and others
 terminaltables             # via aiomonitor


### PR DESCRIPTION
A bunch of Python 3 packages related to aio are now pinned by
katsdpdockerbase, so no longer need pins here.