### PR TITLE
Report start time of products in ?product-list

### DIFF
--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -11,6 +11,8 @@
     }
 }
 {% endmacro %}
+
+{% macro validate(version) %}
 {% if version >= "2.0" %}
 {%     set sdp_vis = "sdp.vis" %}
 {% else %}
@@ -514,3 +516,4 @@
         }
     }
 }
+{% endmacro %}

--- a/katsdpcontroller/schemas/zk_state.json.j2
+++ b/katsdpcontroller/schemas/zk_state.json.j2
@@ -1,3 +1,19 @@
+{% macro validate_version() %}
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "required": ["version"],
+    "properties": {
+        "version": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2
+        }
+    }
+}
+{% endmacro %}
+
+{% macro validate(version) %}
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
@@ -5,8 +21,7 @@
     "required": ["version", "next_capture_block_id", "next_multicast_group", "products"],
     "properties": {
         "version": {
-            "type": "integer",
-            "enum": [1]
+            "type": "integer"
         },
         "next_capture_block_id": {
             "type": "integer",
@@ -21,8 +36,16 @@
             "additionalProperties": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["run_id", "task_id", "host", "port", "config", "multicast_groups"],
+                "required": [
+{% if version >= 2 %}
+                    "start_time",
+{% endif %}
+                    "run_id", "task_id", "host", "port", "config", "multicast_groups"
+                ],
                 "properties": {
+{% if version >= 2 %}
+                    "start_time": {"type": "number"},
+{% endif %}
                     "run_id": {"type": "string"},
                     "task_id": {"type": "string"},
                     "host": {"type": "string"},
@@ -37,3 +60,4 @@
         }
     }
 }
+{% endmacro %}


### PR DESCRIPTION
This became a bit complicated because it was the first time the zk_state
schema version has been bumped. The schema was converted to use the
same multi-versioning system the product_config schema uses. The system
then needed to be modified to cope with version being an integer rather
than a string. Now instead of the full schema being in the template body
(which required some valid version to be supplied just to load the
template), the full schema is in a macro parametrised by the version.

Fixes SPR1-167.