### PR TITLE
Expose sensors to Prometheus from product controller

### DIFF
--- a/katsdpcontroller/master_controller.py
+++ b/katsdpcontroller/master_controller.py
@@ -529,7 +529,7 @@ class InternalProductManager(ProductManagerBase[InternalProduct]):
     async def create_product(self, name: str, config: dict) -> InternalProduct:
         mc_client = aiokatcp.Client(*device_server_sockname(self._server))
         server = product_controller.DeviceServer(
-            '127.0.0.1', 0, mc_client, None, self._args.batch_role,
+            '127.0.0.1', 0, mc_client, name, None, self._args.batch_role,
             True, self._args.localhost, self._image_resolver_factory, {})
         product = InternalProduct(name, config, asyncio.Task.current_task(), server)
         self._add_product(product)

--- a/katsdpcontroller/master_controller.py
+++ b/katsdpcontroller/master_controller.py
@@ -14,7 +14,6 @@ import uuid
 import ipaddress
 import json
 import itertools
-import functools
 import re
 import time
 from datetime import datetime
@@ -31,7 +30,6 @@ import async_timeout
 import jsonschema
 import yarl
 import aiohttp
-from prometheus_client import Gauge, Counter, Histogram, CollectorRegistry, REGISTRY
 import katsdpservices
 
 import katsdpcontroller
@@ -42,9 +40,6 @@ from .controller import (time_request, load_json_dict, log_task_exceptions, devi
                          ProductState, DeviceStatus, device_status_to_sensor_status)
 
 
-_HINT_RE = re.compile(r'\bprometheus: *(?P<type>[a-z]+)(?:\((?P<args>[^)]*)\)|\b)'
-                      r'(?: +labels: *(?P<labels>[a-z,]+))?',
-                      re.IGNORECASE)
 ZK_STATE_VERSION = 3
 logger = logging.getLogger(__name__)
 _T = TypeVar('_T')
@@ -59,51 +54,6 @@ class NoAddressesError(Exception):
 
 class ProductFailed(Exception):
     """Attempt to create a subarray product was unsuccessful"""
-
-
-def _prometheus_factory(registry: CollectorRegistry,
-                        name: str,
-                        sensor: aiokatcp.Sensor) -> Optional[sensor_proxy.PrometheusInfo]:
-    assert sensor.description is not None
-    match = _HINT_RE.search(sensor.description)
-    if not match:
-        return None
-    type_ = match.group('type').lower()
-    args_ = match.group('args')
-    if type_ == 'counter':
-        class_ = Counter
-        if args_ is not None:
-            logger.warning('Arguments are not supported for counters (%s)', sensor.name)
-    elif type_ == 'gauge':
-        class_ = Gauge
-        if args_ is not None:
-            logger.warning('Arguments are not supported for gauges (%s)', sensor.name)
-    elif type_ == 'histogram':
-        class_ = Histogram
-        if args_ is not None:
-            try:
-                buckets = [float(x.strip()) for x in args_.split(',')]
-                class_ = functools.partial(Histogram, buckets=buckets)
-            except ValueError as exc:
-                logger.warning('Could not parse histogram buckets (%s): %s', sensor.name, exc)
-    else:
-        logger.warning('Ignoring unknown Prometheus metric type %s for %s', type_, sensor.name)
-        return None
-    parts = name.rsplit('.')
-    base = parts.pop()
-    label_names = (match.group('labels') or '').split(',')
-    label_names = [label for label in label_names if label]    # ''.split(',') is [''], want []
-    if len(parts) < len(label_names):
-        logger.warning('Not enough parts in name %s for labels %s', name, label_names)
-        return None
-    service_parts = len(parts) - len(label_names)
-    service = '.'.join(parts[:service_parts])
-    labels = dict(zip(label_names, parts[service_parts:]))
-    if service:
-        labels['service'] = service
-    normalised_name = 'katsdpcontroller_' + base.replace('-', '_')
-    return sensor_proxy.PrometheusInfo(class_, normalised_name, sensor.description,
-                                       labels, registry)
 
 
 def _load_s3_config(filename: str) -> dict:
@@ -175,7 +125,7 @@ class Product:
         self.sensors.add(Sensor(Address, f'{self.name}.katcp-address',
                                 'Address of the katcp server for the product controller'))
 
