### PR TITLE
Reduce capture-done timeout to fit within CAM timeout

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -42,7 +42,7 @@ CAPTURE_TRANSITIONS = {
         KatcpTransition('capture-init', '{capture_block_id}', timeout=30)
     ],
     CaptureBlockState.BURNDOWN: [
-        KatcpTransition('capture-done', timeout=360)
+        KatcpTransition('capture-done', timeout=240)
     ]
 }
 #: Docker images that may appear in the logical graph (used set to Docker image metadata)

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -42,7 +42,7 @@ CAPTURE_TRANSITIONS = {
         KatcpTransition('capture-init', '{capture_block_id}', timeout=30)
     ],
     CaptureBlockState.BURNDOWN: [
-        KatcpTransition('capture-done', timeout=600)
+        KatcpTransition('capture-done', timeout=360)
     ]
 }
 #: Docker images that may appear in the logical graph (used set to Docker image metadata)


### PR DESCRIPTION
The idea is to provide a sensible timeout length, but still fit comfortably inside the CAM timeout (400s) for this command. This will ensure that in a failure, CAM will be able to issue a deconfigure without hitting a busy state.