### PR TITLE
Implement Mesos task reconciliation

### DIFF
--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -1951,8 +1951,9 @@ class PhysicalTask(PhysicalNode):
         self.taskinfo = None
         self.allocation = None
         self.status = None
-        self.start_time = None
-        self.end_time = None
+        self.start_time = None         # time.time()
+        self.end_time = None           # time.time()
+        self.kill_sent_time = None     # loop.time() when killTask called
         self._queue = None
         self.task_stats = None
         for name, cls in GLOBAL_RESOURCES.items():
@@ -2162,6 +2163,7 @@ class PhysicalTask(PhysicalNode):
         # and may need to be attempted again.
         # The poller is stopped by set_state, so we do not need to do it here.
         driver.killTask(self.taskinfo.task_id)
+        self.kill_sent_time = asyncio.get_event_loop().time()
         super().kill(driver, **kwargs)
 
     @property
@@ -2436,6 +2438,12 @@ class Scheduler(pymesos.Scheduler):
     task_stats : :class:`TaskStats`
         Statistics collector passed to constructor
     """
+
+    # If offers come at 5s intervals, then 11s gives two chances.
+    resources_timeout = 11.0         #: Time to wait for sufficient resources to be offered
+    reconciliation_interval = 30.0   #: Time to wait between reconciliation requests
+    kill_timeout = 5.0               #: Minimum time before trying to re-kill a task
+
     def __init__(self, default_role, http_host, http_port, http_url=None,
                  *, task_stats=None, runner_kwargs=None):
         self._loop = asyncio.get_event_loop()
@@ -2450,13 +2458,12 @@ class Scheduler(pymesos.Scheduler):
         #: (task, graph) for tasks that have been launched (STARTED to KILLING), indexed by task ID
         self._active = {}
         self._closing = False       #: set to ``True`` when :meth:`close` is called
-        # If offers come at 5s intervals, then 11s gives two chances.
-        self.resources_timeout = 11.0   #: Time to wait for sufficient resources to be offered
         self.http_host = http_host
         self.http_port = http_port
         self.http_url = http_url
         self.task_stats = task_stats if task_stats is not None else TaskStats()
         self._launcher_task = self._loop.create_task(self._launcher())
+        self._reconciliation_task = self._loop.create_task(self._reconciliation())
 
         # Configure the web app
         app = aiohttp.web.Application()
@@ -2640,6 +2647,18 @@ class Scheduler(pymesos.Scheduler):
                     # The task itself is responsible for advancing to
                     # READY
             task.set_status(status)
+            if (task.kill_sent_time is not None
+                    and status.state != 'TASK_KILLING'
+                    and status.state not in TERMINAL_STATUSES
+                    and self._loop.time() > task.kill_sent_time + self.kill_timeout):
+                logger.warning('Retrying kill on %s (task ID %s)',
+                               task.name, status.task_id.value)
+                self._driver.killTask(status.task_id)
+        else:
+            if status.state not in TERMINAL_STATUSES:
+                logger.warning('Received status update for unknown task %s, killing it',
+                               status.task_id.value)
+                self._driver.killTask(status.task_id)
         self._driver.acknowledgeStatusUpdate(status)
 
     @classmethod
@@ -3278,6 +3297,34 @@ class Scheduler(pymesos.Scheduler):
             futures.append(asyncio.ensure_future(kill_one(node, kill_graph)))
         await asyncio.gather(*futures)
 
+    async def _reconciliation(self) -> None:
+        """Background task that periodically requests reconciliation.
+
+        See http://mesos.apache.org/documentation/latest/reconciliation/ for
+        a description of reconciliation.
+
+        We don't use the (somewhat complex) algorithm described there, instead
+        just periodically requesting either implicit or explicit
+        reconciliation (the former is useful to learn about tasks we thought
+        were dead, the latter to learn about tasks we thought were alive but
+        have been lost). This means that it may take somewhat longer to
+        converge.
+        """
+        explicit = True
+        while True:
+            try:
+                if explicit:
+                    tasks = [{'task_id': task_id} for task_id in self._active]
+                    logger.debug('Requesting explicit reconciliation of %d tasks', len(tasks))
+                else:
+                    tasks = []
+                    logger.debug('Requesting implicit reconciliation')
+                self._driver.reconcileTasks(tasks)
+            except Exception:
+                logger.warning('Exception during task reconciliation', exc_info=True)
+            await asyncio.sleep(self.reconciliation_interval)
+            explicit = not explicit
+
     async def close(self):
         """Shut down the scheduler. This is a coroutine that kills any graphs
         with running tasks or pending launches, and joins the driver thread. It
