### PR TITLE
Add separate 'postprocessing' state

### DIFF
--- a/katsdpcontroller/controller.py
+++ b/katsdpcontroller/controller.py
@@ -130,7 +130,8 @@ class ProductState(scheduler.OrderedEnum):
     - CONFIGURING -> IDLE (via product-configure)
     - IDLE -> CAPTURING (via capture-init)
     - CAPTURING -> IDLE (via capture-done)
-    - CONFIGURING/IDLE/CAPTURING/ERROR -> DECONFIGURING -> POSTPROCESSING -> DEAD (via product-deconfigure)
+    - CONFIGURING/IDLE/CAPTURING/ERROR -> DECONFIGURING -> POSTPROCESSING -> DEAD
+      (via product-deconfigure)
     - IDLE/CAPTURING/DECONFIGURING/POSTPROCESSING -> ERROR (via an internal error)
     """
     CONFIGURING = 0

--- a/katsdpcontroller/controller.py
+++ b/katsdpcontroller/controller.py
@@ -130,8 +130,8 @@ class ProductState(scheduler.OrderedEnum):
     - CONFIGURING -> IDLE (via product-configure)
     - IDLE -> CAPTURING (via capture-init)
     - CAPTURING -> IDLE (via capture-done)
-    - CONFIGURING/IDLE/CAPTURING/ERROR -> DECONFIGURING -> DEAD (via product-deconfigure)
-    - IDLE/CAPTURING/DECONFIGURING -> ERROR (via an internal error)
+    - CONFIGURING/IDLE/CAPTURING/ERROR -> DECONFIGURING -> POSTPROCESSING -> DEAD (via product-deconfigure)
+    - IDLE/CAPTURING/DECONFIGURING/POSTPROCESSING -> ERROR (via an internal error)
     """
     CONFIGURING = 0
     IDLE = 1
@@ -139,6 +139,7 @@ class ProductState(scheduler.OrderedEnum):
     DECONFIGURING = 3
     DEAD = 4
     ERROR = 5
+    POSTPROCESSING = 6
 
 
 class DeviceStatus(scheduler.OrderedEnum):

--- a/katsdpcontroller/master_controller.py
+++ b/katsdpcontroller/master_controller.py
@@ -993,7 +993,7 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
 class DeviceServer(aiokatcp.DeviceServer):
     """katcp server around a :class:`ProductManagerBase`."""
 
-    VERSION = "sdpcontroller-3.2"
+    VERSION = "sdpcontroller-3.3"
     BUILD_STATE = "katsdpcontroller-" + katsdpcontroller.__version__
 
     _manager: ProductManagerBase

--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -1025,8 +1025,8 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
 
         # We don't go to error state from CONFIGURING because we check all
         # nodes at the end of configuration and will fail the configure
-        # there; and from DECONFIGURING we don't want to go to ERROR because
-        # that may prevent deconfiguring.
+        # there; and from DECONFIGURING/POSTPROCESSING we don't want to go to
+        # ERROR because that may prevent deconfiguring.
         if self.state in (ProductState.IDLE, ProductState.CAPTURING):
             self.state = ProductState.ERROR
 
@@ -1087,12 +1087,13 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
             wait_tasks = [node.dead_event.wait() for node in self.physical_graph if must_wait(node)]
             shutdown_task = asyncio.get_event_loop().create_task(self._shutdown(force=force))
             await asyncio.gather(*wait_tasks)
+            self.state = ProductState.POSTPROCESSING
             ready.set()
             await shutdown_task
 
 
 class DeviceServer(aiokatcp.DeviceServer):
-    VERSION = 'product-controller-1.0'
+    VERSION = 'product-controller-1.1'
     BUILD_STATE = "katsdpcontroller-" + katsdpcontroller.__version__
 
     def __init__(self, host: str, port: int, master_controller: aiokatcp.Client,

--- a/katsdpcontroller/test/utils.py
+++ b/katsdpcontroller/test/utils.py
@@ -201,7 +201,7 @@ EXPECTED_INTERFACE_SENSOR_LIST: List[Tuple[bytes, ...]] = [
     (b'timeplot.sdp_l0.1.html_port', b'', b'address'),
     (b'cal.1.capture-block-state', b'', b'string'),
     (b'state', b'', b'discrete',
-     b'configuring', b'idle', b'capturing', b'deconfiguring', b'dead', b'error'),
+     b'configuring', b'idle', b'capturing', b'deconfiguring', b'dead', b'error', b'postprocessing'),
     (b'capture-block-state', b'', b'string')
 ]
 


### PR DESCRIPTION
Subarray products now go into 'deconfiguring' when ?product-deconfigure
is called, and into 'postprocessing' when it returns (indicating the
realtime processes including cam2telstate have been killed). From CAM's
point of view, 'postprocessing' subarray products are no longer CAM's
problem and have no effect other than on resources.

This should help with detecting things like
(a) CAM configuring a new subarray before properly deconfiguring the
old one.
(b) SDP gets jammed up in the 'deconfiguring' state, versus just ticking
along in 'postprocessing' state.

In future we could also use it to do things like refuse to build a new
subarray product with the same name wildcard as an existing one (other
than those in 'postprocessing') and CAM could use it to do
reconciliation with its internal state.

I've bumped the device server minor versions, but this will still need
an ECP to update the ICD.