### PR TITLE
Put upper bound on aiokatcp version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'networkx>=2.0',
         'pydotplus',
         'netifaces',
-        'aiokatcp>=0.2',
+        'aiokatcp>=0.2,<0.5',        # 0.5 is expected to change SensorSet constructor
         'katdal',
         'katsdptelstate',
         'katsdpservices',


### PR DESCRIPTION
I'm making changes to aiokatcp that will break the way katsdpcontroller
(ab)uses aiokatcp.SensorSet.