### PR TITLE
Make spectral imager use tmp file on disk

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1836,11 +1836,11 @@ def _make_spectral_imager(g, config, capture_block_id, name, telstate, target_ma
             imager = SDPLogicalTask('spectral_image.{}.{:05}-{:05}.{}'.format(
                 name, first_channel, last_channel, target_name))
             imager.cpus = _spectral_imager_cpus(config)
-            # TODO: these resources are very rough estimates. The memory
+            # TODO: these resources are very rough estimates. The disk
             # estimate is conservative since it assumes no compression.
             dumps = int(round(obs_time / l0_info.int_time))
-            imager.mem = _mb(dump_bytes * dumps) + 8192
-            imager.disk = 8192
+            imager.mem = 15 * 1024
+            imager.disk = _mb(dump_bytes * dumps) + 1024
             imager.max_run_time = 6 * 3600     # 6 hours
             imager.volumes = [DATA_VOL]
             imager.gpus = [scheduler.GPURequest()]
@@ -1851,6 +1851,7 @@ def _make_spectral_imager(g, config, capture_block_id, name, telstate, target_ma
             imager.image = 'katsdpimager'
             # TODO: add lots more options to the ICD
             imager.command = [
+                'run-and-cleanup', '--create', '--tmp', '/mnt/mesos/sandbox/tmp', '--',
                 'imager-mkat-pipeline.py',
                 '-i', 'target={}'.format(target.description),
                 '-i', 'access-key={resolver.s3_config[spectral][read][access_key]}',
@@ -1861,7 +1862,6 @@ def _make_spectral_imager(g, config, capture_block_id, name, telstate, target_ma
                 '--major', '5',
                 '--weight-type', 'robust',
                 '--channel-batch', str(SPECTRAL_OBJECT_CHANNELS),
-                '--no-tmp-file',
                 data_url,
                 DATA_VOL.container_path,
                 '{}_{}_{}'.format(capture_block_id, name, target_name)


### PR DESCRIPTION
This makes it about 10% slower (at the moment - may get more significant
with further optimisation), but keeps memory bounded. A quick test
suggests 9GB is probably enough, but allowing 15GB because we can afford
it and it gives some spare room that can be used for caching. It's still
more than I think ought to be getting used given the design, but that
may be because many channels are being loaded and processed at once.

Depends on ska-sa/katsdpdockerbase#44.