### PR TITLE
Temporarily disable beamformer signal displays

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1433,9 +1433,10 @@ def build_logical_graph(config):
         _make_beamformer_engineering(g, config, name)
 
     # Collect all tied-array-channelised-voltage streams and make signal displays for them
-    for name in inputs.get('cbf.tied_array_channelised_voltage', []):
-        if name in inputs_used:
-            _make_timeplot_beamformer(g, config, name)
+    # XXX Temporarily disabled due to MKAIV-1331.
+    # for name in inputs.get('cbf.tied_array_channelised_voltage', []):
+    #     if name in inputs_used:
+    #         _make_timeplot_beamformer(g, config, name)
 
     for name in outputs.get('sdp.continuum_image', []):
         raise NotImplementedError('Continuum imaging is not yet implemented')


### PR DESCRIPTION
The bf_ingest keeps running on the same machine as the correlator
ingest, and the NIC can't seem to handle it (lots of dropped packets).
Temporarily disabling it until we have ConnectX-5's in all the ingest
machines.

See MKAIV-1331.