### PR TITLE
Fix display of task runtime

### DIFF
--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -2153,9 +2153,9 @@ class PhysicalTask(PhysicalNode):
 
     def set_status(self, status):
         self.status = status
-        if status.state == 'TASK_RUNNING':
+        if status.state == 'TASK_RUNNING' and self.start_time is None:
             self.start_time = status.timestamp
-        elif status.state in TERMINAL_STATUSES:
+        elif status.state in TERMINAL_STATUSES and self.end_time is None:
             self.end_time = status.timestamp
 
     def kill(self, driver, **kwargs):


### PR DESCRIPTION
Reconciliation was causing extra status updates to come in, and each
time it would reset the start time. Now only set the start and end time
the first time a corresponding status is seen.