### PR TITLE
Pass --outputdir to continuum imager

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1694,6 +1694,7 @@ def _make_continuum_imager(g, config, capture_block_id, name, telstate, target_c
         imager.mem = 50000 if not is_develop(config) else 8000
         imager.disk = _mb(1000 * l0_info.size + 1000)
         imager.max_run_time = 86400     # 24 hours
+        imager.volumes = [DATA_VOL]
         imager.gpus = [scheduler.GPURequest()]
         # Just use a whole GPU - no benefit in time-sharing for batch tasks (unless
         # it can help improve parallelism). There is no memory enforcement and I
@@ -1711,6 +1712,7 @@ def _make_continuum_imager(g, config, capture_block_id, name, telstate, target_c
             '--capture-block-id', capture_block_id,
             '--output-id', name,
             '--telstate-id', telstate.join(name, target_name),
+            '--outputdir', DATA_VOL.container_path,
             '--mfimage', _render_continuum_parameters(mfimage_parameters),
             '-w', '/mnt/mesos/sandbox', data_url
         ]

--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -506,9 +506,11 @@ class SDPPhysicalTask(SDPConfigMixin, scheduler.PhysicalTask):
                 self.subarray_product.unexpected_death(self)
 
     def clone(self):
-        return self.logical_node.physical_factory(
+        clone = self.logical_node.physical_factory(
             self.logical_node, self.loop, self.sdp_controller, self.subarray_product,
             self.capture_block_id)
+        clone.generation = self.generation + 1
+        return clone
 
     def add_capture_block(self, capture_block):
         self._capture_blocks.add(capture_block.name)


### PR DESCRIPTION
This gives it a place to write images that will be picked up by
katsdptransfer.

There is also some code that tracks the number of times a physical task
has been retried, to simplify generating names that are unique across
all physical tasks, but it ended up not being needed because
katsdpcontim now generates a unique directory name itself.