-    def connect(self, server: aiokatcp.DeviceServer, registry: CollectorRegistry,
+    def connect(self, server: aiokatcp.DeviceServer,
                 rewrite_gui_urls: Optional[Callable[[Sensor], bytes]],
                 host: _IPAddress, ports: Dict[str, int]) -> None:
         """Notify product of the location of the katcp interface.
@@ -193,8 +143,7 @@ class Product:
                 self.logger.warning('Sensor %s does not exist', sensor_name)
         self.katcp_conn = aiokatcp.Client(str(host), ports['katcp'])
         self.katcp_conn.add_sensor_watcher(sensor_proxy.SensorWatcher(
-            self.katcp_conn, server, f'{self.name}.', {'subarray_product_id': self.name},
-            functools.partial(_prometheus_factory, registry),
+            self.katcp_conn, server, f'{self.name}.',
             rewrite_gui_urls=rewrite_gui_urls,
             enum_types=(DeviceStatus,)))
         self.katcp_conn.add_inform_callback('disconnect', self._disconnect_callback)
@@ -288,7 +237,6 @@ class ProductManagerBase(Generic[_P]):
 
     def __init__(self, args: argparse.Namespace, server: aiokatcp.DeviceServer,
                  image_resolver_factory: scheduler.ImageResolverFactory,
-                 prometheus_registry: CollectorRegistry = REGISTRY,
                  rewrite_gui_urls: Callable[[Sensor], bytes] = None) -> None:
         self._args = args
         self._multicast_network = ipaddress.IPv4Network(args.safe_multicast_cidr)
@@ -297,7 +245,6 @@ class ProductManagerBase(Generic[_P]):
         self._products: Dict[str, _P] = {}
         self._next_capture_block_id = 1
         self._image_resolver_factory = image_resolver_factory
-        self._prometheus_registry = prometheus_registry
         self._rewrite_gui_urls = rewrite_gui_urls
 
     @abstractmethod
@@ -487,8 +434,7 @@ class ProductManagerBase(Generic[_P]):
         `ports` must contain at least ``katcp``, but subclasses may include
         additional ports.
         """
-        product.connect(self._server, self._prometheus_registry, self._rewrite_gui_urls,
-                        host, ports)
+        product.connect(self._server, self._rewrite_gui_urls, host, ports)
         assert product.katcp_conn is not None
         product.katcp_conn.add_sensor_watcher(DeviceStatusWatcher(self._update_device_status))
 
@@ -586,10 +532,8 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
     def __init__(self, args: argparse.Namespace,
                  server: aiokatcp.DeviceServer,
                  image_resolver_factory: scheduler.ImageResolverFactory,
-                 prometheus_registry: CollectorRegistry = REGISTRY,
                  rewrite_gui_urls: Callable[[Sensor], bytes] = None) -> None:
-        super().__init__(args, server, image_resolver_factory,
-                         prometheus_registry, rewrite_gui_urls)
+        super().__init__(args, server, image_resolver_factory, rewrite_gui_urls)
         self._request_id_prefix = args.name + '_product_'
         self._task_cache: Dict[str, dict] = {}  # Maps Singularity Task IDs to their info
         # Task IDs that we didn't expect to see, but have been seen once.
@@ -1002,7 +946,6 @@ class DeviceServer(aiokatcp.DeviceServer):
     _interface_changed_callbacks: List[Callable[[], None]]
 
     def __init__(self, args: argparse.Namespace,
-                 prometheus_registry: CollectorRegistry = REGISTRY,
                  rewrite_gui_urls: Callable[[Sensor], bytes] = None) -> None:
         if args.no_pull or args.interface_mode:
             self._image_lookup = scheduler.SimpleImageLookup(args.registry)
@@ -1016,7 +959,6 @@ class DeviceServer(aiokatcp.DeviceServer):
         else:
             manager_cls = SingularityProductManager
         self._manager = manager_cls(args, self, image_resolver_factory,
-                                    prometheus_registry,
                                     rewrite_gui_urls if args.haproxy else None)
         self._consul_url = args.consul_url
         self._override_dicts = {}

--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -5,8 +5,10 @@ import logging
 import json
 import time
 import os
+import re
 import copy
 import uuid
+import functools
 from ipaddress import IPv4Address
 from typing import Dict, Set, List, Callable, Sequence, Optional, Type, Mapping
 
@@ -16,10 +18,11 @@ import networkx
 import aiohttp
 import aiokatcp
 from aiokatcp import FailReply, Sensor, Address
+from prometheus_client import Gauge, Counter, Histogram, CollectorRegistry, REGISTRY
 import katsdptelstate
 
 import katsdpcontroller
-from . import scheduler, product_config, generator, tasks
+from . import scheduler, product_config, generator, tasks, sensor_proxy
 from .controller import (load_json_dict, log_task_exceptions,
                          DeviceStatus, device_status_to_sensor_status, ProductState)
 from .tasks import CaptureBlockState, KatcpTransition, DEPENDS_INIT
@@ -28,6 +31,9 @@ from .tasks import CaptureBlockState, KatcpTransition, DEPENDS_INIT
 BATCH_PRIORITY = 1        #: Scheduler priority for batch queues
 BATCH_RESOURCES_TIMEOUT = 7 * 86400   # A week
 CONSUL_URL = 'http://localhost:8500'
+_HINT_RE = re.compile(r'\bprometheus: *(?P<type>[a-z]+)(?:\((?P<args>[^)]*)\)|\b)'
+                      r'(?: +labels: *(?P<labels>[a-z,]+))?',
+                      re.IGNORECASE)
 logger = logging.getLogger(__name__)
 
 
@@ -74,6 +80,50 @@ def _redact_keys(taskinfo: addict.Dict, s3_config: dict) -> addict.Dict:
         taskinfo.command.arguments = [_redact_arg(arg, s3_config)
                                       for arg in taskinfo.command.arguments]
     return taskinfo
+
+
+def _prometheus_factory(registry: CollectorRegistry,
+                        sensor: aiokatcp.Sensor) -> Optional[sensor_proxy.PrometheusInfo]:
+    assert sensor.description is not None
+    match = _HINT_RE.search(sensor.description)
+    if not match:
+        return None
+    type_ = match.group('type').lower()
+    args_ = match.group('args')
+    if type_ == 'counter':
+        class_ = Counter
+        if args_ is not None:
+            logger.warning('Arguments are not supported for counters (%s)', sensor.name)
+    elif type_ == 'gauge':
+        class_ = Gauge
+        if args_ is not None:
+            logger.warning('Arguments are not supported for gauges (%s)', sensor.name)
+    elif type_ == 'histogram':
+        class_ = Histogram
+        if args_ is not None:
+            try:
+                buckets = [float(x.strip()) for x in args_.split(',')]
+                class_ = functools.partial(Histogram, buckets=buckets)
+            except ValueError as exc:
+                logger.warning('Could not parse histogram buckets (%s): %s', sensor.name, exc)
+    else:
+        logger.warning('Ignoring unknown Prometheus metric type %s for %s', type_, sensor.name)
+        return None
+    parts = sensor.name.rsplit('.')
+    base = parts.pop()
+    label_names = (match.group('labels') or '').split(',')
+    label_names = [label for label in label_names if label]    # ''.split(',') is [''], want []
+    if len(parts) < len(label_names):
+        logger.warning('Not enough parts in name %s for labels %s', sensor.name, label_names)
+        return None
+    service_parts = len(parts) - len(label_names)
+    service = '.'.join(parts[:service_parts])
+    labels = dict(zip(label_names, parts[service_parts:]))
+    if service:
+        labels['service'] = service
+    normalised_name = 'katsdpcontroller_' + base.replace('-', '_')
+    return sensor_proxy.PrometheusInfo(class_, normalised_name, sensor.description,
+                                       labels, registry)
 
 
 class KatcpImageLookup(scheduler.ImageLookup):
@@ -1107,7 +1157,8 @@ class DeviceServer(aiokatcp.DeviceServer):
                  image_resolver_factory: scheduler.ImageResolverFactory,
                  s3_config: dict,
                  graph_dir: str = None,
-                 dashboard_url: str = None) -> None:
+                 dashboard_url: str = None,
+                 prometheus_registry: CollectorRegistry = REGISTRY) -> None:
         self.sched = sched
         self.subarray_product_id = subarray_product_id
         self.batch_role = batch_role
