### PR TITLE
Disable GPU for continuum imager

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1569,7 +1569,7 @@ def _make_continuum_imager(g, config, name):
         '--access-key', '{resolver.s3_config[continuum][read][access_key]}',
         '--secret-key', '{resolver.s3_config[continuum][read][secret_key]}',
         '--select', 'scans="track"; corrprods="cross"',
-        '--mfimage', 'nThreads={}'.format(cpus),
+        '--mfimage', 'doGPU=False; nThreads={}'.format(cpus),
         '-w', '/mnt/mesos/sandbox', data_url
     ]
     g.add_node(imager)


### PR DESCRIPTION
This is a temporary workaround until Bill Cotton fixes the GPU support
in Obit.