### PR TITLE
Give KatcpTransition a __repr__

### DIFF
--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -85,6 +85,10 @@ class KatcpTransition(object):
                           for arg in self.args]
         return KatcpTransition(self.name, *formatted_args, timeout=self.timeout)
 
+    def __repr__(self):
+        args = ['{!r}'.format(arg) for arg in (self.name,) + self.args]
+        return 'KatcpTransition({}, timeout={!r})'.format(', '.join(args), self.timeout)
+
 
 class SDPLogicalTask(scheduler.LogicalTask):
     def __init__(self, *args, **kwargs):

--- a/katsdpcontroller/test/test_tasks.py
+++ b/katsdpcontroller/test/test_tasks.py
@@ -1,0 +1,18 @@
+from nose.tools import assert_equal
+
+from katsdpcontroller.tasks import KatcpTransition
+
+
+class TestKatcpTransition:
+    def test_format(self):
+        orig = KatcpTransition('{noformat}', 'pos {}', 'named {named}', 5, timeout=10)
+        new = orig.format(123, named='foo')
+        assert_equal(new.name, '{noformat}')
+        assert_equal(new.args, ('pos 123', 'named foo', 5))
+        assert_equal(new.timeout, 10)
+
+    def test_repr(self):
+        assert_equal(repr(KatcpTransition('name', timeout=5)),
+                     "KatcpTransition('name', timeout=5)")
+        assert_equal(repr(KatcpTransition('name', 'arg1', True, timeout=10)),
+                     "KatcpTransition('name', 'arg1', True, timeout=10)")


### PR DESCRIPTION
This will make error messages in logs more readable (closes SR-1393).

Also added unit tests for KatcpTransition, which didn't have any.