### PR TITLE
Integrate continuum imager pipeline

### DIFF
--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -1669,8 +1669,8 @@ class PhysicalNode:
         An event that becomes set once the task reaches
         :class:`~TaskState.DEAD`.
     death_expected : bool
-        The task has been requested to exit, and so if it dies it is normal
-        rather than a failure.
+        The task has been requested to exit or is a batch task, and so if it
+        dies it is normal rather than a failure.
     depends_ready : list of :class:`PhysicalNode`
         Nodes that this node has `depends_ready` dependencies on. This is only
         populated during :meth:`resolve`.
@@ -2897,6 +2897,9 @@ class Scheduler(pymesos.Scheduler):
             if node.status is not None and node.status.state != 'TASK_FINISHED':
                 raise TaskError(node)
 
+        for node in nodes:
+            # Batch tasks die on their own
+            node.death_expected = True
         await self.launch(graph, resolver, nodes, queue=queue, resources_timeout=resources_timeout)
         futures = []
         for node in nodes:

--- a/katsdpcontroller/schemas/s3_config.json
+++ b/katsdpcontroller/schemas/s3_config.json
@@ -19,13 +19,19 @@
                 "url": { "type": "string", "format": "uri" }
             },
             "required": ["write", "url"]
+        },
+        "rwstore": {
+            "allOf": [
+                { "$ref": "#/definitions/store" },
+                { "required": ["read"] }
+            ]
         }
     },
     "type": "object",
     "additionalProperties": false,
     "properties": {
-        "continuum": {"$ref": "#/definitions/store"},
-        "spectral": {"$ref": "#/definitions/store"},
+        "continuum": {"$ref": "#/definitions/rwstore"},
+        "spectral": {"$ref": "#/definitions/rwstore"},
         "archive": {"$ref": "#/definitions/store"}
     },
     "required": ["continuum", "spectral", "archive"]

--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -110,6 +110,7 @@ class SDPPhysicalTaskBase(scheduler.PhysicalTask):
         super().__init__(logical_task, loop)
         self.sdp_controller = sdp_controller
         self.subarray_product = subarray_product
+        self.capture_block_id = capture_block_id   # Only useful for batch tasks
         self.logger = logging.LoggerAdapter(
             logger, dict(subarray_product_id=self.subarray_product_id, child_task=self.name))
         if capture_block_id is None:
@@ -130,6 +131,12 @@ class SDPPhysicalTaskBase(scheduler.PhysicalTask):
         self.katsdpservices_logging = False
         # Whether we should abort the capture block if the task fails
         self.critical = True
+
+    def subst_args(self, resolver):
+        args = super().subst_args(resolver)
+        if self.capture_block_id is not None:
+            args['capture_block_id'] = self.capture_block_id
+        return args
 
     @property
     def subarray_product_id(self):
@@ -245,7 +252,8 @@ class SDPPhysicalTaskBase(scheduler.PhysicalTask):
 
     def clone(self):
         return self.logical_node.physical_factory(
-            self.logical_node, self.loop, self.sdp_controller, self.subarray_product)
+            self.logical_node, self.loop, self.sdp_controller, self.subarray_product,
+            self.capture_block_id)
 
     def add_capture_block(self, capture_block):
         self._capture_blocks.add(capture_block.name)

--- a/sandbox/s3_config.json
+++ b/sandbox/s3_config.json
@@ -1,5 +1,9 @@
 {
     "continuum": {
+        "read": {
+            "access_key": "minioaccesskey",
+            "secret_key": "miniosecretkey"
+        },
         "write": {
             "access_key": "minioaccesskey",
             "secret_key": "miniosecretkey"
@@ -7,6 +11,10 @@
         "url": "http://localhost:9000/"
     },
     "spectral": {
+        "read": {
+            "access_key": "minioaccesskey",
+            "secret_key": "miniosecretkey"
+        },
         "write": {
             "access_key": "minioaccesskey",
             "secret_key": "miniosecretkey"


### PR DESCRIPTION
The integration still needs some work within the katsdpcontim image:
several logs are written to file and ideally should be integrated into
our logging system (tricky since it comes from Obit). At least the
Python logging should be done with katsdpservices.

Resource allocations are also a guess and will need to be tweaked.

The schema for s3_config.json is stricter and now requires read keys
(although they can be the same as the write keys). Production systems
will need to be updated for this.

Closes SR-1344.