### PR TITLE
Expose subarray `state` sensor to Prometheus

### DIFF
--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -271,7 +271,7 @@ class SDPSubarrayProductBase:
             default="{}", initial_status=Sensor.Status.NOMINAL)
         self._state_sensor = Sensor(
             ProductState, "state",
-            "State of the subarray product state machine",
+            "State of the subarray product state machine (prometheus: gauge)",
             status_func=_error_on_error)
         self._device_status_sensor = sdp_controller.sensors['device-status']
 

--- a/katsdpcontroller/test/test_sensor_proxy.py
+++ b/katsdpcontroller/test/test_sensor_proxy.py
@@ -84,6 +84,9 @@ class TestSensorProxyClient(asynctest.TestCase):
             elif name == 'histogram-sensor':
                 return PrometheusInfo(functools.partial(Histogram, buckets=(1, 10)),
                                       'test_histogram_sensor', 'A histogram', {}, self.registry)
+            elif name == 'enum-sensor':
+                return PrometheusInfo(Gauge, 'test_enum_sensor', 'An enum gauge',
+                                      {}, self.registry)
             else:
                 return None
 
@@ -188,6 +191,10 @@ class TestSensorProxyClient(asynctest.TestCase):
         # Gauge must not change.
         await self._set('float-sensor', 1.0, status=Sensor.Status.FAILURE)
         self._check_prom('test_float_sensor', 2.5, Sensor.Status.FAILURE)
+
+    async def test_enum_gauge(self) -> None:
+        await self._set('enum-sensor', MyEnum.NO)
+        self._check_prom('test_enum_sensor', 1.0)
 
     async def test_histogram(self) -> None:
         # Record some values, check the counts


### PR DESCRIPTION
This will allow Grafana dashboards to show the subarray product state
(via a value-to-text mapping). Since Prometheus doesn't support string
values, enum/discrete sensors are mapped to an integer according to the
position in the list of legal values.