### PR TITLE
Replace many instances of 'localhost' with '127.0.0.1'

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -36,6 +36,9 @@ def escape_format(s: str) -> str:
     return s.replace('{', '{{').replace('}', '}}')
 
 
+# Docker doesn't support IPv6 out of the box, and on some systems 'localhost'
+# resolves to ::1, so force an IPv4 localhost.
+LOCALHOST = '127.0.0.1'
 INGEST_GPU_NAME = 'GeForce GTX TITAN X'
 CAPTURE_TRANSITIONS = {
     CaptureBlockState.CAPTURING: [
@@ -133,7 +136,7 @@ class TelstateTask(SDPPhysicalTask):
             # host-side binding, so we have to provide docker parameters
             # directly.
             parameters = self.taskinfo.container.docker.setdefault('parameters', [])
-            parameters.append({'key': 'publish', 'value': f'127.0.0.1:{host_port}:6379'})
+            parameters.append({'key': 'publish', 'value': f'{LOCALHOST}:{host_port}:6379'})
 
 
 class IngestTask(SDPPhysicalTask):
@@ -614,7 +617,7 @@ def _make_timeplot(g, name, description,
     timeplot.critical = False
 
     g.add_node(timeplot, config=lambda task, resolver: dict({
-        'html_host': 'localhost' if resolver.localhost else '',
+        'html_host': LOCALHOST if resolver.localhost else '',
         'config_base': os.path.join(CONFIG_VOL.container_path, '.katsdpdisp'),
         'spead_interface': task.interfaces['sdp_10g'].name,
         'memusage': -timeplot_buffer_mb     # Negative value gives MB instead of %
@@ -1060,7 +1063,7 @@ def _make_cal(g, config, name, l0_name, flags_names):
             cal_config = {
                 'l0_interface': task.interfaces['sdp_10g'].name,
                 'server_id': server_id,
-                'dask_diagnostics': ('127.0.0.1' if resolver.localhost else '',
+                'dask_diagnostics': (LOCALHOST if resolver.localhost else '',
                                      task.ports['dask_diagnostics']),
                 'dask_prefix': dask_prefix.format(task),
                 'flags_streams': copy.deepcopy(flags_streams_base)
@@ -1445,7 +1448,7 @@ def build_logical_graph(config):
     g = networkx.MultiDiGraph(
         archived_streams=archived_streams,  # For access as g.graph['archived_streams']
         init_telstate=init_telstate,        # ditto
-        config=lambda resolver: ({'host': '127.0.0.1'} if resolver.localhost else {})
+        config=lambda resolver: ({'host': LOCALHOST} if resolver.localhost else {})
     )
 
     # telstate node

--- a/katsdpcontroller/master_controller.py
+++ b/katsdpcontroller/master_controller.py
@@ -1551,7 +1551,7 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
                         help='Run haproxy to provide frontend to GUIs [no]')
     parser.add_argument('--external-url', metavar='URL', type=yarl.URL,
                         help='External URL for clients to browse the GUI')
-    parser.add_argument('--consul-url', type=yarl.URL, default='http://localhost:8500/',
+    parser.add_argument('--consul-url', type=yarl.URL, default='http://127.0.0.1:8500/',
                         help='base URL for local consul agent [%(default)s]')
     parser.add_argument('--image-tag-file',
                         metavar='FILE', help='Load image tag to run from file (on each configure)')

--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -31,7 +31,8 @@ from .tasks import (CaptureBlockState, KatcpTransition, DEPENDS_INIT,
 
 BATCH_PRIORITY = 1        #: Scheduler priority for batch queues
 BATCH_RESOURCES_TIMEOUT = 7 * 86400   # A week
-CONSUL_URL = 'http://localhost:8500'
+LOCALHOST = '127.0.0.1'        # Unlike 'localhost', guaranteed to be IPv4
+CONSUL_URL = f'http://{LOCALHOST}:8500'
 _HINT_RE = re.compile(r'\bprometheus: *(?P<type>[a-z]+)(?:\((?P<args>[^)]*)\)|\b)'
                       r'(?: +labels: *(?P<labels>[a-z,]+))?',
                       re.IGNORECASE)
@@ -1263,7 +1264,7 @@ class DeviceServer(aiokatcp.DeviceServer):
                 {
                     "Interval": "15s",
                     "Timeout": "5s",
-                    "HTTP": f"http://localhost:{port}/health",
+                    "HTTP": f"http://{LOCALHOST}:{port}/health",
                     "DeregisterCriticalServiceAfter": "90s"
                 }
             ]

--- a/katsdpcontroller/test/test_master_controller.py
+++ b/katsdpcontroller/test/test_master_controller.py
@@ -125,7 +125,7 @@ CONSUL_POWEROFF_SERVERS = [
         "ModifyIndex": 7
     }
 ]
-CONSUL_POWEROFF_URL = 'http://localhost:8500/v1/catalog/service/poweroff?near=_agent'
+CONSUL_POWEROFF_URL = 'http://127.0.0.1:8500/v1/catalog/service/poweroff?near=_agent'
 
 
 class DummyServer(aiokatcp.DeviceServer):

--- a/katsdpcontroller/test/test_scheduler.py
+++ b/katsdpcontroller/test/test_scheduler.py
@@ -1199,7 +1199,7 @@ class TestScheduler(asynctest.ClockedTestCase):
 
     async def _wait_request(self, task_id):
         async with aiohttp.ClientSession() as session:
-            async with session.get('http://localhost:{}/tasks/{}/wait_start'.format(
+            async with session.get('http://127.0.0.1:{}/tasks/{}/wait_start'.format(
                     self.sched.http_port, task_id)) as resp:
                 resp.raise_for_status()
                 await resp.read()

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - exhibitor
     environment:
       MESOS_IP: 127.0.0.1
+      MESOS_HOSTNAME: 127.0.0.1
       MESOS_PORT: 5050
       MESOS_ZK: zk://127.0.0.1:2181/mesos
       MESOS_QUORUM: 1
@@ -29,6 +30,7 @@ services:
       - exhibitor
     environment:
       MESOS_IP: 127.0.0.1
+      MESOS_HOSTNAME: 127.0.0.1
       MESOS_PORT: 5051
       MESOS_MASTER: zk://127.0.0.1:2181/mesos
       MESOS_CONTAINERIZERS: docker,mesos

--- a/sandbox/elk-setup.sh
+++ b/sandbox/elk-setup.sh
@@ -4,13 +4,13 @@ set -e -u
 trap 'echo Failed' ERR
 
 echo "Setting Elasticsearch pipeline"
-curl -s --fail -X PUT -H 'Content-type: application/json' -d '@etc/elk/elasticsearch-pipeline.json' 'http://localhost:9200/_ingest/pipeline/timestamp_precise' > /dev/null
+curl -s --fail -X PUT -H 'Content-type: application/json' -d '@etc/elk/elasticsearch-pipeline.json' 'http://127.0.0.1:9200/_ingest/pipeline/timestamp_precise' > /dev/null
 echo "Setting Kibana settings"
-curl -s --fail -X POST -H 'Content-type: application/json' -H 'kbn-xsrf: true' -d '@etc/elk/kibana-settings.json' 'http://localhost:5601/api/saved_objects/config/7.3.1?overwrite=true' > /dev/null
+curl -s --fail -X POST -H 'Content-type: application/json' -H 'kbn-xsrf: true' -d '@etc/elk/kibana-settings.json' 'http://127.0.0.1:5601/api/saved_objects/config/7.3.1?overwrite=true' > /dev/null
 echo "Setting Kibana index pattern"
-curl -s --fail -X POST -H 'Content-type: application/json' -H 'kbn-xsrf: true' -d '@etc/elk/kibana-index-pattern.json' 'http://localhost:5601/api/saved_objects/index-pattern/logstash?overwrite=true' > /dev/null
+curl -s --fail -X POST -H 'Content-type: application/json' -H 'kbn-xsrf: true' -d '@etc/elk/kibana-index-pattern.json' 'http://127.0.0.1:5601/api/saved_objects/index-pattern/logstash?overwrite=true' > /dev/null
 echo "Setting Kibana search"
-curl -s --fail -X POST -H 'Content-type: application/json' -H 'kbn-xsrf: true' -d '@etc/elk/sdp-messages.json' 'http://localhost:5601/api/saved_objects/search/sdp-messages?overwrite=true' > /dev/null
+curl -s --fail -X POST -H 'Content-type: application/json' -H 'kbn-xsrf: true' -d '@etc/elk/sdp-messages.json' 'http://127.0.0.1:5601/api/saved_objects/search/sdp-messages?overwrite=true' > /dev/null
 
 echo
 echo "Success"

--- a/sandbox/etc/singularity/singularity.yaml
+++ b/sandbox/etc/singularity/singularity.yaml
@@ -30,7 +30,7 @@ zookeeper:
 
 ui:
   title: Singularity (docker)
-  baseUrl: http://localhost:7099/singularity
+  baseUrl: http://127.0.0.1:7099/singularity
 
 logging:
   loggers:

--- a/sandbox/gui-urls/mesos.json
+++ b/sandbox/gui-urls/mesos.json
@@ -2,7 +2,7 @@
     {
         "title": "Mesos",
         "description": "Mesos UI",
-        "href": "http://localhost:5050/",
+        "href": "http://127.0.0.1:5050/",
         "category": "Link"
     }
 ]

--- a/sandbox/gui-urls/prometheus.json
+++ b/sandbox/gui-urls/prometheus.json
@@ -2,13 +2,13 @@
     {
         "title": "Grafana",
         "description": "Grafana dashboard",
-        "href": "http://localhost:3000/",
+        "href": "http://127.0.0.1:3000/",
         "category": "Dashboard"
     },
     {
         "title": "Prometheus",
         "description": "Low-level interface to query metrics",
-        "href": "http://localhost:9090/",
+        "href": "http://127.0.0.1:9090/",
         "category": "Link"
     }
 ]

--- a/sandbox/gui-urls/singularity.json
+++ b/sandbox/gui-urls/singularity.json
@@ -2,7 +2,7 @@
     {
         "title": "Singularity",
         "description": "Singularity UI",
-        "href": "http://localhost:7099/singularity",
+        "href": "http://127.0.0.1:7099/singularity",
         "category": "Link"
     }
 ]

--- a/sandbox/s3_config.json
+++ b/sandbox/s3_config.json
@@ -8,7 +8,7 @@
             "access_key": "minioaccesskey",
             "secret_key": "miniosecretkey"
         },
-        "url": "http://localhost:9000/"
+        "url": "http://127.0.0.1:9000/"
     },
     "spectral": {
         "read": {
@@ -19,7 +19,7 @@
             "access_key": "minioaccesskey",
             "secret_key": "miniosecretkey"
         },
-        "url": "http://localhost:9000/"
+        "url": "http://127.0.0.1:9000/"
     },
     "archive": {
         "read": {


### PR DESCRIPTION
There is variation in host systems as to whether localhost resolves to
::1 in addition to 127.0.0.1. This can cause problems if the system
doesn't also have Docker configured for IPv6.

This is mainly expected to affect developer test systems using the
sandbox. In particular, it doesn't address the problem of a
system-configured Mesos slave that advertises itself as 'localhost'.