### PR TITLE
Explicitly set haproxy ulimit-n (again)

### DIFF
--- a/katsdpcontroller/templates/haproxy.conf.j2
+++ b/katsdpcontroller/templates/haproxy.conf.j2
@@ -3,6 +3,11 @@ global
     # Enables hitless reloads. See
     # https://www.haproxy.com/blog/hitless-reloads-with-haproxy-howto/
     stats socket {{ tmpdir }}/haproxy.sock mode 600 expose-fd listeners level user
+    # haproxy normally computes this from maxconn, number of backends etc, but when
+    # we do a reload it complains if we've added more backends as it cannot
+    # increase it.  So we set it to a large enough value up front (increase it
+    # if maxconn increases).
+    ulimit-n 1024
 
 defaults
     mode http


### PR DESCRIPTION
The auto-computed limit depends on the number of backends. If it was
started with no arrays then it would set a low limit, and warn because
it was unable to raise it when a new backend was added. That's only
serious if we actually get close to maxconn, but for safety I'm now
setting a ulimit-n that's much higher than the auto-computed value and
should handle hundreds of backends.