### PR TITLE
Enable beamformer signal display again

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1497,9 +1497,7 @@ def build_logical_graph(config):
     # Collect all tied-array-channelised-voltage streams and make signal displays for them
     for name in inputs.get('cbf.tied_array_channelised_voltage', []):
         if name in inputs_used:
-            # NOTE: Temporary fix until CAM / CBF send us correct meta-data
-            # See MKAIV-1470 for more detail.
-            pass  # _make_timeplot_beamformer(g, config, name)
+            _make_timeplot_beamformer(g, config, name)
 
     for name in outputs.get('sdp.continuum_image', []):
         _make_imager_writers(g, config, have_cal, 'continuum', name)


### PR DESCRIPTION
katsdpbfingest should no longer flood the logging system when we're sent
bad data.