### PR TITLE
Send X-Poweroff-Server header to poweroff_server

### DIFF
--- a/katsdpcontroller/master_controller.py
+++ b/katsdpcontroller/master_controller.py
@@ -1483,7 +1483,7 @@ class DeviceServer(aiokatcp.DeviceServer):
         failed: List[str] = []
         async with aiohttp.ClientSession() as session:
             async def post1(url):
-                async with session.post(url) as resp:
+                async with session.post(url, headers={'X-Poweroff-Server': '1'}) as resp:
                     resp.raise_for_status()
 
             futures = [post1(url) for url in urls]

--- a/katsdpcontroller/test/test_master_controller.py
+++ b/katsdpcontroller/test/test_master_controller.py
@@ -884,8 +884,8 @@ class TestDeviceServer(asynctest.ClockedTestCase):
         await self.client.request('capture-init', 'product')
         reply, informs = await self.client.request('sdp-shutdown')
         self.assertEqual(reply[0], b'127.0.0.144,127.0.0.42')
-        poweroff_mock.assert_any_call(url1, data=None)
-        poweroff_mock.assert_any_call(url2, data=None)
+        poweroff_mock.assert_any_call(url1, headers={'X-Poweroff-Server': '1'}, data=None)
+        poweroff_mock.assert_any_call(url2, headers={'X-Poweroff-Server': '1'}, data=None)
         # The product should have been forcibly deconfigured
         self.assertEqual(self.server._manager.products, {})
 
@@ -914,7 +914,7 @@ class TestDeviceServer(asynctest.ClockedTestCase):
                                     r'^Success: 127\.0\.0\.42 Failed: 127.0.0.144$'):
             await self.client.request('sdp-shutdown')
         # Other machine must still have been powered off
-        poweroff_mock.assert_any_call(url1, data=None)
+        poweroff_mock.assert_any_call(url1, headers={'X-Poweroff-Server': '1'}, data=None)
         # The product should have been forcibly deconfigured
         self.assertEqual(self.server._manager.products, {})
 


### PR DESCRIPTION
This is needed after ska-sa/poweroff_server#2.