### PR TITLE
Update memory allocations for vis_writer/flag_writer

### DIFF
--- a/katsdpcontroller/test/test_sdp_controller.py
+++ b/katsdpcontroller/test/test_sdp_controller.py
@@ -653,6 +653,7 @@ class TestSDPController(BaseTestSDPController):
             'l0_interface': 'em1',
             'l0_name': 'sdp_l0',
             's3_endpoint_url': 'http://archive.s3.invalid/',
+            'workers': mock.ANY,
             'override_test': 'value'
         }, immutable=True)
         # Test that the output channel rounding was done correctly


### PR DESCRIPTION
It hadn't been updated after the change to katsdpdatawriter, which uses
a deeper ringbuffer in vis_writer (probably because it took the code
from flag_writer) and also needs extra memory to handle the parallel
writing. The socket buffer calculation was also incorrect.

This will require about 55GB for 64A 32K. It could be reduced
substantially, either by reducing the safety margin (currently a factor
of 2) or by reducing the ringbuffer depth in katsdpdatawriter, but this
will get things going for now.

The number of workers is now also set explicitly to ensure that the
number used matches the number used for the calculation.