### PR TITLE
Allow the whole of taskinfo to be overridden

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -324,7 +324,7 @@ def _make_telstate(g, config):
     telstate.image = 'katsdptelstate'
     telstate.ports = ['telstate']
     # Run it in /mnt/mesos/sandbox so that the dump.rdb ends up there.
-    telstate.container.docker.setdefault('parameters', []).append(
+    telstate.taskinfo.container.docker.setdefault('parameters', []).append(
         {'key': 'workdir', 'value': '/mnt/mesos/sandbox'})
     telstate.command = ['redis-server', '/usr/local/etc/redis/redis.conf']
     telstate.physical_factory = TelstateTask
@@ -481,7 +481,7 @@ def _make_cbf_simulator(g, config, name):
             # The verbs send interface seems to create a large number of
             # file handles per stream, easily exceeding the default of
             # 1024.
-            sim.container.docker.parameters = [{"key": "ulimit", "value": "nofile=8192"}]
+            sim.taskinfo.container.docker.parameters = [{"key": "ulimit", "value": "nofile=8192"}]
         sim.interfaces = [scheduler.InterfaceRequest('cbf', infiniband=ibv)]
         sim.interfaces[0].bandwidth_out = info.net_bandwidth
         sim.transitions = {
@@ -1046,7 +1046,7 @@ def _make_beamformer_ptuse(g, config, name):
     # If the kernel is < 3.16, the default values are very low. Set
     # the values to the default from more recent Linux versions
     # (https://github.com/torvalds/linux/commit/060028bac94bf60a65415d1d55a359c3a17d5c31)
-    bf_ingest.container.docker.parameters = [
+    bf_ingest.taskinfo.container.docker.parameters = [
         {'key': 'sysctl', 'value': 'kernel.shmmax=18446744073692774399'},
         {'key': 'sysctl', 'value': 'kernel.shmall=18446744073692774399'}
     ]

--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -477,15 +477,15 @@ class PoweroffLogicalTask(scheduler.LogicalTask):
         self.command = ['/sbin/poweroff']
 
         # See https://groups.google.com/forum/#!topic/coreos-dev/AXCs_2_J6Mc
-        self.container.volumes = []
+        self.taskinfo.container.volumes = []
         for path in ['/var/run/dbus', '/run/systemd']:
             volume = Dict()
             volume.mode = 'RW'
             volume.container_path = path
             volume.host_path = path
-            self.container.volumes.append(volume)
-        self.container.docker.parameters = []
-        self.container.docker.parameters.append({'key': 'user', 'value': 'root'})
+            self.taskinfo.container.volumes.append(volume)
+        self.taskinfo.container.docker.setdefault('parameters', [])
+        self.taskinfo.container.docker.parameters.append({'key': 'user', 'value': 'root'})
 
     def valid_agent(self, agent):
         if not super().valid_agent(agent):


### PR DESCRIPTION
Previously one could customise taskinfo.container in the LogicalTask,
but any other customisations to taskinfo had to be done by defining a
new PhysicalTask subclass and overriding resolve(). Now LogicalTask
allows the whole of taskinfo to be customised. This makes it easier to
customise things like taskinfo.command.environment or
taskinfo.command.shell.