@@ -1136,6 +1187,9 @@ class DeviceServer(aiokatcp.DeviceServer):
         self.sensors.add(Sensor(str, 'gui-urls', 'URLs for product-wide GUIs',
                                 default=json.dumps(gui_urls),
                                 initial_status=Sensor.Status.NOMINAL))
+        self._prometheus_watcher = sensor_proxy.PrometheusWatcher(
+            self.sensors, {'subarray_product_id': subarray_product_id},
+            functools.partial(_prometheus_factory, prometheus_registry))
         if sched is not None:
             task_stats = sched.task_stats
             if isinstance(task_stats, TaskStats):
@@ -1201,6 +1255,7 @@ class DeviceServer(aiokatcp.DeviceServer):
 
     async def on_stop(self) -> None:
         await self._consul_deregister()
+        self._prometheus_watcher.close()
         if self.product is not None and self.product.state != ProductState.DEAD:
             logger.warning('Product controller interrupted - deconfiguring running product')
             try:

--- a/katsdpcontroller/sensor_proxy.py
+++ b/katsdpcontroller/sensor_proxy.py
@@ -323,4 +323,7 @@ class PrometheusWatcher:
             self.sensors.remove_remove_callback(self._removed)
         except ValueError:
             pass
-        self.sensors.remove_add_callback(self._added)
+        try:
+            self.sensors.remove_add_callback(self._added)
+        except ValueError:
+            pass

