### PR TITLE
Add nodes to write continuum product to imager buffer

### DIFF
--- a/katsdpcontroller/test/test_sdp_controller.py
+++ b/katsdpcontroller/test/test_sdp_controller.py
@@ -49,7 +49,7 @@ STREAMS = '''{
 }'''
 
 CONFIG = '''{
-    "version": "1.1",
+    "version": "2.2",
     "inputs": {
         "camdata": {
             "type": "cam.http",
@@ -101,29 +101,33 @@ CONFIG = '''{
     },
     "outputs": {
         "sdp_l0": {
-            "type": "sdp.l0",
+            "type": "sdp.vis",
             "src_streams": ["i0_baseline_correlation_products"],
             "output_int_time": 4.0,
-            "continuum_factor": 1
+            "continuum_factor": 1,
+            "archive": true
         },
         "sdp_l0_continuum": {
-            "type": "sdp.l0",
+            "type": "sdp.vis",
             "src_streams": ["i0_baseline_correlation_products"],
             "output_int_time": 4.0,
-            "continuum_factor": 16
+            "continuum_factor": 16,
+            "archive": true
         },
         "sdp_l0_spectral_only": {
-            "type": "sdp.l0",
+            "type": "sdp.vis",
             "src_streams": ["i0_baseline_correlation_products"],
             "output_int_time": 1.9,
-            "continuum_factor": 1
+            "continuum_factor": 1,
+            "archive": true
         },
         "sdp_l0_continuum_only": {
-            "type": "sdp.l0",
+            "type": "sdp.vis",
             "src_streams": ["i0_baseline_correlation_products"],
             "output_int_time": 2.1,
             "continuum_factor": 16,
-            "output_channels": [117, 3472]
+            "output_channels": [117, 3472],
+            "archive": true
         },
         "sdp_beamformer": {
             "type": "sdp.beamformer",
@@ -154,6 +158,22 @@ CONFIG = '''{
             "type": "sdp.cal",
             "src_streams": ["sdp_l0"],
             "buffer_time": 1800.0
+        },
+        "sdp_l1_flags": {
+            "type": "sdp.flags",
+            "src_streams": ["sdp_l0"],
+            "calibration": ["cal"],
+            "archive": true
+        },
+        "sdp_l1_flags_continuum": {
+            "type": "sdp.flags",
+            "src_streams": ["sdp_l0_continuum"],
+            "calibration": ["cal"],
+            "archive": true
+        },
+        "continuum_image": {
+            "type": "sdp.continuum_image",
+            "src_streams": ["sdp_l1_flags_continuum"]
         }
     },
     "config": {}

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -41,3 +41,10 @@ services:
     entrypoint:
       - /usr/bin/mesos-init-wrapper
       - slave
+  minio:
+    network_mode: host
+    image: minio/minio:RELEASE.2018-10-18T00-28-58Z
+    command: server --address 127.0.0.1:9000 /data
+    environment:
+      MINIO_ACCESS_KEY: minioaccesskey
+      MINIO_SECRET_KEY: miniosecretkey

--- a/sandbox/s3_config.json
+++ b/sandbox/s3_config.json
@@ -1,17 +1,17 @@
 {
     "continuum": {
         "write": {
-            "access_key": "dummy",
-            "secret_key": "dummy"
+            "access_key": "minioaccesskey",
+            "secret_key": "miniosecretkey"
         },
-        "url": "http://s3.invalid/"
+        "url": "http://localhost:9000/"
     },
     "spectral": {
         "write": {
-            "access_key": "dummy",
-            "secret_key": "dummy"
+            "access_key": "minioaccesskey",
+            "secret_key": "miniosecretkey"
         },
-        "url": "http://s3.invalid/"
+        "url": "http://localhost:9000/"
     },
     "archive": {
         "write": {


### PR DESCRIPTION
This will still need some surrounding infrastructure:
- On-site Ceph archive for it to work in production
- Fix for SR-1401 for it to work in dev with minio
- ska-sa/katsdpdata#129

It should all be safe to merge because it's only triggered by a
continuum_image output in the SDP config.