### PR TITLE
Make unit tests reliable again

### DIFF
--- a/katsdpcontroller/test/test_product_controller.py
+++ b/katsdpcontroller/test/test_product_controller.py
@@ -530,6 +530,10 @@ class TestSDPController(BaseTestSDPController):
                     node.status = Dict(state=self.fail_launches[node.logical_node.name])
                 else:
                     node.set_state(scheduler.TaskState.RUNNING)
+        futures = []
+        for node in nodes:
+            futures.append(node.ready_event.wait())
+        await asyncio.gather(*futures)
 
     async def _batch_run(self, graph: networkx.MultiDiGraph,
                          resolver: scheduler.Resolver,


### PR DESCRIPTION
PR #466 changed the handling of failures of dependencies in a way that
required some mocking in the unit tests, but the way it was handled
wasn't reliable (basically, if the failure didn't propagate and set the
state to KILLING before the mocking code inspected the state, the
mocking code wouldn't set the state to DEAD). The approach to mocking
has been changed so that the KILLING -> DEAD transition is handled in a
wrapper around `dependency_abort`, which seems to be more reliable.