--- a/katsdpcontroller/sensor_proxy.py
+++ b/katsdpcontroller/sensor_proxy.py
@@ -14,10 +14,10 @@ _Metric = Union[Gauge, Counter, Histogram]
 # Use a string so that code won't completely break if Prometheus internals change.
 # The Union is required because mypy doesn't like pure strings being used indirectly.
 _LabelWrapper = Union['prometheus_client.core._LabelWrapper']
-_Factory = Callable[[str, aiokatcp.Sensor], Optional['PrometheusInfo']]
+_Factory = Callable[[aiokatcp.Sensor], Optional['PrometheusInfo']]
 
 
-def _dummy_factory(name: str, sensor: aiokatcp.Sensor) -> None:
+def _dummy_factory(sensor: aiokatcp.Sensor) -> None:
     return None
 
 
@@ -32,6 +32,116 @@ def _reading_to_float(reading: aiokatcp.Reading) -> float:
         return float(idx)
     else:
         return float(reading.value)
+
+
+class SensorWatcher(aiokatcp.SensorWatcher):
+    """Mirrors sensors from a client into a server.
+
+    See :class:`SensorProxyClient` for an explanation of the parameters.
+    """
+
+    def __init__(self, client: aiokatcp.Client, server: aiokatcp.DeviceServer,
+                 prefix: str,
+                 rewrite_gui_urls: Callable[[aiokatcp.Sensor], bytes] = None,
+                 enum_types: Sequence[Type[enum.Enum]] = ()) -> None:
+        super().__init__(client, enum_types)
+        self.prefix = prefix
+        self.server = server
+        # We keep track of the sensors after name rewriting but prior to gui-url rewriting
+        self.orig_sensors: aiokatcp.SensorSet
+        try:
+            self.orig_sensors = self.server.orig_sensors  # type: ignore
+        except AttributeError:
+            self.orig_sensors = aiokatcp.SensorSet()
+
+        self.rewrite_gui_urls = rewrite_gui_urls
+        # Whether we need to do an interface-changed at the end of the batch
+        self._interface_changed = False
+
+    def rewrite_name(self, name: str) -> str:
+        return self.prefix + name
+
+    def sensor_added(self, name: str, description: str, units: str, type_name: str,
+                     *args: bytes) -> None:
+        """Add a new or replaced sensor with unqualified name `name`."""
+        super().sensor_added(name, description, units, type_name, *args)
+        sensor = self.sensors[self.rewrite_name(name)]
+        self.orig_sensors.add(sensor)
+        if (self.rewrite_gui_urls is not None
+                and sensor.name.endswith('.gui-urls') and sensor.stype is bytes):
+            new_value = self.rewrite_gui_urls(sensor)
+            sensor = aiokatcp.Sensor(sensor.stype, sensor.name, sensor.description,
+                                     sensor.units, new_value, sensor.status)
+        self.server.sensors.add(sensor)
+        self._interface_changed = True
+
+    def _sensor_removed(self, name: str) -> None:
+        """Like :meth:`sensor_removed`, but takes the prefixed name"""
+        self.server.sensors.pop(name, None)
+        self.orig_sensors.pop(name, None)
+        self._interface_changed = True
+
+    def sensor_removed(self, name: str) -> None:
+        super().sensor_removed(name)
+        rewritten = self.rewrite_name(name)
+        self._sensor_removed(rewritten)
+
+    def sensor_updated(self, name: str, value: bytes, status: aiokatcp.Sensor.Status,
+                       timestamp: float) -> None:
+        super().sensor_updated(name, value, status, timestamp)
+        rewritten_name = self.rewrite_name(name)
+        sensor = self.sensors[rewritten_name]
+        if (self.rewrite_gui_urls is not None
+                and rewritten_name.endswith('.gui-urls') and sensor.stype is bytes):
+            value = self.rewrite_gui_urls(sensor)
+            self.server.sensors[rewritten_name].set_value(value, status, timestamp)
+
+    def batch_stop(self) -> None:
+        super().batch_stop()
+        if self._interface_changed:
+            self.server.mass_inform('interface-changed', 'sensor-list')
+        self._interface_changed = False
+
+    def state_updated(self, state: aiokatcp.SyncState) -> None:
+        super().state_updated(state)
+        # TODO: move this into aiokatcp itself?
+        if state == aiokatcp.SyncState.CLOSED:
+            self.batch_start()
+            for name in self.sensors.keys():
+                self._sensor_removed(name)
+            self.batch_stop()
+
+
+class SensorProxyClient(aiokatcp.Client):
+    """Client that mirrors sensors into a device server.
+
+    Parameters
+    ----------
+    server
+        Server to which sensors will be added
+    prefix
+        String prepended to the remote server's sensor names to obtain names
+        used on `server`. These should be unique per `server` to avoid
+        collisions.
+    rewrite_gui_urls
+        If given, a function that is given a ``.gui-urls`` sensor and returns a
+        replacement value. Note that the function is responsible for decoding
+        and encoding between JSON and :class:`bytes`.
+    args, kwargs
+        Passed to the base class
+    """
+
+    def __init__(self, server: aiokatcp.DeviceServer, prefix: str,
+                 rewrite_gui_urls: Callable[[aiokatcp.Sensor], bytes] = None,
+                 enum_types: Sequence[Type[enum.Enum]] = (),
+                 **kwargs) -> None:
+        super().__init__(**kwargs)
+        watcher = SensorWatcher(self, server, prefix, rewrite_gui_urls)
+        self._synced = watcher.synced
+        self.add_sensor_watcher(watcher)
+
+    async def wait_synced(self) -> None:
+        await self._synced.wait()
 
 
 class PrometheusInfo:
