### PR TITLE
Run spectral imager report

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1879,7 +1879,8 @@ def _make_spectral_imager(g, config, capture_block_id, name, telstate, target_ma
                 '--channel-batch', str(SPECTRAL_OBJECT_CHANNELS),
                 data_url,
                 escape_format(DATA_VOL.container_path),
-                escape_format('{}_{}_{}'.format(capture_block_id, name, target_name))
+                escape_format('{}_{}_{}'.format(capture_block_id, name, target_name)),
+                escape_format(name)
             ]
             if continuum_telstate_name is not None:
                 sky_model_url = _sky_model_url(data_url, output['src_streams'][1], target)

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1907,6 +1907,7 @@ def _make_spectral_imager(g, config, capture_block_id, name, telstate, target_ma
     view['output_channels'] = list(range(output_channels[0], output_channels[1]))
     return data_url, nodes
 
+
 def _make_spectral_imager_report(g, config, capture_block_id, name, data_url, spectral_nodes):
     report = SDPLogicalTask(f'spectral_image_report.{name}')
     report.cpus = 1.0

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1900,6 +1900,9 @@ def _make_spectral_imager(g, config, capture_block_id, name, telstate, target_ma
                     ', '.join(target.name for target, _ in targets))
     view = telstate.view(telstate.join(capture_block_id, name))
     view['targets'] = {target.description: target_mapper(target) for target, _ in targets}
+    # While it is currently just a contiguous range, output the channels as a
+    # list to allow for applying a static mask in future.
+    view['output_channels'] = list(range(output_channels[0], output_channels[1]))
 
 
 def build_postprocess_logical_graph(config, capture_block_id, telstate):

--- a/katsdpcontroller/test/test_product_controller.py
+++ b/katsdpcontroller/test/test_product_controller.py
@@ -910,7 +910,7 @@ class TestSDPController(BaseTestSDPController):
 
         # Check that postprocessing ran and didn't fail
         self.assertEqual(product.capture_blocks, {})
-        self.assertEqual(self.n_batch_tasks, 10)    # 4 continuum, 3x2 spectral
+        self.assertEqual(self.n_batch_tasks, 11)    # 4 continuum, 3x2 spectral, 1 report
 
     async def test_capture_done_disable_batch(self) -> None:
         """Checks that capture-init with override takes effect"""


### PR DESCRIPTION
The spectral imager pipeline now also takes an extra parameter so that it can extract the appropriate information from telstate. This PR should thus be merged at the same time as ska-sa/katsdpimager#38.