### PR TITLE
Add counter for number of batch task retries

### DIFF
--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -221,6 +221,8 @@ class TaskStats(scheduler.TaskStats):
                     'Number of batch tasks that were skipped because a dependency failed')
         add_counter('batch-tasks-done',
                     'Number of completed batch tasks (including failed and skipped)')
+        add_counter('batch-tasks-retried',
+                    'Number of batch tasks that failed and were rescheduled')
         add_counter('batch-tasks-failed',
                     'Number of batch tasks that failed (after all retries)')
 
@@ -243,6 +245,9 @@ class TaskStats(scheduler.TaskStats):
 
     def batch_tasks_skipped(self, n_tasks: int) -> None:
         self.sensors['batch-tasks-skipped'].value += n_tasks
+
+    def batch_tasks_retried(self, n_tasks: int) -> None:
+        self.sensors['batch-tasks-retried'].value += n_tasks
 
     def batch_tasks_failed(self, n_tasks: int) -> None:
         self.sensors['batch-tasks-failed'].value += n_tasks

--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -2380,6 +2380,9 @@ class TaskStats:
         """`n_tasks` batch tasks were skipped because a dependency failed."""
         pass
 
+    def batch_tasks_retried(self, n_tasks):
+        """`n_tasks` batch tasks failed and were re-scheduled."""
+
     def batch_tasks_failed(self, n_tasks):
         """`n_tasks` batch tasks failed after all retries."""
         pass
@@ -3176,6 +3179,7 @@ class Scheduler(pymesos.Scheduler):
                     mapping = dict(zip(nodes, new_nodes))
                     networkx.relabel_nodes(graph, mapping, copy=False)
                     nodes = new_nodes
+                    self.task_stats.batch_tasks_retried(len(nodes))
             else:
                 break
 
@@ -3263,7 +3267,7 @@ class Scheduler(pymesos.Scheduler):
                         resources_timeout=resources_timeout, attempts=attempts)
                 except Exception:
                     logger.exception('Batch task %s failed', node.name)
-                    self.task_stats.batch_tasks_failed(1)
+                    self.task_stats.batch_tasks_failed(len(node_set))
                     raise
             finally:
                 self.task_stats.batch_tasks_done(len(node_set))

--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -2382,6 +2382,7 @@ class TaskStats:
 
     def batch_tasks_retried(self, n_tasks):
         """`n_tasks` batch tasks failed and were re-scheduled."""
+        pass
 
     def batch_tasks_failed(self, n_tasks):
         """`n_tasks` batch tasks failed after all retries."""

--- a/katsdpcontroller/test/test_scheduler.py
+++ b/katsdpcontroller/test/test_scheduler.py
@@ -55,6 +55,7 @@ class SimpleTaskStats(scheduler.TaskStats):
         self.batch_created = 0
         self.batch_started = 0
         self.batch_done = 0
+        self.batch_retried = 0
         self.batch_failed = 0
         self.batch_skipped = 0
         self._state_counts = Counter()
@@ -72,6 +73,9 @@ class SimpleTaskStats(scheduler.TaskStats):
 
     def batch_tasks_done(self, n_tasks):
         self.batch_done += n_tasks
+
+    def batch_tasks_retried(self, n_tasks):
+        self.batch_retried += n_tasks
 
     def batch_tasks_failed(self, n_tasks):
         self.batch_failed += n_tasks
@@ -1873,6 +1877,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         assert_equal(self.task_stats.batch_created, 1)
         assert_equal(self.task_stats.batch_started, 1)
         assert_equal(self.task_stats.batch_done, 1)
+        assert_equal(self.task_stats.batch_retried, 0)
         assert_equal(self.task_stats.batch_failed, 0)
         assert_equal(self.task_stats.batch_skipped, 0)
 
@@ -1889,6 +1894,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         assert_equal(self.task_stats.batch_created, 1)
         assert_equal(self.task_stats.batch_started, 1)
         assert_equal(self.task_stats.batch_done, 1)
+        assert_equal(self.task_stats.batch_retried, 0)
         assert_equal(self.task_stats.batch_failed, 1)
         assert_equal(self.task_stats.batch_skipped, 0)
 