@@ -49,7 +159,7 @@ class PrometheusInfo:
         Labels to combine with `name` to produce the series.
     """
 
-    def __init__(self, class_: Callable[..., 'prometheus_client.core._LabelWrapper'],
+    def __init__(self, class_: Callable[..., _LabelWrapper],
                  name: str, description: str,
                  labels: Mapping[str, str],
                  registry: CollectorRegistry = prometheus_client.REGISTRY) -> None:
@@ -61,7 +171,8 @@ class PrometheusInfo:
 
 
 class PrometheusObserver:
-    """Watches a sensor and mirrors updates into a Prometheus Gauge, Counter or Histogram"""
+    """Watches a sensor and mirrors updates into a Prometheus Gauge, Counter or Histogram."""
+
     def __init__(self, sensor: aiokatcp.Sensor,
                  value_metric: _LabelWrapper,
                  status_metric: _LabelWrapper,
@@ -117,175 +228,99 @@ class PrometheusObserver:
         self._value_metric_root.remove(*self._label_values)
 
 
-class SensorWatcher(aiokatcp.SensorWatcher):
-    """Mirrors sensors from a client into a server and optionally Prometheus.
+class PrometheusWatcher:
+    """Mirror sensors from a :class:`aiokatcp.SensorSet` into Prometheus metrics.
 
-    See :class:`SensorProxyClient` for an explanation of the parameters.
-    """
-
-    # Caches metrics by name. Each entry stores the primary metric
-    # and the status metric.
-    prometheus_sensors: Dict[str, Tuple[_LabelWrapper, _LabelWrapper]] = {}
-
-    def __init__(self, client: aiokatcp.Client, server: aiokatcp.DeviceServer,
-                 prefix: str,
-                 prometheus_labels: Mapping[str, str] = None,
-                 prometheus_factory: _Factory = None,
-                 prometheus_sensors: Dict[str, Tuple[_LabelWrapper, _LabelWrapper]] = None,
-                 rewrite_gui_urls: Callable[[aiokatcp.Sensor], bytes] = None,
-                 enum_types: Sequence[Type[enum.Enum]] = ()) -> None:
-        super().__init__(client, enum_types)
-        self.prefix = prefix
-        self.server = server
-        # We keep track of the sensors after name rewriting but prior to gui-url rewriting
-        self.orig_sensors: aiokatcp.SensorSet
-        try:
-            self.orig_sensors = self.server.orig_sensors  # type: ignore
-        except AttributeError:
-            self.orig_sensors = aiokatcp.SensorSet()
-
-        self.rewrite_gui_urls = rewrite_gui_urls
-        if prometheus_labels is not None:
-            self.prometheus_labels = prometheus_labels
-        else:
-            self.prometheus_labels = {}
-        if prometheus_factory is not None:
-            self.prometheus_factory = prometheus_factory
-        else:
-            self.prometheus_factory = _dummy_factory
-        if prometheus_sensors is not None:
-            self.prometheus_sensors = prometheus_sensors
-        # Indexed by rewritten sensor name; None if no observer is needed.
-        # Invariant: _observers has an entry if and only if the corresponding
-        # sensor exists in self.server.sensors
-        self._observers: Dict[str, Optional[PrometheusObserver]] = {}
-        # Whether we need to do an interface-changed at the end of the batch
-        self._interface_changed = False
-
-    def rewrite_name(self, name: str) -> str:
-        return self.prefix + name
-
-    def _make_observer(self, name: str, sensor: aiokatcp.Sensor) -> Optional[PrometheusObserver]:
-        """Make a :class:`PrometheusObserver` for client sensor `name`, if appropriate.
-        Otherwise returns ``None``.
-        """
-        info = self.prometheus_factory(name, sensor)
-        if info is None:
-            return None
-        try:
-            value_metric, status_metric = self.prometheus_sensors[info.name]
-        except KeyError:
-            label_names = list(self.prometheus_labels.keys()) + list(info.labels.keys())
-            value_metric = info.class_(info.name, info.description, label_names,
-                                       registry=info.registry)
-            status_metric = Gauge(info.name + '_status', f'Status of katcp sensor {info.name}',
-                                  label_names, registry=info.registry)
-            self.prometheus_sensors[info.name] = (value_metric, status_metric)
-
-        label_values = list(self.prometheus_labels.values()) + list(info.labels.values())
-        return PrometheusObserver(sensor, value_metric, status_metric, label_values)
-
-    def sensor_added(self, name: str, description: str, units: str, type_name: str,
-                     *args: bytes) -> None:
-        """Add a new or replaced sensor with unqualified name `name`."""
-        super().sensor_added(name, description, units, type_name, *args)
-        sensor = self.sensors[self.rewrite_name(name)]
-        self.orig_sensors.add(sensor)
-        if (self.rewrite_gui_urls is not None
-                and sensor.name.endswith('.gui-urls') and sensor.stype is bytes):
-            new_value = self.rewrite_gui_urls(sensor)
-            sensor = aiokatcp.Sensor(sensor.stype, sensor.name, sensor.description,
-                                     sensor.units, new_value, sensor.status)
-        self.server.sensors.add(sensor)
-        old_observer = self._observers.get(sensor.name)
-        if old_observer is not None:
-            old_observer.close()
-        self._observers[sensor.name] = self._make_observer(name, sensor)
-        self._interface_changed = True
-
-    def _sensor_removed(self, name: str) -> None:
-        """Like :meth:`sensor_removed`, but takes the prefixed name"""
-        self.server.sensors.pop(name, None)
-        self.orig_sensors.pop(name, None)
-        observer = self._observers.pop(name, None)
-        if observer is not None:
-            observer.close()
-        self._interface_changed = True
-
-    def sensor_removed(self, name: str) -> None:
-        super().sensor_removed(name)
-        rewritten = self.rewrite_name(name)
-        self._sensor_removed(rewritten)
-
-    def sensor_updated(self, name: str, value: bytes, status: aiokatcp.Sensor.Status,
-                       timestamp: float) -> None:
-        super().sensor_updated(name, value, status, timestamp)
-        rewritten_name = self.rewrite_name(name)
-        sensor = self.sensors[rewritten_name]
-        if (self.rewrite_gui_urls is not None
-                and rewritten_name.endswith('.gui-urls') and sensor.stype is bytes):
-            value = self.rewrite_gui_urls(sensor)
-            self.server.sensors[rewritten_name].set_value(value, status, timestamp)
-
-    def batch_stop(self) -> None:
-        super().batch_stop()
-        if self._interface_changed:
-            self.server.mass_inform('interface-changed', 'sensor-list')
-        self._interface_changed = False
-
-    def state_updated(self, state: aiokatcp.SyncState) -> None:
-        super().state_updated(state)
-        # TODO: move this into aiokatcp itself?
-        if state == aiokatcp.SyncState.CLOSED:
-            self.batch_start()
-            for name in self.sensors.keys():
-                self._sensor_removed(name)
-            self.batch_stop()
-
-
-class SensorProxyClient(aiokatcp.Client):
-    """Client that mirrors sensors into a device server and Prometheus gauges.
+    It automatically deals with additions and removals of sensors from the
+    sensor set.
 
     Parameters
     ----------
-    server
-        Server to which sensors will be added
-    prefix
-        String prepended to the remote server's sensor names to obtain names
-        used on `server`. These should be unique per `server` to avoid
-        collisions.
-    prometheus_labels
+    sensors
+        Sensors to monitor.
+    labels
         Extra labels to apply to every sensor.
-    prometheus_factory
+    factory
         Extracts information to create the Prometheus series from a sensor.
         It may return ``None`` to skip generating a Prometheus series for that
         sensor. This argument may also be ``None`` to skip creating any
         Prometheus metrics.
-    prometheus_sensors
+    metrics
         Store for Prometheus metrics. If not provided, generated sensors are
         stored in a class-level variable. This is mainly intended to allow
         tests to be isolated from global state.
-    rewrite_gui_urls
-        If given, a function that is given a ``.gui-urls`` sensor and returns a
-        replacement value. Note that the function is responsible for decoding
-        and encoding between JSON and :class:`bytes`.
-    args, kwargs
-        Passed to the base class
     """
 
