### PR TITLE
Increase number of file handles for haproxy

### DIFF
--- a/katsdpcontroller/templates/haproxy.conf.j2
+++ b/katsdpcontroller/templates/haproxy.conf.j2
@@ -1,5 +1,8 @@
 global
     maxconn 256
+    # Workaround for haproxy apparently leaking file handles to
+    # /dev/random and /dev/urandom. Remove if that gets fixed.
+    ulimit-n 1048576
 
 defaults
     mode http


### PR DESCRIPTION
This is a workaround for OPS-377.