### PR TITLE
Support separate URLs for read and write in s3_config

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -437,7 +437,7 @@ def _make_cam2telstate(g, config, name):
 
 def _make_meta_writer(g, config):
     def make_meta_writer_config(task, resolver):
-        s3_url = urllib.parse.urlsplit(resolver.s3_config['archive']['url'])
+        s3_url = urllib.parse.urlsplit(resolver.s3_config['archive']['write']['url'])
         return {
             's3_host': s3_url.hostname,
             's3_port': s3_url.port,
@@ -1198,7 +1198,8 @@ def _make_vis_writer(g, config, name, s3_name, local, prefix=None, max_channels=
             'obj_max_dumps': max_accum_dumps,
             'workers': workers,
             'buffer_dumps': buffer_dumps,
-            's3_endpoint_url': resolver.s3_config[s3_name]['url'],
+            's3_endpoint_url': resolver.s3_config[s3_name]['read']['url'],
+            's3_write_url': resolver.s3_config[s3_name]['write']['url'],
             's3_expiry_days': resolver.s3_config[s3_name].get('expiry_days', None),
             'direct_write': True,
             'aiomonitor': True
@@ -1275,7 +1276,8 @@ def _make_flag_writer(g, config, name, l0_name, s3_name, local, prefix=None, max
             'obj_max_dumps': max_accum_dumps,
             'workers': workers,
             'buffer_dumps': buffer_dumps,
-            's3_endpoint_url': resolver.s3_config[s3_name]['url'],
+            's3_endpoint_url': resolver.s3_config[s3_name]['read']['url'],
+            's3_write_url': resolver.s3_config[s3_name]['write']['url'],
             's3_expiry_days': resolver.s3_config[s3_name].get('expiry_days', None),
             'direct_write': True,
             'aiomonitor': True

--- a/katsdpcontroller/schemas/s3_config.json
+++ b/katsdpcontroller/schemas/s3_config.json
@@ -8,18 +8,44 @@
             "properties": {
                 "access_key": {"$ref": "#/definitions/key"},
                 "secret_key": {"$ref": "#/definitions/key"}
-            }
+            },
+            "required": ["access_key", "secret_key"]
         },
-        "store": {
+        "key_pair_url": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "read": {"$ref": "#/definitions/key_pair"},
-                "write": {"$ref": "#/definitions/key_pair"},
-                "url": { "type": "string", "format": "uri" },
-                "expiry_days": { "type": "integer", "minimumValue": 0 }
+                "access_key": {"$ref": "#/definitions/key"},
+                "secret_key": {"$ref": "#/definitions/key"},
+                "url": { "type": "string", "format": "uri" }
             },
-            "required": ["write", "url"]
+            "required": ["access_key", "secret_key", "url"]
+        },
+        "expiry": { "type": "integer", "minimumValue": 0 },
+        "store": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "read": {"$ref": "#/definitions/key_pair"},
+                        "write": {"$ref": "#/definitions/key_pair"},
+                        "url": { "type": "string", "format": "uri" },
+                        "expiry_days": { "$ref": "#/definitions/expiry" }
+                    },
+                    "required": ["write", "url"]
+                },
+                {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "read": {"$ref": "#/definitions/key_pair_url"},
+                        "write": {"$ref": "#/definitions/key_pair_url"},
+                        "expiry_days": { "$ref": "#/definitions/expiry" }
+                    },
+                    "required": ["write"]
+                }
+            ]
         },
         "rwstore": {
             "allOf": [


### PR DESCRIPTION
For compatibility, each archive can be specified as before, or url's can
be specified separately in the `read` and `write` sections and not in
the top level (making for a somewhat complex JSON schema). There is a
schema fix, where previously the access key and secret key weren't
marked required even though they are.

Internally, the old format is rewritten into the new format by the
product controller when it starts up.

This is slightly brittle in terms of backwards/forwards compatibility:
once we update the config file, we'll only be able to use the new
version of the product controller. It'll also need a new
katsdpdatawriter to actually have the desired effect, although an old
one will still work but use the read endpoint for writing.