### PR TITLE
Enable haproxy statistics page, plus health checks

### DIFF
--- a/katsdpcontroller/templates/haproxy.conf.j2
+++ b/katsdpcontroller/templates/haproxy.conf.j2
@@ -20,9 +20,13 @@ frontend http-in
     http-request set-var(req.label) path,field(5,/) if has_gui
     use_backend %[var(req.product)]:%[var(req.service)]:%[var(req.label)] if has_gui
     default_backend fallback
+    stats enable
+    stats uri /stats
+    stats refresh 10s
+    stats admin if LOCALHOST
 
 backend fallback
-    server fallback_html_server 127.0.0.1:{{ internal_port }}
+    server fallback_html_server 127.0.0.1:{{ internal_port }} check
 
 {% for product_name, product in guis.products.items() %}
 {% for gui in product %}
@@ -30,6 +34,6 @@ backend {{ product_name }}:{{ gui.service or 'product' }}:{{ gui.label }}
 {% if not gui.orig_href.path.startswith('/gui/' + product_name + '/' + gui.service + '/' + gui.label) %}
     http-request set-path {{ gui.orig_href.path }}%[path,regsub(^/gui/.*?/.*?/.*?/,)]
 {% endif %}
-    server {{ product_name }}:{{ gui.service }}:{{ gui.label }}:server {{ gui.orig_href.host }}:{{ gui.orig_href.port }}
+    server {{ product_name }}:{{ gui.service }}:{{ gui.label }}:server {{ gui.orig_href.host }}:{{ gui.orig_href.port }} check
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
It adds a /stats to the server, from which we can see the status of the
various backend servers. I've also enabled TCP-level health checks so
that we can see whether haproxy is able to connect to the servers. I
briefly tried http health checks, but most of the backend servers return
a 404 if asked for / so that failed (we could of course try asking for
the URL where they actually display the dashboard, but in some cases I
think that could be expensive).