### PR TITLE
Beamformer tweaks for 1K

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1316,7 +1316,7 @@ def _make_beamformer_engineering_pol(g, info, node_name, src_name, timeplot, ram
         if src_info.n_channels == 1024 and src_info.n_channels_per_substream == 4:
             max_packet = 1100
         else:
-            max_packet = 2200
+            max_packet = 4200
         config = {
             'affinity': [task.cores['disk'], task.cores['network']],
             'interface': task.interfaces['cbf'].name,


### PR DESCRIPTION
- Re-enable signal displays
- Prevent them running on the same node as correlator ingest (still seems to be an issue).