-    def __init__(self, server: aiokatcp.DeviceServer, prefix: str,
-                 prometheus_labels: Mapping[str, str] = None,
-                 prometheus_factory: _Factory = None,
-                 prometheus_sensors: Dict[str, Tuple[_LabelWrapper, _LabelWrapper]] = None,
-                 rewrite_gui_urls: Callable[[aiokatcp.Sensor], bytes] = None,
-                 enum_types: Sequence[Type[enum.Enum]] = (),
-                 **kwargs) -> None:
-        super().__init__(**kwargs)
-        watcher = SensorWatcher(self, server, prefix,
-                                prometheus_labels, prometheus_factory, prometheus_sensors,
-                                rewrite_gui_urls)
-        self._synced = watcher.synced
-        self.add_sensor_watcher(watcher)
+    # Caches metrics by name. Each entry stores the primary metric
+    # and the status metric.
+    _metrics: Dict[str, Tuple[_LabelWrapper, _LabelWrapper]] = {}
 
-    async def wait_synced(self) -> None:
-        await self._synced.wait()
+    def __init__(self, sensors: aiokatcp.SensorSet,
+                 labels: Mapping[str, str] = None,
+                 factory: _Factory = None,
+                 metrics: Dict[str, Tuple[_LabelWrapper, _LabelWrapper]] = None) -> None:
+        self.sensors = sensors
+        # Indexed by sensor name; None if no observer is needed.
+        # Invariant: _observers has an entry if and only if the corresponding
+        # sensor exists in self.sensors (except after `close`).
+        self._observers: Dict[str, Optional[PrometheusObserver]] = {}
+        if labels is not None:
+            self._labels = labels
+        else:
+            self._labels = {}
+        if factory is not None:
+            self._factory = factory
+        else:
+            self._factory = _dummy_factory
+        if metrics is not None:
+            self._metrics = metrics
+        for sensor in self.sensors.values():
+            self._added(sensor)
+        self.sensors.add_add_callback(self._added)
+        self.sensors.add_remove_callback(self._removed)
+
+    def _make_observer(self, sensor: aiokatcp.Sensor) -> Optional[PrometheusObserver]:
+        """Make a :class:`PrometheusObserver` for sensor `sensor`, if appropriate.
+
+        Otherwise returns ``None``.
+        """
+        info = self._factory(sensor)
+        if info is None:
+            return None
+        try:
+            value_metric, status_metric = self._metrics[info.name]
+        except KeyError:
+            label_names = list(self._labels.keys()) + list(info.labels.keys())
+            value_metric = info.class_(info.name, info.description, label_names,
+                                       registry=info.registry)
+            status_metric = Gauge(info.name + '_status', f'Status of katcp sensor {info.name}',
+                                  label_names, registry=info.registry)
+            self._metrics[info.name] = (value_metric, status_metric)
+
+        label_values = list(self._labels.values()) + list(info.labels.values())
+        observer = PrometheusObserver(sensor, value_metric, status_metric, label_values)
+        # Populate initial value
+        observer(sensor, sensor.reading)
+        return observer
+
+    def _added(self, sensor: aiokatcp.Sensor) -> None:
+        old_observer = self._observers.get(sensor.name)
+        if old_observer is not None:
+            old_observer.close()
+        self._observers[sensor.name] = self._make_observer(sensor)
+
+    def _removed(self, sensor: aiokatcp.Sensor) -> None:
+        old_observer = self._observers.pop(sensor.name, None)
+        if old_observer is not None:
+            old_observer.close()
+
+    def close(self) -> None:
+        for observer in self._observers.values():
+            if observer is not None:
+                observer.close()
+        self._observers = {}
+        try:
+            self.sensors.remove_remove_callback(self._removed)
+        except ValueError:
+            pass
+        self.sensors.remove_add_callback(self._added)

