### PR TITLE
Full endpoint in "Port mappings" section of dashboard

### DIFF
--- a/katsdpcontroller/templates/task_details.html.j2
+++ b/katsdpcontroller/templates/task_details.html.j2
@@ -71,7 +71,7 @@ N/A
   <thead><tr><th>Name</th><th>Port</th></tr></thead>
   <tbody>
 {% for name, value in task.ports.items() %}
-    <tr><td>{{name}}</td><td>{{value}}</td></tr>
+    <tr><td>{{name}}</td><td>{{task.host}}:{{value}}</td></tr>
 {% endfor %}
   </tbody>
 </table>


### PR DESCRIPTION
This makes it easier to copy-and-paste endpoints e.g. for telstate.