### PR TITLE
Add support for non-realtime clocks in simulator

### DIFF
--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -339,6 +339,9 @@ def normalise(config):
                               'cbf.tied_array_channelised_voltage']:
             if stream.setdefault('simulate', False) is True:
                 stream['simulate'] = {}
+            if stream.get('simulate', False) is not False:
+                stream['simulate'].setdefault('clock_ratio', 1.0)
+                stream['simulate'].setdefault('sources', [])
 
     for name, output in config['outputs'].items():
         if output['type'] == 'sdp.vis':

--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -66,6 +66,10 @@
                 {
                     "type": "object",
                     "properties": {
+{% if version >= "2.4" %}
+                        "clock_ratio": {"type": "number", "minimum": 0.0, "default": 1.0},
+                        "start_time": {"$ref": "#/definitions/positive_number"},
+{% endif %}
                         "sources": {
                             "type": "array",
                             "items": {"type": "string"}
@@ -74,7 +78,7 @@
                             "type": "array",
                             "items": {"type": "string"}
                         },
-                        "center_freq": {"type": "number"}
+                        "center_freq": {"$ref": "#/definitions/positive_number"}
                     },
                     "additionalProperties": false
                 }

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -342,7 +342,10 @@ class TestValidate:
         self.config_v1_0["inputs"]["i0_baseline_correlation_products"]["simulate"] = True
         config = product_config.normalise(self.config_v1_0)
         expected = self.config
-        expected["inputs"]["i0_baseline_correlation_products"]["simulate"] = {}
+        expected["inputs"]["i0_baseline_correlation_products"]["simulate"] = {
+            "clock_ratio": 1.0,
+            "sources": []
+        }
         expected["inputs"]["i0_tied_array_channelised_voltage_0x"]["simulate"] = False
         expected["inputs"]["i0_tied_array_channelised_voltage_0y"]["simulate"] = False
         expected["outputs"]["l0"]["excise"] = True
@@ -366,7 +369,10 @@ class TestValidate:
         del self.config["outputs"]["continuum_image"]["mfimage_parameters"]
         del self.config["outputs"]["spectral_image"]["output_channels"]
 
-        expected["inputs"]["i0_baseline_correlation_products"]["simulate"] = {}
+        expected["inputs"]["i0_baseline_correlation_products"]["simulate"] = {
+            "clock_ratio": 1.0,
+            "sources": []
+        }
         expected["inputs"]["i0_tied_array_channelised_voltage_0x"]["simulate"] = False
         expected["inputs"]["i0_tied_array_channelised_voltage_0y"]["simulate"] = False
         expected["outputs"]["l0"]["excise"] = True

--- a/katsdpcontroller/test/test_sdp_controller.py
+++ b/katsdpcontroller/test/test_sdp_controller.py
@@ -773,7 +773,8 @@ class TestSDPController(BaseTestSDPController):
             'sd_int_time': 1.996,
             'output_int_time': 1.996,
             'output_channels': '96:3488',
-            'servers': 2
+            'servers': 2,
+            'clock_ratio': 1.0
         })
 
         # Verify the state of the subarray
@@ -930,6 +931,7 @@ class TestSDPController(BaseTestSDPController):
             'cbf_adc_sample_rate': 1712000000.0,
             'cbf_bandwidth': 856000000.0,
             'cbf_int_time': 0.499,
+            'cbf_sim_clock_ratio': 1.0,
             'cbf_sync_time': mock.ANY,
             'cbf_spead': '239.102.255.0+15:7148',
             'max_packet_size': mock.ANY,


### PR DESCRIPTION
Adds `clock_ratio` and `start_time` options to `simulate` block in
product_config. Apart from passing it through to the simulator, it also
passes clock_ratio to ingest and cal so that they can scale their
transmission rates to keep up.

At the moment using start_time makes it impractical to do more than one
capture block in the lifetime of the subarray, because they will all
happen at the same time. Fixing that will need interface changes to
`capture-init` to communicate the per-CB start time.

These are rolled into the 2.4 version of the ICD.