### PR TITLE
Give product controller 512MB of RAM

### DIFF
--- a/katsdpcontroller/master_controller.py
+++ b/katsdpcontroller/master_controller.py
@@ -700,7 +700,7 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
             },
             "resources": {
                 "cpus": 0.2,
-                "memoryMb": 128,
+                "memoryMb": 512,
                 "numPorts": 5         # katcp, http, aiomonitor, aioconsole, dashboard
             }
         }


### PR DESCRIPTION
It was crashing with 128MB. This should fix SPR1-262.