### PR TITLE
Update to use the docker-base-runtime image for shutdown

### DIFF
--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -473,7 +473,7 @@ class PoweroffLogicalTask(scheduler.LogicalTask):
         # Use minimal resources, to reduce chance it that it won't fit
         self.cpus = 0.001
         self.mem = 64
-        self.image = 'docker-base'
+        self.image = 'docker-base-runtime'
         self.command = ['/sbin/poweroff']
 
         # See https://groups.google.com/forum/#!topic/coreos-dev/AXCs_2_J6Mc

--- a/scripts/sdpmc_dependencies.py
+++ b/scripts/sdpmc_dependencies.py
@@ -13,7 +13,7 @@ def find_images():
     images = set(katsdpcontroller.generator.IMAGES)
     # Add some repositories that do not form part of the graph
     images.add('katsdpcontroller')
-    images.add('docker-base')
+    images.add('docker-base-runtime')
     return images
 
 


### PR DESCRIPTION
docker-base has been removed, but I'd missed updating the shutdown code
to use the new image.