### PR TITLE
Support multiple S3 stores in s3_config.json

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -351,7 +351,7 @@ def _make_cam2telstate(g, config, name):
 
 def _make_meta_writer(g, config):
     def make_config(task, resolver):
-        s3_url = urllib.parse.urlsplit(resolver.s3_config['url'])
+        s3_url = urllib.parse.urlsplit(resolver.s3_config['archive']['url'])
         return {
             's3_host': s3_url.hostname,
             's3_port': s3_url.port,
@@ -364,8 +364,8 @@ def _make_meta_writer(g, config):
     # they are redacted from telstate
     meta_writer.command = [
         'meta_writer.py',
-        '--access-key', '{resolver.s3_config[write][access_key]}',
-        '--secret-key', '{resolver.s3_config[write][secret_key]}'
+        '--access-key', '{resolver.s3_config[archive][write][access_key]}',
+        '--secret-key', '{resolver.s3_config[archive][write][secret_key]}'
     ]
     meta_writer.cpus = 0.2
     # Only a base allocation: it also gets telstate_extra added
@@ -947,7 +947,7 @@ def _make_vis_writer(g, config, name):
         'l0_interface': task.interfaces['sdp_10g'].name,
         'obj_size_mb': 10.0,
         'npy_path': OBJ_DATA_VOL.container_path,
-        's3_endpoint_url': resolver.s3_config['url']
+        's3_endpoint_url': resolver.s3_config['archive']['url']
     })
     g.add_edge(vis_writer, src_multicast, port='spead',
                depends_resolve=True, depends_init=True, depends_ready=True,

--- a/katsdpcontroller/schemas/s3_config.json
+++ b/katsdpcontroller/schemas/s3_config.json
@@ -9,15 +9,24 @@
                 "access_key": {"$ref": "#/definitions/key"},
                 "secret_key": {"$ref": "#/definitions/key"}
             }
+        },
+        "store": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "read": {"$ref": "#/definitions/key_pair"},
+                "write": {"$ref": "#/definitions/key_pair"},
+                "url": { "type": "string", "format": "uri" }
+            },
+            "required": ["write", "url"]
         }
     },
     "type": "object",
     "additionalProperties": false,
     "properties": {
-        "read": {"$ref": "#/definitions/key_pair"},
-        "write": {"$ref": "#/definitions/key_pair"},
-        "url": { "type": "string", "format": "uri" }
+        "continuum": {"$ref": "#/definitions/store"},
+        "spectral": {"$ref": "#/definitions/store"},
+        "archive": {"$ref": "#/definitions/store"}
     },
-    "required": ["read", "write", "url"]
+    "required": ["continuum", "spectral", "archive"]
 }
-

--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -68,11 +68,13 @@ def _load_s3_config(filename):
 
 def _redact_arg(arg, s3_config):
     """Process one argument for _redact_keys"""
-    for mode in ['read', 'write']:
-        for name in ['access_key', 'secret_key']:
-            key = s3_config[mode][name]
-            if arg == key or arg.endswith('=' + key):
-                return arg[:-len(key)] + 'REDACTED'
+    for config in s3_config.values():
+        for mode in ['read', 'write']:
+            if mode in config:
+                for name in ['access_key', 'secret_key']:
+                    key = config[mode][name]
+                    if arg == key or arg.endswith('=' + key):
+                        return arg[:-len(key)] + 'REDACTED'
     return arg
 
 

--- a/katsdpcontroller/test/test_sdp_controller.py
+++ b/katsdpcontroller/test/test_sdp_controller.py
@@ -201,13 +201,16 @@ EXPECTED_REQUEST_LIST = [
 class TestRedactKeys(unittest.TestCase):
     def setUp(self):
         self.s3_config = {
-            'read': {
-                'access_key': 'ACCESS_KEY',
-                'secret_key': 'tellno1'
-            },
-            'write': {
-                'access_key': 's3cr3t',
-                'secret_key': 'mores3cr3t'
+            'archive': {
+                'read': {
+                    'access_key': 'ACCESS_KEY',
+                    'secret_key': 'tellno1'
+                },
+                'write': {
+                    'access_key': 's3cr3t',
+                    'secret_key': 'mores3cr3t'
+                },
+                'url': 'http://invalid/'
             }
         }
 
@@ -462,15 +465,39 @@ class TestSDPController(BaseTestSDPController):
         self.open_mock = self.create_patch('builtins.open', new_callable=open_file_mock.MockOpen)
         self.open_mock.set_read_data_for('s3_config.json', '''
             {
-                "read": {
-                    "access_key": "not-really-an-access-key",
-                    "secret_key": "tellno1"
+                "continuum": {
+                    "read": {
+                        "access_key": "not-really-an-access-key",
+                        "secret_key": "tellno1"
+                    },
+                    "write": {
+                        "access_key": "another-fake-key",
+                        "secret_key": "s3cr3t"
+                    },
+                    "url": "http://continuum.s3.invalid/"
                 },
-                "write": {
-                    "access_key": "another-fake-key",
-                    "secret_key": "s3cr3t"
+                "spectral": {
+                    "read": {
+                        "access_key": "not-really-an-access-key",
+                        "secret_key": "tellno1"
+                    },
+                    "write": {
+                        "access_key": "another-fake-key",
+                        "secret_key": "s3cr3t"
+                    },
+                    "url": "http://spectral.s3.invalid/"
                 },
-                "url": "http://s3.invalid/"
+                "archive": {
+                    "read": {
+                        "access_key": "not-really-an-access-key",
+                        "secret_key": "tellno1"
+                    },
+                    "write": {
+                        "access_key": "another-fake-key",
+                        "secret_key": "s3cr3t"
+                    },
+                    "url": "http://archive.s3.invalid/"
+                }
             }''')
         await self.setup_server(
             '127.0.0.1', 0, self.sched, s3_config_file='s3_config.json',
@@ -620,7 +647,7 @@ class TestSDPController(BaseTestSDPController):
             'l0_spead': mock.ANY,
             'l0_interface': 'em1',
             'l0_name': 'sdp_l0',
-            's3_endpoint_url': 'http://s3.invalid/',
+            's3_endpoint_url': 'http://archive.s3.invalid/',
             'override_test': 'value'
         }, immutable=True)
         # Test that the output channel rounding was done correctly

--- a/sandbox/s3_config.json
+++ b/sandbox/s3_config.json
@@ -1,11 +1,23 @@
 {
-    "read": {
-        "access_key": "dummy",
-        "secret_key": "dummy"
+    "continuum": {
+        "write": {
+            "access_key": "dummy",
+            "secret_key": "dummy"
+        },
+        "url": "http://s3.invalid/"
     },
-    "write": {
-        "access_key": "dummy",
-        "secret_key": "dummy"
+    "spectral": {
+        "write": {
+            "access_key": "dummy",
+            "secret_key": "dummy"
+        },
+        "url": "http://s3.invalid/"
     },
-    "url": "http://s3.invalid/"
+    "archive": {
+        "write": {
+            "access_key": "dummy",
+            "secret_key": "dummy"
+        },
+        "url": "http://s3.invalid/"
+    }
 }


### PR DESCRIPTION
This is to support an on-site imaging buffer that is separate from the
transfer-to-CHPC buffer. To provide maximum flexibility I've provided
keys for "continuum", "spectral" and "archive" (the last being for
chunks that will eventually be archived).

This will need a bit of work during deployment to update the deployed
s3_config.json files.