### PR TITLE
Increase spectral channels from 64 to 128

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -81,7 +81,7 @@ CONFIG_VOL = scheduler.VolumeRequest('config', '/var/kat/config', 'RW')
 #: Target size of objects in the object store
 WRITER_OBJECT_SIZE = 20e6    # 20 MB
 #: Maximum channels per chunk for spectral imager
-SPECTRAL_OBJECT_CHANNELS = 64
+SPECTRAL_OBJECT_CHANNELS = 128
 #: Minimum observation time for continuum imager (seconds)
 DEFAULT_CONTINUUM_MIN_TIME = 15 * 60     # 15 minutes
 #: Minimum observation time for spectral imager (seconds)

--- a/katsdpcontroller/test/utils.py
+++ b/katsdpcontroller/test/utils.py
@@ -144,7 +144,7 @@ CONFIG = '''{
         "spectral_image": {
             "type": "sdp.spectral_image",
             "src_streams": ["sdp_l1_flags"],
-            "output_channels": [60, 70]
+            "output_channels": [120, 130]
         }
     },
     "config": {}


### PR DESCRIPTION
Testing (on an otherwise idle system) shows about 39m to process 64
channels and 64m to process 128 i.e. ~20% throughput increase. This is
because there are fixed costs such as opening the dataset and computing
parallactic angles and UVW coordinates.