### PR TITLE
update-local-registry: remove katsdpcal special case

### DIFF
--- a/sandbox/update-local-registry.py
+++ b/sandbox/update-local-registry.py
@@ -41,7 +41,6 @@ IMAGE_INFO = {
     'docker-base-build': ImageInfo(repo='katsdpdockerbase'),
     'docker-base-gpu-build': ImageInfo(action=Action.BUILD, repo='katsdpdockerbase'),
     'docker-base-gpu-runtime': ImageInfo(action=Action.BUILD, repo='katsdpdockerbase'),
-    'katsdpcal': ImageInfo(action=Action.BUILD, repo='katsdppipelines'),
     'katsdpcontim': ImageInfo(action=Action.BUILD),
     'katsdpingest_geforce_gtx_titan_x': ImageInfo(action=Action.TUNE, repo='katsdpingest'),
     'katsdpingest': ImageInfo(action=Action.BUILD),


### PR DESCRIPTION
No longer needed now that katsdpcal is in its own repo and pushed to
quay.io.