### PR TITLE
Backout temporary alloc fix

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -930,9 +930,7 @@ def _writer_mem_mb(dump_size, obj_size, n_substreams, workers):
 
     # Double the memory allocation to be on the safe side. This gives some
     # headroom for page cache etc.
-    # WIP: Testing factor 8 x allocation to see if memory issues on 31 Aug
-    # are solved.
-    return 8 * _mb(memory_pool + worker_mem + socket_buffers) + 256
+    return 2 * _mb(memory_pool + worker_mem + socket_buffers) + 256
 
 
 def _make_vis_writer(g, config, name):


### PR DESCRIPTION
This undoes the temporary fix of commit 40a6b6b - the vis_writer allocation has been fixed in katsdpdata (66cdd00). This is confirmed from observation of the vis_writer container which is sitting just below 10% usage of the allocation on a large observation.