### PR TITLE
Update JSON schemas to draft-07

### DIFF
--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -185,18 +185,7 @@ def validate(config):
     """
     from . import generator     # Imported locally to break circular import
 
-    # Error messages for the oneOf parts of the schema are not helpful by
-    # default, because it doesn't know which branch is the relevant one. The
-    # "not" branches are generally just there to make validation conditional
-    # on the type.
-    def relevance(error):
-        return (error.validator == 'not',) + jsonschema.exceptions.relevance(error)
-
-    errors = schemas.PRODUCT_CONFIG.iter_errors(config)
-    error = jsonschema.exceptions.best_match(errors, key=relevance)
-    if error is not None:
-        raise error
-
+    schemas.PRODUCT_CONFIG.validate(config)
     version = StrictVersion(config['version'])
     # All stream sources must match known names, and have the right type
     src_valid_types = {

--- a/katsdpcontroller/schemas/__init__.py
+++ b/katsdpcontroller/schemas/__init__.py
@@ -53,17 +53,6 @@ class MultiVersionValidator(object):
         validator = _make_validator(schema)
         validator.validate(doc)
 
-    def iter_errors(self, doc):
-        try:
-            self._version_validator.validate(doc)
-        except jsonschema.ValidationError:
-            return self._version_validator.iter_errors(doc)
-        else:
-            version = self._get_version(doc)
-            schema = json.loads(self._template.module.validate(version=version))
-            validator = _make_validator(schema)
-            return validator.iter_errors(doc)
-
 
 for name in pkg_resources.resource_listdir(__name__, '.'):
     if name.endswith('.json'):

--- a/katsdpcontroller/schemas/gpus.json
+++ b/katsdpcontroller/schemas/gpus.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "array",
     "items": {
         "type": "object",

--- a/katsdpcontroller/schemas/infiniband_devices.json
+++ b/katsdpcontroller/schemas/infiniband_devices.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "array",
     "items": {
         "type": "string",

--- a/katsdpcontroller/schemas/interfaces.json
+++ b/katsdpcontroller/schemas/interfaces.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "array",
     "items": {
         "type": "object",

--- a/katsdpcontroller/schemas/numa.json
+++ b/katsdpcontroller/schemas/numa.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "array",
     "items": {
         "type": "array",

--- a/katsdpcontroller/schemas/nvidia_container_runtime.json
+++ b/katsdpcontroller/schemas/nvidia_container_runtime.json
@@ -1,4 +1,4 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "boolean"
 }

--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -123,113 +123,76 @@
                     },
                     "allOf": [
                         {
-                            "oneOf": [
-                                {
-                                    "properties": {
-                                        "type": {"enum": ["cbf.antenna_channelised_voltage"]},
-                                        "antennas": {
-                                            "type": "array",
-                                            "minItems": 1,
-                                            "items": {"type": "string"}
-                                        },
-                                        "n_chans": {"$ref": "#/definitions/nonneg_integer"},
-                                        "n_samples_between_spectra": {
-                                            "$ref": "#/definitions/nonneg_integer"
-                                        },
-                                        "n_pols": {"type": "integer", "enum": [1, 2]},
-                                        "adc_sample_rate": {"type": "number"},
-                                        "bandwidth": {"type": "number"},
-                                        "instrument_dev_name": {"type": "string"}
+                            "if": {"properties": {"type": {"const": "cbf.antenna_channelised_voltage"}}},
+                            "then": {
+                                "properties": {
+                                    "antennas": {
+                                        "type": "array",
+                                        "minItems": 1,
+                                        "items": {"type": "string"}
                                     },
-                                    "required": [
-                                        "antennas",
-                                        "n_chans", "n_samples_between_spectra", "n_pols",
-                                        "adc_sample_rate", "bandwidth", "instrument_dev_name"
-                                    ]
+                                    "n_chans": {"$ref": "#/definitions/nonneg_integer"},
+                                    "n_samples_between_spectra": {
+                                        "$ref": "#/definitions/nonneg_integer"
+                                    },
+                                    "n_pols": {"type": "integer", "enum": [1, 2]},
+                                    "adc_sample_rate": {"type": "number"},
+                                    "bandwidth": {"type": "number"},
+                                    "instrument_dev_name": {"type": "string"}
                                 },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "not": {"enum": ["cbf.antenna_channelised_voltage"]}
-                                        }
-                                    }
-                                }
-                            ]
+                                "required": [
+                                    "antennas",
+                                    "n_chans", "n_samples_between_spectra", "n_pols",
+                                    "adc_sample_rate", "bandwidth", "instrument_dev_name"
+                                ]
+                            }
                         },
                         {
-                            "oneOf": [
-                                {
-                                    "properties": {
-                                        "type": {"enum": ["cbf.baseline_correlation_products"]},
-                                        "src_streams": {"$ref": "#/definitions/singleton"},
-                                        "int_time": {"type": "number"},
-                                        "n_bls": {"$ref": "#/definitions/nonneg_integer"},
-                                        "xeng_out_bits_per_sample": {"enum": [32]},
-                                        "n_chans_per_substream": {
-                                            "$ref": "#/definitions/nonneg_integer"
-                                        },
-                                        "instrument_dev_name": {"type": "string"},
-                                        "simulate": {"$ref": "#/definitions/simulate"}
+                            "if": {"properties": {"type": {"const": "cbf.baseline_correlation_products"}}},
+                            "then": {
+                                "properties": {
+                                    "src_streams": {"$ref": "#/definitions/singleton"},
+                                    "int_time": {"type": "number"},
+                                    "n_bls": {"$ref": "#/definitions/nonneg_integer"},
+                                    "xeng_out_bits_per_sample": {"enum": [32]},
+                                    "n_chans_per_substream": {
+                                        "$ref": "#/definitions/nonneg_integer"
                                     },
-                                    "required": [
-                                        "src_streams", "int_time", "n_bls",
-                                        "xeng_out_bits_per_sample", "n_chans_per_substream",
-                                        "instrument_dev_name"
-                                    ]
+                                    "instrument_dev_name": {"type": "string"},
+                                    "simulate": {"$ref": "#/definitions/simulate"}
                                 },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "not": {"enum": ["cbf.baseline_correlation_products"]}
-                                        }
-                                    }
-                                }
-                            ]
+                                "required": [
+                                    "src_streams", "int_time", "n_bls",
+                                    "xeng_out_bits_per_sample", "n_chans_per_substream",
+                                    "instrument_dev_name"
+                                ]
+                            }
                         },
                         {
-                            "oneOf": [
-                                {
-                                    "properties": {
-                                        "type": {"enum": ["cbf.tied_array_channelised_voltage"]},
-                                        "src_streams": {"$ref": "#/definitions/singleton"},
-                                        "beng_out_bits_per_sample": {"enum": [8]},
-                                        "spectra_per_heap": {
-                                            "$ref": "#/definitions/nonneg_integer"
-                                        },
-                                        "n_chans_per_substream": {
-                                            "$ref": "#/definitions/nonneg_integer"
-                                        },
-                                        "instrument_dev_name": {"type": "string"},
-                                        "simulate": {"$ref": "#/definitions/simulate"}
+                            "if": {"properties": {"type": {"const": "cbf.tied_array_channelised_voltage"}}},
+                            "then": {
+                                "properties": {
+                                    "src_streams": {"$ref": "#/definitions/singleton"},
+                                    "beng_out_bits_per_sample": {"enum": [8]},
+                                    "spectra_per_heap": {
+                                        "$ref": "#/definitions/nonneg_integer"
                                     },
-                                    "required": [
-                                        "src_streams", "beng_out_bits_per_sample",
-                                        "spectra_per_heap",
-                                        "n_chans_per_substream", "instrument_dev_name"
-                                    ]
+                                    "n_chans_per_substream": {
+                                        "$ref": "#/definitions/nonneg_integer"
+                                    },
+                                    "instrument_dev_name": {"type": "string"},
+                                    "simulate": {"$ref": "#/definitions/simulate"}
                                 },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "not": {"enum": ["cbf.tied_array_channelised_voltage"]}
-                                        }
-                                    }
-                                }
-                            ]
+                                "required": [
+                                    "src_streams", "beng_out_bits_per_sample",
+                                    "spectra_per_heap",
+                                    "n_chans_per_substream", "instrument_dev_name"
+                                ]
+                            }
                         },
                         {
-                            "oneOf": [
-                                {
-                                    "properties": {
-                                        "type": {"enum": ["cam.http"]}
-                                    }
-                                },
-                                {
-                                    "properties": {
-                                        "type": {"not": {"enum": ["cam.http"]}}
-                                    }
-                                }
-                            ]
+                            "if": {"properties": {"type": {"const": "cam.http"}}},
+                            "then": {}
                         }
                     ]
                 }
@@ -267,254 +230,198 @@
                     "additionalProperties": true,
                     "allOf": [
                         {
-                            "oneOf": [
-                                {
-                                    "properties": {
-                                        "type": {"enum": ["{{sdp_vis}}"]},
-                                        "src_streams": {"$ref": "#/definitions/singleton"},
-                                        "output_int_time": {"type": "number"},
-                                        "output_channels": {"$ref": "#/definitions/channel_range"},
-                                        "continuum_factor": {
-                                            "$ref": "#/definitions/positive_integer"
-                                        },
+                            "if": {"properties": {"type": {"const": "{{sdp_vis}}"}}},
+                            "then": {
+                                "properties": {
+                                    "type": {},
+                                    "src_streams": {"$ref": "#/definitions/singleton"},
+                                    "output_int_time": {"type": "number"},
+                                    "output_channels": {"$ref": "#/definitions/channel_range"},
+                                    "continuum_factor": {
+                                        "$ref": "#/definitions/positive_integer"
+                                    },
 {% if version >= "2.0" %}
-                                        "archive": {"type": "boolean"},
+                                    "archive": {"type": "boolean"},
 {% endif %}
-                                        "excise": {"type": "boolean", "default": true}
-                                    },
-                                    "required": [
-                                        "src_streams", "output_int_time", "continuum_factor"
-                                    ],
-                                    "additionalProperties": false
+                                    "excise": {"type": "boolean", "default": true}
                                 },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "not": {"enum": ["{{sdp_vis}}"]}
-                                        }
-                                    }
-                                }
-                            ]
+                                "required": [
+                                    "src_streams", "output_int_time", "continuum_factor"
+                                ],
+                                "additionalProperties": false
+                            }
                         },
                         {
-                            "oneOf": [
-                                {
-                                    "properties": {
-                                        "type": {"enum": ["sdp.beamformer_engineering"]},
-                                        "src_streams": {"$ref": "#/definitions/pair"},
-                                        "output_channels": {"$ref": "#/definitions/channel_range"},
-                                        "store": {
-                                            "enum": ["ram", "ssd"]
-                                        }
-                                    },
-                                    "required": ["src_streams", "store"],
-                                    "additionalProperties": false
-                                },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "not": {"enum": ["sdp.beamformer_engineering"]}
-                                        }
+                            "if": {"properties": {"type": {"const": "sdp.beamformer_engineering"}}},
+                            "then": {
+                                "properties": {
+                                    "type": {},
+                                    "src_streams": {"$ref": "#/definitions/pair"},
+                                    "output_channels": {"$ref": "#/definitions/channel_range"},
+                                    "store": {
+                                        "enum": ["ram", "ssd"]
                                     }
-                                }
-                            ]
+                                },
+                                "required": ["src_streams", "store"],
+                                "additionalProperties": false
+                            }
                         },
                         {
-                            "oneOf": [
-                                {
-                                    "properties": {
-                                        "type": {"enum": ["sdp.beamformer"]},
-                                        "src_streams": {"$ref": "#/definitions/pair"}
-                                    },
-                                    "required": ["src_streams"],
-                                    "additionalProperties": false
+                            "if": {"properties": {"type": {"const": "sdp.beamformer"}}},
+                            "then": {
+                                "properties": {
+                                    "type": {},
+                                    "src_streams": {"$ref": "#/definitions/pair"}
                                 },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "not": {"enum": ["sdp.beamformer"]}
-                                        }
-                                    }
-                                }
-                            ]
+                                "required": ["src_streams"],
+                                "additionalProperties": false
+                            }
                         }
 {% if version >= "1.1" %}
                         ,
                         {
-                            "oneOf": [
-                                {
-                                    "properties": {
-                                        "type": {"enum": ["sdp.cal"]},
-                                        "src_streams": {"$ref": "#/definitions/singleton"},
-                                        "parameters": {
-                                            "type": "object",
-                                            "properties": {
-                                                "preferred_refants": {
-                                                    "type": "array",
-                                                    "items": {"type": "string"},
-                                                    "minItems": 1,
-                                                    "uniqueItems": true
-                                                },
-                                                "k_solint": {"$ref": "#/definitions/positive_number"},
-                                                "k_chan_sample": {"$ref": "#/definitions/positive_integer"},
-                                                "k_bchan": {"$ref": "#/definitions/nonneg_integer"},
-                                                "k_echan": {"$ref": "#/definitions/nonneg_integer"},
-                                                "kcross_chanave": {"$ref": "#/definitions/positive_integer"},
-                                                "bp_solint": {"$ref": "#/definitions/positive_number"},
-                                                "g_solint": {"$ref": "#/definitions/positive_number"},
-                                                "g_bchan": {"$ref": "#/definitions/nonneg_integer"},
-                                                "g_echan": {"$ref": "#/definitions/nonneg_integer"},
-                                                "rfi_calib_nsigma": {"$ref": "#/definitions/positive_number"},
-                                                "rfi_targ_nsigma": {"$ref": "#/definitions/positive_number"},
-                                                "rfi_windows_freq": {
-                                                    "type": "array",
-                                                    "items": {"$ref": "#/definitions/positive_integer"},
-                                                    "minItems": 1,
-                                                    "uniqueItems": true
-                                                },
-                                                "rfi_average_freq": {"$ref": "#/definitions/positive_integer"},
-                                                "rfi_targ_spike_width_freq": {"$ref": "#/definitions/positive_number"},
-                                                "rfi_calib_spike_width_freq": {"$ref": "#/definitions/positive_number"},
-                                                "rfi_spike_width_time": {"$ref": "#/definitions/positive_number"},
-                                                "rfi_extend_freq": {"$ref": "#/definitions/nonneg_integer"},
-                                                "rfi_freq_chunks": {"$ref": "#/definitions/positive_integer"}
+                            "if": {"properties": {"type": {"const": "sdp.cal"}}},
+                            "then": {
+                                "properties": {
+                                    "type": {},
+                                    "src_streams": {"$ref": "#/definitions/singleton"},
+                                    "parameters": {
+                                        "type": "object",
+                                        "properties": {
+                                            "preferred_refants": {
+                                                "type": "array",
+                                                "items": {"type": "string"},
+                                                "minItems": 1,
+                                                "uniqueItems": true
                                             },
-                                            "additionalProperties": false
+                                            "k_solint": {"$ref": "#/definitions/positive_number"},
+                                            "k_chan_sample": {"$ref": "#/definitions/positive_integer"},
+                                            "k_bchan": {"$ref": "#/definitions/nonneg_integer"},
+                                            "k_echan": {"$ref": "#/definitions/nonneg_integer"},
+                                            "kcross_chanave": {"$ref": "#/definitions/positive_integer"},
+                                            "bp_solint": {"$ref": "#/definitions/positive_number"},
+                                            "g_solint": {"$ref": "#/definitions/positive_number"},
+                                            "g_bchan": {"$ref": "#/definitions/nonneg_integer"},
+                                            "g_echan": {"$ref": "#/definitions/nonneg_integer"},
+                                            "rfi_calib_nsigma": {"$ref": "#/definitions/positive_number"},
+                                            "rfi_targ_nsigma": {"$ref": "#/definitions/positive_number"},
+                                            "rfi_windows_freq": {
+                                                "type": "array",
+                                                "items": {"$ref": "#/definitions/positive_integer"},
+                                                "minItems": 1,
+                                                "uniqueItems": true
+                                            },
+                                            "rfi_average_freq": {"$ref": "#/definitions/positive_integer"},
+                                            "rfi_targ_spike_width_freq": {"$ref": "#/definitions/positive_number"},
+                                            "rfi_calib_spike_width_freq": {"$ref": "#/definitions/positive_number"},
+                                            "rfi_spike_width_time": {"$ref": "#/definitions/positive_number"},
+                                            "rfi_extend_freq": {"$ref": "#/definitions/nonneg_integer"},
+                                            "rfi_freq_chunks": {"$ref": "#/definitions/positive_integer"}
                                         },
-                                        "models": {
-                                            "type": "object",
-                                            "additionalProperties": {"type": "string"}
-                                        },
-{% if version >= "2.1" %}
-                                        "max_scans": {"$ref": "#/definitions/positive_integer"},
-{% endif %}
-                                        "buffer_time": {"$ref": "#/definitions/positive_number"}
+                                        "additionalProperties": false
                                     },
-                                    "required": ["src_streams"],
-                                    "additionalProperties": false
+                                    "models": {
+                                        "type": "object",
+                                        "additionalProperties": {"type": "string"}
+                                    },
+{% if version >= "2.1" %}
+                                    "max_scans": {"$ref": "#/definitions/positive_integer"},
+{% endif %}
+                                    "buffer_time": {"$ref": "#/definitions/positive_number"}
                                 },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "not": {"enum": ["sdp.cal"]}
-                                        }
-                                    }
-                                }
-                            ]
+                                "required": ["src_streams"],
+                                "additionalProperties": false
+                            }
                         }
 {% endif %}
 {% if version >= "2.0" %}
                         ,
                         {
-                            "oneOf": [
-                                {
-                                    "properties": {
-                                        "type": {"enum": ["sdp.flags"]},
-                                        "src_streams": {"$ref": "#/definitions/singleton"},
-                                        "calibration": {"$ref": "#/definitions/singleton"},
-                                        "rate_ratio": {
-                                            "type": "number",
-                                            "exclusiveMinimum": 1.0
-                                        },
-                                        "archive": {"type": "boolean"}
+                            "if": {"properties": {"type": {"const": "sdp.flags"}}},
+                            "then": {
+                                "properties": {
+                                    "type": {},
+                                    "src_streams": {"$ref": "#/definitions/singleton"},
+                                    "calibration": {"$ref": "#/definitions/singleton"},
+                                    "rate_ratio": {
+                                        "type": "number",
+                                        "exclusiveMinimum": 1.0
                                     },
-                                    "required": ["src_streams", "calibration", "archive"],
-                                    "additionalProperties": false
+                                    "archive": {"type": "boolean"}
                                 },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "not": {"enum": ["sdp.flags"]}
-                                        }
-                                    }
-                                }
-                            ]
+                                "required": ["src_streams", "calibration", "archive"],
+                                "additionalProperties": false
+                            }
                         }
 {% endif %}
 {% if version >= "2.2" %}
                         ,
                         {
-                            "oneOf": [
-                                {
-                                    "properties": {
-                                        "type": {"enum": ["sdp.continuum_image"]},
-                                        "src_streams": {"$ref": "#/definitions/singleton"},
-                                        "uvblavg_parameters": {"$ref": "#/definitions/continuum_parameters"},
-                                        "mfimage_parameters": {"$ref": "#/definitions/continuum_parameters"},
+                            "if": {"properties": {"type": {"const": "sdp.continuum_image"}}},
+                            "then": {
+                                "properties": {
+                                    "type": {},
+                                    "src_streams": {"$ref": "#/definitions/singleton"},
+                                    "uvblavg_parameters": {"$ref": "#/definitions/continuum_parameters"},
+                                    "mfimage_parameters": {"$ref": "#/definitions/continuum_parameters"},
 {% if version >= "2.5" %}
-                                        "min_time": {"$ref": "#/definitions/positive_number"},
+                                    "min_time": {"$ref": "#/definitions/positive_number"},
 {% endif %}
-                                        "max_realtime": {"$ref": "#/definitions/nonneg_number"}
-                                    },
-                                    "required": ["src_streams"],
-                                    "additionalProperties": false
+                                    "max_realtime": {"$ref": "#/definitions/nonneg_number"}
                                 },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "not": {"enum": ["sdp.continuum_image"]}
-                                        }
-                                    }
-                                }
-                            ]
+                                "required": ["src_streams"],
+                                "additionalProperties": false
+                            }
                         }
 {% endif %}
 {% if version >= "2.4" %}
                         ,
                         {
-                            "oneOf": [
-                                {
-                                    "properties": {
-                                        "type": {"enum": ["sdp.spectral_image"]},
-                                        "src_streams": {
-                                            "type": "array",
-                                            "minItems": 1,
-                                            "maxItems": 2
-                                        },
+                            "if": {"properties": {"type": {"const": "sdp.spectral_image"}}},
+                            "then": {
+                                "properties": {
+                                    "type": {},
+                                    "src_streams": {
+                                        "type": "array",
+                                        "minItems": 1,
+                                        "maxItems": 2
+                                    },
 {% if version >= "2.5" %}
-                                        "min_time": {"$ref": "#/definitions/positive_number"},
+                                    "min_time": {"$ref": "#/definitions/positive_number"},
 {% endif %}
 {% if version >= "2.6" %}
-                                        "parameters": {
-                                            "type": "object",
-                                            "properties": {
-                                                "robustness": {"type": "number"},
-                                                "grid_oversample": {"$ref": "#/definitions/positive_integer"},
-                                                "kernel_image_oversample": {"$ref": "#/definitions/positive_integer"},
-                                                "w_slices": {"$ref": "#/definitions/positive_integer"},
-                                                "aa_width": {"$ref": "#/definitions/positive_number"},
-                                                "kernel_width": {"$ref": "#/definitions/positive_integer"},
-                                                "eps_w": {"$ref": "#/definitions/positive_number"},
-                                                "primary_beam_cutoff": {"$ref": "#/definitions/positive_number"},
-                                                "psf_cutoff": {"$ref": "#/definitions/positive_number"},
-                                                "psf_limit": {"$ref": "#/definitions/positive_number"},
-                                                "loop_gain": {"$ref": "#/definitions/positive_number"},
-                                                "major_gain": {"$ref": "#/definitions/positive_number"},
-                                                "threshold": {"$ref": "#/definitions/positive_number"},
-                                                "major": {"$ref": "#/definitions/positive_integer"},
-                                                "minor": {"$ref": "#/definitions/positive_integer"},
-                                                "border": {"$ref": "#/definitions/positive_number"},
-                                                "clean_mode": {
-                                                    "type": "string",
-                                                    "enum": ["I", "IQUV"]
-                                                }
-                                            },
-                                            "additionalProperties": false
+                                    "parameters": {
+                                        "type": "object",
+                                        "properties": {
+                                            "robustness": {"type": "number"},
+                                            "grid_oversample": {"$ref": "#/definitions/positive_integer"},
+                                            "kernel_image_oversample": {"$ref": "#/definitions/positive_integer"},
+                                            "w_slices": {"$ref": "#/definitions/positive_integer"},
+                                            "aa_width": {"$ref": "#/definitions/positive_number"},
+                                            "kernel_width": {"$ref": "#/definitions/positive_integer"},
+                                            "eps_w": {"$ref": "#/definitions/positive_number"},
+                                            "primary_beam_cutoff": {"$ref": "#/definitions/positive_number"},
+                                            "psf_cutoff": {"$ref": "#/definitions/positive_number"},
+                                            "psf_limit": {"$ref": "#/definitions/positive_number"},
+                                            "loop_gain": {"$ref": "#/definitions/positive_number"},
+                                            "major_gain": {"$ref": "#/definitions/positive_number"},
+                                            "threshold": {"$ref": "#/definitions/positive_number"},
+                                            "major": {"$ref": "#/definitions/positive_integer"},
+                                            "minor": {"$ref": "#/definitions/positive_integer"},
+                                            "border": {"$ref": "#/definitions/positive_number"},
+                                            "clean_mode": {
+                                                "type": "string",
+                                                "enum": ["I", "IQUV"]
+                                            }
                                         },
-{% endif %}
-                                        "output_channels": {"$ref": "#/definitions/channel_range"}
+                                        "additionalProperties": false
                                     },
-                                    "required": ["src_streams"],
-                                    "additionalProperties": false
+{% endif %}
+                                    "output_channels": {"$ref": "#/definitions/channel_range"}
                                 },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "not": {"enum": ["sdp.spectral_image"]}
-                                        }
-                                    }
-                                }
-                            ]
+                                "required": ["src_streams"],
+                                "additionalProperties": false
+                            }
                         }
 {% endif %}
                     ]

--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -154,7 +154,7 @@
                                     "src_streams": {"$ref": "#/definitions/singleton"},
                                     "int_time": {"type": "number"},
                                     "n_bls": {"$ref": "#/definitions/nonneg_integer"},
-                                    "xeng_out_bits_per_sample": {"enum": [32]},
+                                    "xeng_out_bits_per_sample": {"const": 32},
                                     "n_chans_per_substream": {
                                         "$ref": "#/definitions/nonneg_integer"
                                     },
@@ -173,7 +173,7 @@
                             "then": {
                                 "properties": {
                                     "src_streams": {"$ref": "#/definitions/singleton"},
-                                    "beng_out_bits_per_sample": {"enum": [8]},
+                                    "beng_out_bits_per_sample": {"const": 8},
                                     "spectra_per_heap": {
                                         "$ref": "#/definitions/nonneg_integer"
                                     },
@@ -453,7 +453,7 @@
         },
         "version": {
             "type": "string",
-            "enum": ["{{version}}"]
+            "const": "{{version}}"
         }
     }
 }

--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -1,6 +1,6 @@
 {% macro validate_version() %}
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": ["version"],
     "properties": {
@@ -20,7 +20,7 @@
 {% endif %}
 
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "stream_name": {
             "type": "string",
@@ -48,8 +48,7 @@
         },
         "positive_number": {
             "type": "number",
-            "minimum": 0.0,
-            "exclusiveMinimum": true
+            "exclusiveMinimum": 0.0
         },
         "continuum_parameters": {
             "type": "object",
@@ -415,8 +414,7 @@
                                         "calibration": {"$ref": "#/definitions/singleton"},
                                         "rate_ratio": {
                                             "type": "number",
-                                            "minimum": 1.0,
-                                            "exclusiveMinimum": true
+                                            "exclusiveMinimum": 1.0
                                         },
                                         "archive": {"type": "boolean"}
                                     },

--- a/katsdpcontroller/schemas/streams.json
+++ b/katsdpcontroller/schemas/streams.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "additionalProperties": {
         "type": "object",

--- a/katsdpcontroller/schemas/volumes.json
+++ b/katsdpcontroller/schemas/volumes.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "array",
     "items": {
         "type": "object",

--- a/katsdpcontroller/schemas/zk_state.json.j2
+++ b/katsdpcontroller/schemas/zk_state.json.j2
@@ -1,6 +1,6 @@
 {% macro validate_version() %}
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": ["version"],
     "properties": {
@@ -15,7 +15,7 @@
 
 {% macro validate(version) %}
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "additionalProperties": false,
     "required": ["version", "next_capture_block_id", "next_multicast_group", "products"],


### PR DESCRIPTION
Bring all the JSON schemas up to the latest version of the standard that is supported by the Python jsonschema package (it doesn't yet appear to support the newer 2019-09 version).

In the case of the product_config, this has allowed for some nice simplification/readability improvements by using the if-then construct.