@@ -3290,6 +3337,13 @@ class Scheduler(pymesos.Scheduler):
             running will not be shut down. This is subject to change in the
             future.
         """
+        async def cleanup_task(task):
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
         # TODO: do we need to explicitly decline outstanding offers?
         self._closing = True    # Prevents concurrent launches
         await self.http_runner.cleanup()
@@ -3305,12 +3359,10 @@ class Scheduler(pymesos.Scheduler):
         for queue in self._queues:
             while queue:
                 queue.front().future.cancel()
-        self._launcher_task.cancel()
-        try:
-            await self._launcher_task
-        except asyncio.CancelledError:
-            pass
+        await cleanup_task(self._launcher_task)
         self._launcher_task = None
+        await cleanup_task(self._reconciliation_task)
+        self._reconciliation_task = None
         self._driver.stop()
         # If self._driver is a mock, then asyncio incorrectly complains about passing
         # self._driver.join directly, due to

--- a/katsdpcontroller/test/test_scheduler.py
+++ b/katsdpcontroller/test/test_scheduler.py
@@ -1204,6 +1204,10 @@ class TestScheduler(asynctest.ClockedTestCase):
     def _dummy_random():
         return 0.0
 
+    def _driver_calls(self):
+        """self.driver.mock_calls, with reconcileTasks filtered out."""
+        return [call for call in self.driver.mock_calls if call[0] != 'reconcileTasks']
+
     async def setUp(self):
         self.framework_id = 'frameworkid'
         # Normally TaskIDAllocator's constructor returns a singleton to keep
@@ -1297,7 +1301,7 @@ class TestScheduler(asynctest.ClockedTestCase):
             AnyOrderList([
                 mock.call.declineOffer(AnyOrderList([offers[0].id, offers[1].id, offers[2].id])),
                 mock.call.suppressOffers({'default'})
-            ]), self.driver.mock_calls)
+            ]), self._driver_calls())
 
     async def test_launch_cycle(self):
         """Launch raises CycleError if there is a cycle of depends_ready edges"""
@@ -1419,13 +1423,13 @@ class TestScheduler(asynctest.ClockedTestCase):
             assert_false(node.ready_event.is_set())
             assert_false(node.dead_event.is_set())
         assert_equal({TaskState.STARTING: 2}, self.task_stats.state_counts)
-        assert_equal([mock.call.reviveOffers({'default'})], self.driver.mock_calls)
+        assert_equal([mock.call.reviveOffers({'default'})], self._driver_calls())
         self.driver.reset_mock()
         # Now provide an offer that is suitable for node1 but not node0.
         # Nothing should happen, because we don't yet have enough resources.
         self.sched.resourceOffers(self.driver, [offer1])
         await asynctest.exhaust_callbacks(self.loop)
-        assert_equal([], self.driver.mock_calls)
+        assert_equal([], self._driver_calls())
         for node in self.nodes:
             assert_equal(TaskState.STARTING, node.state)
             assert_false(node.ready_event.is_set())
@@ -1453,7 +1457,7 @@ class TestScheduler(asynctest.ClockedTestCase):
             mock.call.launchTasks([offer0.id], [expected_taskinfo0]),
             mock.call.launchTasks([offer1.id], [expected_taskinfo1]),
             mock.call.suppressOffers({'default'})
-        ]), self.driver.mock_calls)
+        ]), self._driver_calls())
         self.driver.reset_mock()
         assert_equal({TaskState.STARTED: 2}, self.task_stats.state_counts)
 
@@ -1464,7 +1468,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         assert_equal(TaskState.RUNNING, self.nodes[1].state)
         assert_equal(status, self.nodes[1].status)
         assert_equal([mock.call.acknowledgeStatusUpdate(status)],
-                     self.driver.mock_calls)
+                     self._driver_calls())
         self.driver.reset_mock()
         assert_equal({TaskState.STARTED: 1, TaskState.RUNNING: 1}, self.task_stats.state_counts)
 
@@ -1484,7 +1488,7 @@ class TestScheduler(asynctest.ClockedTestCase):
             assert_equal(TaskState.RUNNING, self.nodes[0].state)
             assert_equal(status, self.nodes[0].status)
             assert_equal([mock.call.acknowledgeStatusUpdate(status)],
-                         self.driver.mock_calls)
+                         self._driver_calls())
             self.driver.reset_mock()
             poll_ports.assert_called_once_with('agenthost0', [30000])
         assert_equal({TaskState.RUNNING: 2}, self.task_stats.state_counts)
@@ -1644,7 +1648,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         assert_equal(TaskState.NOT_READY, self.nodes[1].state)
         assert_equal(TaskState.NOT_READY, self.nodes[2].state)
         # Once we abort, we should no longer be interested in offers
-        assert_equal([mock.call.suppressOffers({'default'})], self.driver.mock_calls)
+        assert_equal([mock.call.suppressOffers({'default'})], self._driver_calls())
 
     async def test_launch_force_host(self):
         """Like test_launch_serial, but tests forcing a logical task to a node."""
@@ -1681,7 +1685,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         # The offers must be returned to Mesos
         assert_equal(AnyOrderList([
             mock.call.declineOffer(AnyOrderList([offers[0].id, offers[1].id])),
-            mock.call.suppressOffers({'default'})]), self.driver.mock_calls)
+            mock.call.suppressOffers({'default'})]), self._driver_calls())
 
     async def test_offer_rescinded(self):
         """Test offerRescinded"""
@@ -1704,7 +1708,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         offer2 = self._make_offer({'cpus': 0.8, 'mem': 128.0, 'ports': [(31000, 32000)]}, 1)
         self.sched.offerRescinded(self.driver, offer2.id)
         await asynctest.exhaust_callbacks(self.loop)
-        assert_equal([], self.driver.mock_calls)
+        assert_equal([], self._driver_calls())
         launch.cancel()
 
     async def test_unavailability(self):
@@ -1717,7 +1721,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         self.sched.resourceOffers(self.driver, [offer0])
         await asynctest.exhaust_callbacks(self.loop)
         assert_equal(TaskState.STARTING, self.nodes[0].state)
-        assert_equal([mock.call.declineOffer([offer0.id])], self.driver.mock_calls)
+        assert_equal([mock.call.declineOffer([offer0.id])], self._driver_calls())
         launch.cancel()
 
     async def test_unavailability_past(self):
@@ -1733,7 +1737,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         assert_equal([
             mock.call.launchTasks([offer0.id], mock.ANY),
             mock.call.suppressOffers({'default'})
-        ], self.driver.mock_calls)
+        ], self._driver_calls())
         launch.cancel()
 
     async def _test_kill_in_state(self, state):
@@ -1801,7 +1805,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         kill = asyncio.ensure_future(self.sched.kill(self.physical_graph))
         await asynctest.exhaust_callbacks(self.loop)
         assert_equal([mock.call.killTask(self.nodes[1].taskinfo.task_id)],
-                     self.driver.mock_calls)
+                     self._driver_calls())
         assert_equal(TaskState.READY, self.nodes[0].state)
         assert_equal(TaskState.KILLING, self.nodes[1].state)
         assert_equal(TaskState.READY, self.nodes[2].state)
@@ -1814,7 +1818,7 @@ class TestScheduler(asynctest.ClockedTestCase):
                 mock.call.killTask(self.nodes[0].taskinfo.task_id),
                 mock.call.acknowledgeStatusUpdate(status)
             ]),
-            self.driver.mock_calls)
+            self._driver_calls())
         assert_equal(TaskState.KILLING, self.nodes[0].state)
         assert_equal(TaskState.DEAD, self.nodes[1].state)
         assert_equal(TaskState.DEAD, self.nodes[2].state)
@@ -1988,10 +1992,11 @@ class TestScheduler(asynctest.ClockedTestCase):
         # The timing of suppressOffers is undefined, because it depends on the
         # order in which the graphs are killed. However, it must occur
         # after the initial reviveOffers and before stopping the driver.
-        assert_in(mock.call.suppressOffers({'default'}), self.driver.mock_calls)
-        pos = self.driver.mock_calls.index(mock.call.suppressOffers({'default'}))
-        assert_true(1 <= pos < len(self.driver.mock_calls) - 2)
-        del self.driver.mock_calls[pos]
+        driver_calls = self._driver_calls()
+        assert_in(mock.call.suppressOffers({'default'}), driver_calls)
+        pos = driver_calls.index(mock.call.suppressOffers({'default'}))
+        assert_true(1 <= pos < len(driver_calls) - 2)
+        del driver_calls[pos]
         assert_equal([
             mock.call.reviveOffers({'default'}),
             mock.call.killTask(self.nodes[1].taskinfo.task_id),
@@ -2000,10 +2005,47 @@ class TestScheduler(asynctest.ClockedTestCase):
             mock.call.acknowledgeStatusUpdate(status0),
             mock.call.stop(),
             mock.call.join()
-            ], self.driver.mock_calls)
+            ], driver_calls)
         assert_true(launch.done())
         await launch
 
     async def test_status_unknown_task_id(self):
-        """statusUpdate must correctly handle an unknown task ID"""
+        """statusUpdate must correctly handle an unknown task ID.
+
+        It must also kill it if it's not already dead.
+        """
         self._status_update('test-01234567', 'TASK_LOST')
+        self._status_update('test-12345678', 'TASK_RUNNING')
+        await asynctest.exhaust_callbacks(self.loop)
+        self.driver.killTask.assert_called_once_with({'value': 'test-12345678'})
+
+    async def test_retry_kill(self):
+        """Killing a task must be retried after a timeout."""
+        await self._ready_graph()
+        kill = asyncio.ensure_future(self.sched.kill(self.physical_graph, [self.nodes[0]]))
+        await asynctest.exhaust_callbacks(self.loop)
+        self.driver.killTask.assert_called_once_with(self.nodes[0].taskinfo.task_id)
+        self.driver.killTask.reset_mock()
+        # Send a task status update in less than the kill timeout. It must not
+        # lead to a retry.
+        await self.advance(1.0)
+        self._status_update(self.task_ids[0], 'TASK_RUNNING')
+        await asynctest.exhaust_callbacks(self.loop)
+        self.driver.killTask.assert_not_called()
+
+        # Give time for reconciliation requests to occur
+        await self.advance(70.0)
+        self.driver.reconcileTasks.assert_called()
+        self._status_update(self.task_ids[0], 'TASK_RUNNING')
+        await asynctest.exhaust_callbacks(self.loop)
+        self.driver.killTask.assert_called_once_with(self.nodes[0].taskinfo.task_id)
+
+        # Send an update for TASK_KILLING state: must not trigger another attempt
+        self.driver.killTask.reset_mock()
+        self._status_update(self.task_ids[0], 'TASK_KILLING')
+        await asynctest.exhaust_callbacks(self.loop)
+        self.driver.killTask.assert_not_called()
+
+        # Let it die so that we can clean up the async task
+        self._status_update(self.task_ids[0], 'TASK_FAILED')
+        await kill

--- a/scripts/sdp_product_controller.py
+++ b/scripts/sdp_product_controller.py
@@ -160,7 +160,7 @@ def main() -> None:
     framework_info.checkpoint = True
     framework_info.principal = args.principal
     framework_info.roles = [args.realtime_role, args.batch_role]
-    framework_info.capabilities = [{'type': 'MULTI_ROLE'}]
+    framework_info.capabilities = [{'type': 'MULTI_ROLE'}, {'type': 'TASK_KILLING_STATE'}]
 
     loop = asyncio.get_event_loop()
     if args.interface_mode:


### PR DESCRIPTION
This is a fairly simple-minded version, but hopefully that makes it
robust. See http://mesos.apache.org/documentation/latest/reconciliation/
for a description of reconciliation and Mesos' recommendations for more
sophisticated variants of it.

Closes SPR1-326 and SPR1-327.