### PR TITLE
Temporary fix to cater for long capture-done delays in vis_writers

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -37,7 +37,7 @@ CAPTURE_TRANSITIONS = {
         KatcpTransition('capture-init', '{capture_block_id}', timeout=30)
     ],
     CaptureBlockState.BURNDOWN: [
-        KatcpTransition('capture-done', timeout=120)
+        KatcpTransition('capture-done', timeout=600)
     ]
 }
 #: Docker images that may appear in the logical graph (used set to Docker image metadata)


### PR DESCRIPTION
I know this is not best practice, but at the moment we often see the subarray ending up in error state waiting for the spectral vis_writer to complete capture_done (typically takes 3 to 5 minutes). Although we may end up occasionally waiting longer than needed when it has properly wedged, I would prefer to make things a bit more robust while we test and understand 32k performance.