### PR TITLE
Build haproxy from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,28 @@ ARG KATSDPDOCKERBASE_REGISTRY=quay.io/ska-sa
 
 FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-build as build
 
+USER root
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install liblua5.3-dev libssl-dev
+USER kat
+
+# We need to build haproxy from source because the version in Ubuntu 18.04 has
+# a bug that causes it to run out of file handles and the PPA at
+# https://launchpad.net/~vbernat/+archive/ubuntu/haproxy-1.8 deletes non-latest
+# versions.
+#
+# The make flags are based on debian/rules from the Ubuntu 18.04 package.
+RUN VERSION=1.8.22 && \
+    wget http://www.haproxy.org/download/1.8/src/haproxy-$VERSION.tar.gz -O /tmp/haproxy-$VERSION.tar.gz && \
+    tar -C /tmp -zxf /tmp/haproxy-$VERSION.tar.gz && \
+    cd /tmp/haproxy-$VERSION && \
+    make -j PREFIX=/usr \
+        USE_PCRE=1 PCREDIR= USE_PCRE_JIT=1 \
+        USE_OPENSSL=1 USE_ZLIB=1 USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
+        USE_GETADDRINFO=1 \
+        USE_NS=1 TARGET=linux2628 USE_REGPARM=1 DEBUG=-s && \
+    make install PREFIX=/usr DESTDIR=/tmp/haproxy-install
+
 # Switch to Python 3 environment
 ENV PATH="$PATH_PYTHON3" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON3"
 
@@ -26,13 +48,11 @@ ARG dependencies
 RUN test -n "$dependencies" || (echo "Please build with scripts/docker_build.sh" 1>&2; exit 1)
 LABEL za.ac.kat.sdp.image-depends $dependencies
 
-# Install haproxy for --haproxy support and graphviz for --write-graphs support.
-# We need to add a PPA for haproxy because the version in Ubuntu 18.04 has a bug
-# that causes it to run out of file handles.
+# Install haproxy for --haproxy support and graphviz for --write-graphs
 USER root
-RUN apt-add-repository ppa:vbernat/haproxy-1.8 && \
-    apt-get -y update && \
-    apt-get -y --no-install-recommends install "haproxy=1.8.22-*" graphviz && \
+COPY --from=build /tmp/haproxy-install/usr/sbin/haproxy /usr/sbin/haproxy
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install liblua5.3 graphviz && \
     rm -rf /var/lib/apt/lists/*
 USER kat
 


### PR DESCRIPTION
The PPA I was using released a new version and **deleted** the version
we've pinned. So rather than have the carpet removed from under us
every release, I'm building haproxy from a source download. This might
even make the image slightly smaller since only the binary is copied to
the final image, not the docs.