### PR TITLE
Make 'Lost connection' display on dashboard work again

### DIFF
--- a/katsdpcontroller/web.py
+++ b/katsdpcontroller/web.py
@@ -40,7 +40,7 @@ async def _prometheus_handler(request: web.Request) -> web.Response:
     response = await prometheus_async.aio.web.server_stats(request)
     if response.status == 200:
         # Avoid spamming logs (feeds into web_utils.AccessLogger).
-        response.log_level = logging.DEBUG
+        response['log_level'] = logging.DEBUG
     return response
 
 
@@ -112,7 +112,8 @@ async def _block_dashboard(request: web.Request) -> web.Response:
     """
     await asyncio.sleep(2)
     response = web.json_response({}, status=404)
-    response.log_level = logging.DEBUG   # Avoid spamming the logs many times a second
+    # Avoid spamming the logs many times a second
+    response['log_level'] = logging.DEBUG
     return response
 
 

--- a/katsdpcontroller/web_utils.py
+++ b/katsdpcontroller/web_utils.py
@@ -25,7 +25,7 @@ class AccessLogger(aiohttp.web_log.AccessLogger):
     response to specify the log level. If not set, it defaults to INFO.
     """
     def log(self, request, response, time):
-        level = getattr(response, 'log_level', logging.INFO)
+        level = response.get('log_level', logging.INFO)
         # Callee calls self.logger.info. We temporarily swap out the logger
         # to override the log level. It's not thread-safe, but aiohttp runs
         # on the event loop anyway.


### PR DESCRIPTION
It was being thwarted by the proxying: it redirected to the master
controller's web server, and even though that returned a 405, dash would
treat this as completion and reset the loading state.

Hack around that by delaying the response by 2s, so that dash always
believes it has stale data.

Closes SPR1-257.