### PR TITLE
Fix the product_config schema for extra parameters

### DIFF
--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -48,8 +48,9 @@
         "continuum_parameters": {
             "type": "object",
             "patternProperties": {
-                "^[A-Za-z_][A-Za-z0-9_]*$": {"type": "object"}
-            }
+                "^[A-Za-z_][A-Za-z0-9_]*$": {}
+            },
+            "additionalProperties": false
         },
         "singleton": {
             "type": "array",


### PR DESCRIPTION
It was requiring every member of continuum_parmeters (that matched the
regex) to have type object, which means dict. The actual intention was
to ensure that all property names matched the regex, without enforcing a
type.