### PR TITLE
Remove docker-base-runtime from the dependency list

### DIFF
--- a/scripts/sdpmc_dependencies.py
+++ b/scripts/sdpmc_dependencies.py
@@ -11,9 +11,8 @@ except ImportError:
 
 def find_images():
     images = set(katsdpcontroller.generator.IMAGES)
-    # Add some repositories that do not form part of the graph
+    # Add self to the image list
     images.add('katsdpcontroller')
-    images.add('docker-base-runtime')
     return images
 
 


### PR DESCRIPTION
It was originally there to support ?sdp-shutdown, but that's now
implemented by an HTTP service.