### PR TITLE
Make state ERROR => katcp error status

### DIFF
--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -204,6 +204,10 @@ class CaptureBlock:
                 self.state_change_callback()
 
 
+def _error_on_error(state):
+    return Sensor.Status.ERROR if state == ProductState.ERROR else Sensor.Status.NOMINAL
+
+
 class SDPSubarrayProductBase:
     """SDP Subarray Product Base
 
@@ -263,7 +267,8 @@ class SDPSubarrayProductBase:
             default="{}", initial_status=Sensor.Status.NOMINAL)
         self.state_sensor = Sensor(
             ProductState, subarray_product_id + ".state",
-            "State of the subarray product state machine")
+            "State of the subarray product state machine",
+            status_func=_error_on_error)
         self.state = ProductState.CONFIGURING   # This sets the sensor
         self.logger = logging.LoggerAdapter(logger, dict(subarray_product_id=subarray_product_id))
         self.logger.info("Created: %r", self)


### PR DESCRIPTION
When the subarray product state is ProductState.ERROR, the katcp sensor
should be in error state so that it will be more easily discoverable in
the CAM GUI.

Relates to SR-1090.