### PR TITLE
Work around SR-1695 by giving metawriter more RAM

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -423,7 +423,10 @@ def _make_meta_writer(g, config):
     ]
     meta_writer.cpus = 0.2
     # Only a base allocation: it also gets telstate_extra added
-    meta_writer.mem = 256
+    # meta_writer.mem = 256
+    # Temporary workaround for SR-1695, until the machines can have their
+    # kernels upgraded: give it the same memory as telescore state
+    meta_writer.mem = find_node(g, 'telstate').mem
     meta_writer.ports = ['port']
     meta_writer.volumes = [OBJ_DATA_VOL]
     meta_writer.interfaces = [scheduler.InterfaceRequest('sdp_10g')]


### PR DESCRIPTION
It's given the same amount as telstate. That it probably total overkill,
but should prevent the issue recurring until we can get it properly
fixed by updating the kernel.