--- a/katsdpcontroller/test/test_product_controller.py
+++ b/katsdpcontroller/test/test_product_controller.py
@@ -8,6 +8,7 @@ import asyncio
 # Needs to be imported this way so that it is unaffected by mocking of socket.getaddrinfo
 from socket import getaddrinfo
 import ipaddress
+from urllib.parse import urljoin
 import typing
 from typing import List, Tuple, Set, Callable, Sequence, Mapping, Any, Optional
 
@@ -29,7 +30,7 @@ import katpoint
 from ..controller import device_server_sockname
 from ..product_controller import (
     DeviceServer, SDPSubarrayProductBase, SDPSubarrayProduct, SDPResources,
-    ProductState, DeviceStatus, _redact_keys)
+    ProductState, DeviceStatus, _redact_keys, CONSUL_URL)
 from .. import scheduler
 from . import fake_katportalclient
 from .utils import (create_patch, assert_request_fails, assert_sensors, DelayedManager,
@@ -186,7 +187,7 @@ class BaseTestSDPController(asynctest.TestCase):
         # server.start will try to register with consul. Mock that out, and make sure it
         # fails (which will prevent it from trying to deregister on stop).
         with aioresponses() as m:
-            m.put('http://localhost:8500/v1/agent/service/register?replace-existing-checks=1',
+            m.put(urljoin(CONSUL_URL, '/v1/agent/service/register?replace-existing-checks=1'),
                   status=500)
             await self.server.start()
         self.addCleanup(self.server.stop)

--- a/katsdpcontroller/web.py
+++ b/katsdpcontroller/web.py
@@ -24,7 +24,6 @@ import shutil
 from typing import Dict, List, Set, Tuple, Optional
 
 import pkg_resources
-import prometheus_async
 from aiokatcp import Sensor, Reading
 import yarl
 from aiohttp import web, WSMsgType
@@ -36,14 +35,6 @@ from . import master_controller, web_utils
 
 logger = logging.getLogger(__name__)
 GUI_URLS_RE = re.compile(r'^(?P<product>[^.]+)(?:\.(?P<service>.*))?\.gui-urls$')
-
-
-async def _prometheus_handler(request: web.Request) -> web.Response:
-    response = await prometheus_async.aio.web.server_stats(request)
-    if response.status == 200:
-        # Avoid spamming logs (feeds into web_utils.AccessLogger).
-        response['log_level'] = logging.DEBUG
-    return response
 
 
 def _dump_yarl(obj: object) -> str:
@@ -349,7 +340,7 @@ def make_app(server: master_controller.DeviceServer,
     app.add_routes([
         web.get('/', _index_handler),
         web.get('/favicon.ico', _favicon_handler),
-        web.get('/metrics', _prometheus_handler),
+        web.get('/metrics', web_utils.prometheus_handler),
         web.get('/ws', _websocket_handler),
         web.get('/rotate', _rotate_handler),
         web.post('/gui/{product}/{path:.*}/_dash-update-component', _block_dashboard),

--- a/sandbox/etc/prometheus/prometheus.yml
+++ b/sandbox/etc/prometheus/prometheus.yml
@@ -9,3 +9,14 @@ scrape_configs:
     static_configs:
       - targets:
         - "127.0.0.1:5004"
+  - job_name: 'product_controller'
+    consul_sd_configs:
+      - refresh_interval: 5s
+    relabel_configs:
+      - source_labels: [__meta_consul_service]
+        regex: product-controller
+        action: keep
+      - source_labels: [__meta_consul_service_metadata_subarray_product_id]
+        target_label: subarray_product_id
+      - source_labels: [__meta_consul_service_metadata_subarray_product_id]
+        target_label: instance

--- a/scripts/sdp_product_controller.py
+++ b/scripts/sdp_product_controller.py
@@ -169,6 +169,8 @@ def main() -> None:
         sched = scheduler.Scheduler(args.realtime_role, args.host, args.http_port, args.http_url,
                                     task_stats=product_controller.TaskStats(),
                                     runner_kwargs=dict(access_log_class=web_utils.AccessLogger))
+        sched.app.router.add_get('/metrics', web_utils.prometheus_handler)
+        sched.app.router.add_get('/health', web_utils.health_handler)
         driver = pymesos.MesosSchedulerDriver(
             sched, framework_info, args.mesos_master, use_addict=True,
             implicit_acknowledgements=False)
@@ -182,7 +184,7 @@ def main() -> None:
                                            port=args.dashboard_port, path=dashboard_path))
 
     server = product_controller.DeviceServer(
-        args.host, args.port, master_controller, sched,
+        args.host, args.port, master_controller, args.subarray_product_id, sched,
         batch_role=args.batch_role,
         interface_mode=args.interface_mode,
         localhost=args.localhost,


### PR DESCRIPTION
This implements SPR1-320. Refer to individual commits for more details. This should not be merged until Prometheus on site has been updated to do scraping/label rewriting for product controllers.

Note that a fair amount of code that been moved and refactored - big blocks of added lines have generally come from somewhere else.