### PR TITLE
Spectral imager loading from wrong archive

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1681,8 +1681,8 @@ def _make_spectral_imager(g, config, capture_block_id, name, telstate):
             imager.command = [
                 'imager.py',
                 '-i', 'target={}'.format(target.description),
-                '-i', 'access-key={resolver.s3_config[continuum][read][access_key]}',
-                '-i', 'secret-key={resolver.s3_config[continuum][read][secret_key]}',
+                '-i', 'access-key={resolver.s3_config[spectral][read][access_key]}',
+                '-i', 'secret-key={resolver.s3_config[spectral][read][secret_key]}',
                 '--stokes', 'IQUV',
                 '--start-channel', str(first_channel),
                 '--stop-channel', str(last_channel),


### PR DESCRIPTION
It was using the continuum archive config in s3_config.json