### PR TITLE
Fix a bug with showing task details for batch tasks

### DIFF
--- a/katsdpcontroller/dashboard.py
+++ b/katsdpcontroller/dashboard.py
@@ -285,8 +285,7 @@ class Dashboard:
             product = sdp_controller.subarray_products.get(product_name)
             if product is None:
                 return []
-            tasks = [task for (capture_block_id, task) in _get_batch_tasks(product)]
-            return _make_task_details(tasks, active_cell)
+            return _make_task_details(product, active_cell)
 
         return app
 


### PR DESCRIPTION
A previous change to fix things for realtime tasks changed the interface
of `_make_task_details`, but for the batch system it didn't update.