### PR TITLE
Do not go to ERROR state if timeplot dies

### DIFF
--- a/katsdpcontroller/sdpcontroller.py
+++ b/katsdpcontroller/sdpcontroller.py
@@ -866,12 +866,12 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
 
     def unexpected_death(self, task):
         self.logger.warning('Task %s died unexpectedly', task.name)
-        if task.critical:
+        if task.logical_node.critical:
             self._go_to_error()
 
     def bad_device_status(self, task):
         self.logger.warning('Task %s has failed (device-status)', task.name)
-        if task.critical:
+        if task.logical_node.critical:
             self._go_to_error()
 
     def _go_to_error(self):

--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -102,6 +102,8 @@ class SDPLogicalTask(scheduler.LogicalTask):
         self.deconfigure_wait = True
         # Whether to wait until all capture blocks are completely dead before killing
         self.wait_capture_blocks_dead = False
+        # Whether we should abort the capture block if the task fails
+        self.critical = True
 
 
 class SDPPhysicalTaskBase(scheduler.PhysicalTask):
@@ -128,8 +130,6 @@ class SDPPhysicalTaskBase(scheduler.PhysicalTask):
         # Set to true if the image uses katsdpservices.setup_logging() and hence
         # can log directly to logstash without logspout.
         self.katsdpservices_logging = False
-        # Whether we should abort the capture block if the task fails
-        self.critical = True
 
     @property
     def subarray_product_id(self):


### PR DESCRIPTION
The previous attempt at this had a mismatch between physical and logical
tasks. The critical attribute is now consistently set on the logical
task.