### PR TITLE
Work around mypy 0.780 being stricter

### DIFF
--- a/katsdpcontroller/test/test_master_controller.py
+++ b/katsdpcontroller/test/test_master_controller.py
@@ -703,7 +703,7 @@ class TestDeviceServer(asynctest.ClockedTestCase):
                      side_effect=aiokatcp.Client.wait_connected, autospec=True)
         return DelayedManager(
             self.client.request('product-configure', subarray_product, CONFIG),
-            aiokatcp.Client.wait_connected,
+            aiokatcp.Client.wait_connected,         # type: ignore
             None, cancelled)
 
     async def test_product_deconfigure(self) -> None:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,4 @@
 [mypy]
 python_version = 3.6
 ignore_missing_imports = True
+files = katsdpcontroller


### PR DESCRIPTION
It can't see that a function has been mocked out.

Also add the files= to mypy.ini to tell it what to test.