### PR TITLE
Bump Singularity to 1.2 in Sandbox

### DIFF
--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -56,7 +56,7 @@ services:
 
   singularity:
     network_mode: host
-    image: hubspot/singularityservice:1.0.0
+    image: hubspot/singularityservice:1.2.0
     depends_on:
       - mesos-master
       - exhibitor


### PR DESCRIPTION
It has some bug fixes for Mesos reconnects that might be relevant to the
hangs I've been experiencing when I start everything up together. Not
proven, but we might as well give it a try.