@@ -1907,6 +1913,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         assert_equal(self.task_stats.batch_created, 1)
         assert_equal(self.task_stats.batch_started, 1)
         assert_equal(self.task_stats.batch_done, 1)
+        assert_equal(self.task_stats.batch_retried, 0)
         assert_equal(self.task_stats.batch_failed, 1)
         assert_equal(self.task_stats.batch_skipped, 0)
 
@@ -1921,6 +1928,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         assert_equal(self.task_stats.batch_created, 1)
         assert_equal(self.task_stats.batch_started, 1)
         assert_equal(self.task_stats.batch_done, 1)
+        assert_equal(self.task_stats.batch_retried, 0)
         assert_equal(self.task_stats.batch_failed, 1)
         assert_equal(self.task_stats.batch_skipped, 0)
 
@@ -1935,6 +1943,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         assert_equal(self.task_stats.batch_created, 1)
         assert_equal(self.task_stats.batch_started, 1)
         assert_equal(self.task_stats.batch_done, 1)
+        assert_equal(self.task_stats.batch_retried, 1)
         assert_equal(self.task_stats.batch_failed, 0)
         assert_equal(self.task_stats.batch_skipped, 0)
 
@@ -1995,6 +2004,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         assert_equal(self.task_stats.batch_created, 2)
         assert_equal(self.task_stats.batch_started, 1)
         assert_equal(self.task_stats.batch_done, 2)
+        assert_equal(self.task_stats.batch_retried, 0)
         assert_equal(self.task_stats.batch_failed, 1)
         assert_equal(self.task_stats.batch_skipped, 1)
 

--- a/sandbox/etc/grafana/dashboards/imaging.json
+++ b/sandbox/etc/grafana/dashboards/imaging.json
@@ -26,7 +26,7 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 21,
         "x": 0,
         "y": 0
@@ -126,6 +126,8 @@
         "#d44a3a"
       ],
       "datasource": "Prometheus",
+      "decimals": 0,
+      "description": "Tasks that have failed but been rescheduled (counted once for each failure).",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -135,12 +137,95 @@
         "thresholdMarkers": true
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 3,
         "x": 21,
         "y": 0
       },
       "id": 4,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(increase(katsdpcontroller_batch_tasks_retried[$__range]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "1,1",
+      "title": "Retries",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
+      "decimals": 0,
+      "description": "Tasks that have failed after all retry attempts.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 21,
+        "y": 3
+      },
+      "id": 14,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -207,6 +292,7 @@
         "#d44a3a"
       ],
       "datasource": "Prometheus",
+      "decimals": 0,
       "description": "Tasks skipped because a prerequisite task failed",
       "format": "none",
       "gauge": {
@@ -217,10 +303,10 @@
         "thresholdMarkers": true
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 3,
         "x": 21,
-        "y": 4
+        "y": 6
       },
       "id": 5,
       "interval": null,
@@ -298,7 +384,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 9
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -365,7 +451,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 9
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -431,7 +517,7 @@
         "h": 11,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 21
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -497,7 +583,7 @@
         "h": 11,
         "w": 12,
         "x": 12,
-        "y": 20
+        "y": 21
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -551,7 +637,7 @@
         "h": 11,
         "w": 12,
         "x": 0,
-        "y": 31
+        "y": 32
       },
       "id": 13,
       "options": {},
@@ -580,6 +666,12 @@
             "title": "Postprocessing time",
             "type": "linear",
             "zeroline": true
+          },
+          "zaxis": {
+            "rangemode": "normal",
+            "showgrid": true,
+            "type": "linear",
+            "zeroline": false
           }
         },
         "loadFromCDN": false,
@@ -705,5 +797,5 @@
   "timezone": "",
   "title": "Imaging",
   "uid": "sX9cxaxZz",
-  "version": 1
+  "version": 4
 }


### PR DESCRIPTION
It's also added to the local copy of the imaging dashboard. The gauges
on the dashboard are also updated to give zero decimal places after the
counts (since they're integers).