### PR TITLE
Disable spectral imager

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -83,7 +83,7 @@ SPECTRAL_OBJECT_CHANNELS = 64
 #: Minimum observation time for continuum imager (seconds)
 DEFAULT_CONTINUUM_MIN_TIME = 15 * 60     # 15 minutes
 #: Minimum observation time for spectral imager (seconds)
-DEFAULT_SPECTRAL_MIN_TIME = 2 * 3600     # 2 hours
+DEFAULT_SPECTRAL_MIN_TIME = 2000 * 3600     # XXX Huge to disable temporarily - DO NOT MERGE
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This is a hotfix to prevent the spectral imager running until some
issues in the batch scheduler can be dealt with (SPR1-331 and SPR1-332
in particular).