### PR TITLE
Give spectral imager more RAM

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1838,7 +1838,7 @@ def _make_spectral_imager(g, config, capture_block_id, name, telstate, target_ma
             # TODO: these resources are very rough estimates. The memory
             # estimate is conservative since it assumes no compression.
             dumps = int(round(obs_time / l0_info.int_time))
-            imager.mem = _mb(dump_bytes * dumps)  + 8192
+            imager.mem = _mb(dump_bytes * dumps) + 8192
             imager.disk = 8192
             imager.max_run_time = 3600     # 1 hour
             imager.volumes = [DATA_VOL]

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -63,7 +63,7 @@ BYTES_PER_WEIGHT = 1
 #: Number of bytes per vis-flags-weights combination
 BYTES_PER_VFW = BYTES_PER_VIS + BYTES_PER_FLAG + BYTES_PER_WEIGHT
 #: Number of bytes used by spectral imager per visibility
-BYTES_PER_VFW_SPECTRAL = 15.5       # 62 bytes for 4 polarisation products
+BYTES_PER_VFW_SPECTRAL = 14.5       # 58 bytes for 4 polarisation products
 #: Number of visibilities in a 32 antenna 32K channel dump, for scaling.
 _N32_32 = 32 * 33 * 2 * 32768
 #: Number of visibilities in a 16 antenna 32K channel dump, for scaling.

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -62,6 +62,8 @@ BYTES_PER_FLAG = 1
 BYTES_PER_WEIGHT = 1
 #: Number of bytes per vis-flags-weights combination
 BYTES_PER_VFW = BYTES_PER_VIS + BYTES_PER_FLAG + BYTES_PER_WEIGHT
+#: Number of bytes used by spectral imager per visibility
+BYTES_PER_VFW_SPECTRAL = 15.5       # 62 bytes for 4 polarisation products
 #: Number of visibilities in a 32 antenna 32K channel dump, for scaling.
 _N32_32 = 32 * 33 * 2 * 32768
 #: Number of visibilities in a 16 antenna 32K channel dump, for scaling.
@@ -1802,6 +1804,7 @@ def _make_spectral_imager(g, config, capture_block_id, name, telstate, target_ma
     l1_flags_name = output['src_streams'][0]
     l0_name = config['outputs'][l1_flags_name]['src_streams'][0]
     l0_info = L0Info(config, l0_name)
+    dump_bytes = l0_info.n_baselines * SPECTRAL_OBJECT_CHANNELS * BYTES_PER_VFW_SPECTRAL
     output_channels = output['output_channels']
     data_url = _stream_url(capture_block_id, name + '.' + l0_name)
     min_time = output.get('min_time', DEFAULT_SPECTRAL_MIN_TIME)
@@ -1832,8 +1835,10 @@ def _make_spectral_imager(g, config, capture_block_id, name, telstate, target_ma
             imager = SDPLogicalTask('spectral_image.{}.{:05}-{:05}.{}'.format(
                 name, first_channel, last_channel, target_name))
             imager.cpus = _spectral_imager_cpus(config)
-            # TODO: these resources are very rough estimates
-            imager.mem = 8192
+            # TODO: these resources are very rough estimates. The memory
+            # estimate is conservative since it assumes no compression.
+            dumps = int(round(obs_time / l0_info.int_time))
+            imager.mem = _mb(dump_bytes * dumps)  + 8192
             imager.disk = 8192
             imager.max_run_time = 3600     # 1 hour
             imager.volumes = [DATA_VOL]


### PR DESCRIPTION
The calculation is now based on the number of visibilities to be loaded
(as they are held in memory). The current value is rather conservative,
and we can fine-tune it later. It's possible that for very long
observations it will lead to a loss of parallelism if it needs more than
32GB per task (since each imager has 4 GPUs and 128 GB of RAM). That
will occur at about 6-7 hours of full-size 32K, 8s data.