### PR TITLE
Abort when dependencies fail

### DIFF
--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -10,7 +10,7 @@ import copy
 import uuid
 import functools
 from ipaddress import IPv4Address
-from typing import Dict, Set, List, Callable, Sequence, Optional, Type, Mapping
+from typing import Dict, Set, List, Tuple, Callable, Sequence, Optional, Type, Mapping
 
 import addict
 import jsonschema
@@ -1063,19 +1063,29 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
             key = self.telstate.join(*k) if isinstance(k, tuple) else k
             self.telstate[key] = v
 
-    def check_nodes(self) -> bool:
+    def check_nodes(self) -> Tuple[bool, List[scheduler.PhysicalNode]]:
         """Check that all requested nodes are actually running.
+
+        Returns
+        -------
+        result
+            True if all tasks are in state :const:`~scheduler.TaskState.READY`.
+        died
+            Nodes that have died unexpectedly (does not include nodes that we
+            killed).
 
         .. todo::
 
            Also check health state sensors
         """
+        died = []
+        result = True
         for node in self.physical_graph:
             if node.state != scheduler.TaskState.READY:
-                logger.warning('Task %s is in state %s instead of READY',
-                               node.name, node.state.name)
-                return False
-        return True
+                if node.state == scheduler.TaskState.DEAD and not node.death_expected:
+                    died.append(node)
+                result = False
+        return result, died
 
     def unexpected_death(self, task: scheduler.PhysicalTask) -> None:
         logger.warning('Task %s died unexpectedly', task.name)
@@ -1141,10 +1151,13 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
                 await self._launch_telstate()
                 # launch containers for those nodes that require them
                 await self.sched.launch(self.physical_graph, self.resolver)
-                alive = self.check_nodes()
+                alive, died = self.check_nodes()
                 # is everything we asked for alive
                 if not alive:
-                    ret_msg = ("Some nodes in the graph failed to start. "
+                    fail_list = ', '.join(node.logical_node.name for node in died)
+                    if fail_list == '':
+                        fail_list = 'Some nodes'
+                    ret_msg = (f"{fail_list} failed to start. "
                                "Check the error log for specific details.")
                     logger.error(ret_msg)
                     raise FailReply(ret_msg)

--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -1154,9 +1154,7 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
                 alive, died = self.check_nodes()
                 # is everything we asked for alive
                 if not alive:
-                    fail_list = ', '.join(node.logical_node.name for node in died)
-                    if fail_list == '':
-                        fail_list = 'Some nodes'
+                    fail_list = ', '.join(node.logical_node.name for node in died) or 'Some nodes'
                     ret_msg = (f"{fail_list} failed to start. "
                                "Check the error log for specific details.")
                     logger.error(ret_msg)

--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -360,9 +360,9 @@ class SDPPhysicalTask(SDPConfigMixin, scheduler.PhysicalTask):
             raise FailReply(msg) from error
 
     async def wait_ready(self):
-        await super().wait_ready()
+        success = await super().wait_ready()
         # establish katcp connection to this node if appropriate
-        if 'port' in self.ports:
+        if success and 'port' in self.ports:
             while True:
                 self.logger.info("Attempting to establish katcp connection to %s:%s for node %s",
                                  self.host, self.ports['port'], self.name)
@@ -381,7 +381,7 @@ class SDPPhysicalTask(SDPConfigMixin, scheduler.PhysicalTask):
                     if sensor is not None:
                         self.device_status_observer = DeviceStatusObserver(
                             sensor, self)
-                    return
+                    return success
                 except RuntimeError:
                     self.katcp_connection.close()
                     await self.katcp_connection.wait_closed()
@@ -393,6 +393,7 @@ class SDPPhysicalTask(SDPConfigMixin, scheduler.PhysicalTask):
                     # Sleep for a bit to avoid hammering the port if there
                     # is a quick failure, before trying again.
                     await asyncio.sleep(1.0)
+        return success
 
     def _add_sensor(self, sensor):
         """Add the supplied Sensor object to the top level device and

--- a/katsdpcontroller/test/test_product_controller.py
+++ b/katsdpcontroller/test/test_product_controller.py
@@ -514,10 +514,15 @@ class TestSDPController(BaseTestSDPController):
                     node.status = Dict(state=self.fail_launches[node.logical_node.name])
                 else:
                     node.set_state(scheduler.TaskState.RUNNING)
-        futures = []
-        for node in nodes:
-            futures.append(node.ready_event.wait())
-        await asyncio.gather(*futures)
+
+        order_graph = scheduler.subgraph(graph, scheduler.DEPENDS_READY, nodes)
+        for node in reversed(list(networkx.topological_sort(order_graph))):
+            # With the real scheduler, the value returned to delay_run.sh is
+            # used to kill tasks with failed dependencies. We need to simulate
+            # that here - it is sufficient to move tasks from KILLING to DEAD.
+            if node.state == scheduler.TaskState.KILLING:
+                node.set_state(scheduler.TaskState.DEAD)
+            await node.ready_event.wait()
 
     async def _batch_run(self, graph: networkx.MultiDiGraph,
                          resolver: scheduler.Resolver,


### PR DESCRIPTION
When a realtime task fails, don't keep bumbling on running tasks that depend on it; kill them instead. This has a few benefits:
- Failures happen faster.
- There is less spam in the logs from tasks that start up, can't find the things they need in telstate, and vomit up errors that have nothing to do with the root cause.
- It sets up the groundwork for better error reporting back to CAM, since it'll be easier to figure out which tasks are the culprits (e.g. they won't have the death_expected flag set).

Relates to SPR1-424.