### PR TITLE
Spectral beam correction

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1815,7 +1815,7 @@ def _make_spectral_imager(g, config, capture_block_id, name, telstate, target_ma
     data_url = _stream_url(capture_block_id, name + '.' + l0_name)
     min_time = output.get('min_time', DEFAULT_SPECTRAL_MIN_TIME)
     targets, data_set = _get_targets(config, capture_block_id, name, telstate, min_time)
-    band = data_set.spectral_windows[data_set.spw].band
+    band = data_set.spectral_windows[data_set.spw].band if data_set is not None else ''
     del data_set    # Allow Python to recover the memory
 
     for target, obs_time in targets:

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1704,6 +1704,9 @@ def _get_targets(config, capture_block_id, name, telstate, min_time):
     targets : Dict[str, Tuple[katpoint.Target, float]]
         Each key is the unique normalised target name, and the value is the
         target and the observation time on the target.
+    data_set : Optional[katdal.DataSet]
+        A katdal data set corresponding to the arguments. If `targets` is empty
+        then this may be ``None``.
     """
     output = config['outputs'][name]
     l1_flags_name = output['src_streams'][0]
@@ -1711,7 +1714,7 @@ def _get_targets(config, capture_block_id, name, telstate, min_time):
     l0_info = L0Info(config, l0_name)
     if l0_info.n_antennas < 4:
         # Won't be any calibration solutions
-        return {}
+        return {}, None
 
     targets = {}
     l0_stream = name + '.' + l0_name
@@ -1729,7 +1732,7 @@ def _get_targets(config, capture_block_id, name, telstate, min_time):
         else:
             logger.info('Skipping target %s: observed for %.1f seconds, threshold is %.1f',
                         target.name, obs_time, min_time)
-    return targets
+    return targets, data_set
 
 
 def _render_continuum_parameters(parameters):
@@ -1749,7 +1752,7 @@ def _make_continuum_imager(g, config, capture_block_id, name, telstate, target_m
     data_url = _stream_url(capture_block_id, l0_stream)
     cpus = _continuum_imager_cpus(config)
     min_time = output.get('min_time', DEFAULT_CONTINUUM_MIN_TIME)
-    targets = _get_targets(config, capture_block_id, name, telstate, min_time)
+    targets = _get_targets(config, capture_block_id, name, telstate, min_time)[0]
 
     for target, obs_time in targets:
         target_name = target_mapper(target)
@@ -1811,7 +1814,9 @@ def _make_spectral_imager(g, config, capture_block_id, name, telstate, target_ma
     output_channels = output['output_channels']
     data_url = _stream_url(capture_block_id, name + '.' + l0_name)
     min_time = output.get('min_time', DEFAULT_SPECTRAL_MIN_TIME)
-    targets = _get_targets(config, capture_block_id, name, telstate, min_time)
+    targets, data_set = _get_targets(config, capture_block_id, name, telstate, min_time)
+    band = data_set.spectral_windows[data_set.spw].band
+    del data_set    # Allow Python to recover the memory
 
     for target, obs_time in targets:
         for i in range(0, l0_info.n_channels, SPECTRAL_OBJECT_CHANNELS):
@@ -1871,6 +1876,8 @@ def _make_spectral_imager(g, config, capture_block_id, name, telstate, target_ma
             if continuum_telstate_name is not None:
                 sky_model_url = _sky_model_url(data_url, output['src_streams'][1], target)
                 imager.command += ['--subtract', sky_model_url]
+            if band in {'L'}:      # Models are not available for all bands yet
+                imager.command += ['--primary-beam', 'meerkat']
 
             imager.katsdpservices_config = False
             imager.batch_data_time = obs_time

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1876,7 +1876,7 @@ def _make_spectral_imager(g, config, capture_block_id, name, telstate, target_ma
             if continuum_telstate_name is not None:
                 sky_model_url = _sky_model_url(data_url, output['src_streams'][1], target)
                 imager.command += ['--subtract', sky_model_url]
-            if band in {'L'}:      # Models are not available for all bands yet
+            if band in {'L', 'UHF'}:      # Models are not available for other bands yet
                 imager.command += ['--primary-beam', 'meerkat']
 
             imager.katsdpservices_config = False

--- a/katsdpcontroller/test/test_product_controller.py
+++ b/katsdpcontroller/test/test_product_controller.py
@@ -27,6 +27,7 @@ import networkx
 import netifaces
 import katsdptelstate
 import katpoint
+import katdal
 
 from ..controller import device_server_sockname
 from ..product_controller import (
@@ -125,6 +126,10 @@ class DummyDataSet:
             'Observation/scan_state': np.array(scan_state),
             'Observation/target_index': np.array(target_index)
         }
+        self.spw = 0
+        self.spectral_windows = [
+            katdal.SpectralWindow(1284e6, 856e6 / 4096, 4096, 'c856M4k', 'L')
+        ]
 
 
 def get_metric(metric):


### PR DESCRIPTION
Only enabled for L and UHF bands, since those are the only ones supported by katsdpimager.