### PR TITLE
Suppress logging 404 errors for missing GUI URLs

### DIFF
--- a/katsdpcontroller/web.py
+++ b/katsdpcontroller/web.py
@@ -100,7 +100,7 @@ async def _favicon_handler(request: web.Request) -> web.Response:
     raise web.HTTPFound(location='static/favicon.ico')
 
 
-async def _missing_gui_handler(request: web.Request) -> dict:
+async def _missing_gui_handler(request: web.Request) -> web.Response:
     response = aiohttp_jinja2.render_template('missing_gui.html.j2', request, {}, status=404)
     # Avoid spamming logs (feeds into web_utils.AccessLogger).
     response['log_level'] = logging.DEBUG


### PR DESCRIPTION
They tend to get hit a lot due to GUIs that rely on polling going away,
leaving browsers hammering the URL.

Also changed it to accept all HTTP methods and return 404, rather than
only working for GET (and thus returning 405 for everything else).

Closes SPR1-258.