### PR TITLE
Restrict prometheus_client to <0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'katsdptelstate',
         'katsdpservices',
         'kazoo',
-        'prometheus_client',
+        'prometheus_client<0.4.0',   # 0.4.0 forces _total suffix
         'prometheus_async'
     ],
     tests_require=tests_require,


### PR DESCRIPTION
From 0.4.0, it will automatically append `_total` to any counter that
doesn't already have it. We will need to do a significant overhaul of
our sensors to achieve that.

See SR-1392.