### PR TITLE
Show full telstate config in dashboard

### DIFF
--- a/katsdpcontroller/templates/task_details.html.j2
+++ b/katsdpcontroller/templates/task_details.html.j2
@@ -28,9 +28,9 @@
 {% endif %}
 
 <h3>Telstate config</h3>
-{% if task.task_config is defined %}
+{% if task_config %}
 <pre>
-{{task.task_config | tojson(indent=2)}}
+{{task_config | tojson(indent=2)}}
 </pre>
 {% else %}
 <p>N/A</p>


### PR DESCRIPTION
Some tasks have parent group nodes which contain telstate config for a
set of tasks e.g. ingest.sdp_l0 is a parent of ingest.sdp_l0.1. Update
the dashboard code to walk this tree to produce the effective telstate
config.