### PR TITLE
Implement product-config schema version 3

### DIFF
--- a/katsdpcontroller/dashboard.py
+++ b/katsdpcontroller/dashboard.py
@@ -175,7 +175,7 @@ class Dashboard:
         async def top_level(n_intervals):
             if sdp_controller.product is None:
                 return {}, {'display': 'none'}, '', '', [], [], []
-            config = json.dumps(sdp_controller.product.config, indent=2, sort_keys=True)
+            config = json.dumps(sdp_controller.product.config_dict, indent=2, sort_keys=True)
 
             tasks = _get_tasks(sdp_controller.product)
             task_data = [

--- a/katsdpcontroller/defaults.py
+++ b/katsdpcontroller/defaults.py
@@ -1,0 +1,22 @@
+"""Constants controlling tunable policies."""
+
+#: GPU to target when not running develop mode
+INGEST_GPU_NAME = 'GeForce GTX TITAN X'
+#: Maximum number of custom signals requested by (correlator) timeplot
+TIMEPLOT_MAX_CUSTOM_SIGNALS = 256
+#: Target size of objects in the object store
+WRITER_OBJECT_SIZE = 20e6    # 20 MB
+#: Maximum channels per chunk for spectral imager
+SPECTRAL_OBJECT_CHANNELS = 128
+#: Minimum observation time for continuum imager (seconds)
+CONTINUUM_MIN_TIME = 15 * 60.0     # 15 minutes
+#: Minimum observation time for spectral imager (seconds)
+SPECTRAL_MIN_TIME = 3600.0         # 1 hour
+#: Size of cal buffer in seconds
+CAL_BUFFER_TIME = 25 * 60.0        # 25 minutes (allows a single batch of 15 minutes)
+#: Maximum number of scans to include in report
+CAL_MAX_SCANS = 1000
+#: Speed at which flags are transmitted, relative to real time
+FLAGS_RATE_RATIO = 8.0
+#: Alignment constraint for `int_time` in katcbfsim
+KATCBFSIM_SPECTRA_PER_HEAP = 256

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -90,6 +90,8 @@ CONFIG_VOL = scheduler.VolumeRequest('config', '/var/kat/config', 'RW')
 WRITER_OBJECT_SIZE = 20e6    # 20 MB
 #: Maximum channels per chunk for spectral imager
 SPECTRAL_OBJECT_CHANNELS = 128
+
+# TODO: remove these
 #: Minimum observation time for continuum imager (seconds)
 DEFAULT_CONTINUUM_MIN_TIME = 15 * 60     # 15 minutes
 #: Minimum observation time for spectral imager (seconds)

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -88,14 +88,6 @@ WRITER_OBJECT_SIZE = 20e6    # 20 MB
 #: Maximum channels per chunk for spectral imager
 SPECTRAL_OBJECT_CHANNELS = 128
 
-# TODO: remove these
-#: Speed at which flags are transmitted, relative to real time
-FLAGS_RATE_RATIO = 8.0
-#: Minimum observation time for continuum imager (seconds)
-DEFAULT_CONTINUUM_MIN_TIME = 15 * 60     # 15 minutes
-#: Minimum observation time for spectral imager (seconds)
-DEFAULT_SPECTRAL_MIN_TIME = 3600         # 1 hour
-
 logger = logging.getLogger(__name__)
 
 
@@ -805,7 +797,10 @@ def _make_cal(g: networkx.MultiDiGraph,
         cal.interfaces = [scheduler.InterfaceRequest('sdp_10g')]
         # Note: these scale the fixed overheads too, so is not strictly accurate.
         cal.interfaces[0].bandwidth_in = vis.net_bandwidth() / n_cal
-        cal.interfaces[0].bandwidth_out = vis.flag_bandwidth() * FLAGS_RATE_RATIO / n_cal
+        cal.interfaces[0].bandwidth_out = sum(
+            flags_stream.net_bandwidth() / n_cal
+            for flags in flags_streams
+        )
         cal.ports = ['port', 'dask_diagnostics', 'aiomonitor_port', 'aioconsole_port']
         cal.wait_ports = ['port']
         cal.gui_urls = [{

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -78,8 +78,6 @@ _N32_32 = 32 * 33 * 2 * 32768
 _N16_32 = 16 * 17 * 2 * 32768
 #: Maximum number of custom signals requested by (correlator) timeplot
 TIMEPLOT_MAX_CUSTOM_SIGNALS = 256
-#: Speed at which flags are transmitted, relative to real time
-FLAGS_RATE_RATIO = 8.0
 #: Volume serviced by katsdptransfer to transfer results to the archive
 DATA_VOL = scheduler.VolumeRequest('data', '/var/kat/data', 'RW')
 #: Like DATA_VOL, but for high speed data to be transferred to an object store
@@ -92,6 +90,8 @@ WRITER_OBJECT_SIZE = 20e6    # 20 MB
 SPECTRAL_OBJECT_CHANNELS = 128
 
 # TODO: remove these
+#: Speed at which flags are transmitted, relative to real time
+FLAGS_RATE_RATIO = 8.0
 #: Minimum observation time for continuum imager (seconds)
 DEFAULT_CONTINUUM_MIN_TIME = 15 * 60     # 15 minutes
 #: Minimum observation time for spectral imager (seconds)

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -288,7 +288,7 @@ def _make_cbf_simulator(g: networkx.MultiDiGraph,
         }
         sources = configuration.simulation.sources
         if sources:
-            conf['cbf_sim_sources'] = [{'description': str(s)} for s in sources]
+            conf['cbf_sim_sources'] = [{'description': s.description} for s in sources]
         if isinstance(stream, product_config.SimBaselineCorrelationProductsStream):
             conf.update({
                 'cbf_int_time': stream.int_time,
@@ -300,7 +300,7 @@ def _make_cbf_simulator(g: networkx.MultiDiGraph,
                 'beamformer_bits': stream.bits_per_sample
             })
         conf['cbf_center_freq'] = float(stream.centre_frequency)
-        conf['cbf_antennas'] = [{'description': str(ant)}
+        conf['cbf_antennas'] = [{'description': ant.description}
                                 for ant in stream.antenna_channelised_voltage.antenna_objects]
         return conf
 

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -503,8 +503,8 @@ def _beamformer_timeplot_data_rate(
 
     Parameters
     ----------
-    info
-        Info about the single-pol beam.
+    stream
+        The single-pol beam stream.
     """
     # XXX The beamformer signal displays are still in development, but the
     # rates are tiny. Until the protocol is finalised we'll just hardcode a

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -408,12 +408,12 @@ def _make_timeplot_correlator(g: networkx.MultiDiGraph,
     # Exact requirement not known (also depends on number of users). Give it
     # 2 CPUs (max it can use) for 16 antennas, 32K channels and scale from there.
     # Lower bound (from inspection) to cater for fixed overheads.
-    cpus = max(2 * min(1.0, stream.n_baselines * stream.n_spectral_chans / _N16_32), 0.3)
+    cpus = max(2 * min(1.0, stream.n_spectral_vis / _N16_32), 0.3)
 
     # Give timeplot enough memory for 256 time samples, but capped at 16GB.
     # This formula is based on data.py in katsdpdisp.
     percentiles = 5 * 8
-    timeplot_slot = stream.n_spectral_chans * (stream.n_baselines + percentiles) * 8
+    timeplot_slot = (stream.n_spectral_vis + stream.n_spectral_chans * percentiles) * 8
     timeplot_buffer = min(256 * timeplot_slot, 16 * 1024**3)
 
     return _make_timeplot(

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -5,7 +5,7 @@ import time
 import copy
 import urllib
 import os.path
-from typing import Dict, Set
+from typing import List, Dict, Tuple, Set, Sequence, Type, Union, Optional, Any
 
 import addict
 import networkx
@@ -16,7 +16,7 @@ import katdal.datasources
 import katpoint
 from katsdptelstate.endpoint import Endpoint, endpoint_list_parser
 
-from katsdpcontroller import scheduler
+from katsdpcontroller import scheduler, product_config
 from katsdpcontroller.tasks import (
     SDPLogicalTask, SDPPhysicalTask, LogicalGroup,
     CaptureBlockState, KatcpTransition)
@@ -154,12 +154,6 @@ class IngestTask(SDPPhysicalTask):
         await super().resolve(resolver, graph, image_path)
 
 
-def is_develop(config):
-    # This gets called as part of validation, so it cannot assume that
-    # normalise() has been called.
-    return config['config'].get('develop', False)
-
-
 def _mb(value):
     """Convert bytes to mebibytes"""
     return value / 1024**2
@@ -190,229 +184,27 @@ def _bandwidth(size, time, ratio=1.05, overhead=128):
     return (size * ratio + overhead) * 8 / time
 
 
-class CBFStreamInfo:
-    """Wraps a CBF stream from the config to provide convenient access to
-    calculated quantities.
-
-    It only supports streams that are ``cbf.antenna_channelised_voltage`` or
-    have such a stream upstream.
-    """
-    def __init__(self, config, name):
-        self.name = name
-        self.raw = config['inputs'][name]
-        self.config = config
-        acv = self.raw
-        while acv['type'] != 'cbf.antenna_channelised_voltage':
-            src = acv['src_streams'][0]
-            acv = config['inputs'][src]
-        self.antenna_channelised_voltage = acv
-
-    @property
-    def antennas(self):
-        return self.antenna_channelised_voltage['antennas']
-
-    @property
-    def n_antennas(self):
-        return len(self.antennas)
-
-    @property
-    def n_channels(self):
-        return self.antenna_channelised_voltage['n_chans']
-
-    @property
-    def n_pols(self):
-        return self.antenna_channelised_voltage['n_pols']
-
-    @property
-    def bandwidth(self):
-        return self.antenna_channelised_voltage['bandwidth']
-
-    @property
-    def adc_sample_rate(self):
-        return self.antenna_channelised_voltage['adc_sample_rate']
-
-    @property
-    def n_samples_between_spectra(self):
-        return self.antenna_channelised_voltage['n_samples_between_spectra']
-
-    @property
-    def n_endpoints(self):
-        url = self.raw['url']
-        parts = urllib.parse.urlsplit(url)
-        return len(endpoint_list_parser(None)(parts.hostname))
-
-
-class VisInfo:
-    """Mixin for info classes to compute visibility info from baselines and channels."""
-    @property
-    def n_vis(self):
-        return self.n_baselines * self.n_channels
-
-
-class BaselineCorrelationProductsInfo(VisInfo, CBFStreamInfo):
-    @property
-    def n_baselines(self):
-        return self.raw['n_bls']
-
-    @property
-    def int_time(self):
-        return self.raw['int_time']
-
-    @property
-    def n_channels_per_substream(self):
-        return self.raw['n_chans_per_substream']
-
-    @property
-    def size(self):
-        """Size of frame in bytes"""
-        return self.n_vis * 8     # size of complex64
-
-    def net_bandwidth(self, ratio=1.05, overhead=128):
-        return _bandwidth(self.size, self.int_time, ratio, overhead)
-
-
-class TiedArrayChannelisedVoltageInfo(CBFStreamInfo):
-    @property
-    def n_channels_per_substream(self):
-        return self.raw['n_chans_per_substream']
-
-    @property
-    def n_substreams(self):
-        return self.n_channels // self.n_channels_per_substream
-
-    @property
-    def size(self):
-        """Size of frame in bytes"""
-        return (self.raw['beng_out_bits_per_sample'] * 2
-                * self.raw['spectra_per_heap']
-                * self.n_channels) // 8
-
-    @property
-    def int_time(self):
-        """Interval between heaps, in seconds"""
-        return self.raw['spectra_per_heap'] * self.n_samples_between_spectra / self.adc_sample_rate
-
-    def net_bandwidth(self, ratio=1.05, overhead=128):
-        """Network bandwidth in bits per second"""
-        heap_size = self.size / self.n_substreams
-        return _bandwidth(heap_size, self.int_time, ratio, overhead) * self.n_substreams
-
-
-class L0Info(VisInfo):
-    """Query properties of an L0 data stream"""
-    def __init__(self, config, name):
-        self.raw = config['outputs'][name]
-        self.src_info = BaselineCorrelationProductsInfo(config, self.raw['src_streams'][0])
-
-    @property
-    def output_channels(self):
-        return tuple(self.raw['output_channels'])
-
-    @property
-    def n_channels(self):
-        rng = self.output_channels
-        return (rng[1] - rng[0]) // self.raw['continuum_factor']
-
-    @property
-    def n_pols(self):
-        """Number of polarisations per antenna."""
-        return self.src_info.n_pols
-
-    @property
-    def n_antennas(self):
-        return self.src_info.n_antennas
-
-    @property
-    def n_baselines(self):
-        a = self.n_antennas
-        return a * (a + 1) // 2 * self.n_pols**2
-
-    @property
-    def int_time(self):
-        # Round to nearest multiple of CBF integration time
-        ratio = max(1, int(round(self.raw['output_int_time'] / self.src_info.int_time)))
-        return ratio * self.src_info.int_time
-
-    @property
-    def size(self):
-        """Size of single frame in bytes"""
-        # complex64 for vis, uint8 for weights and flags, float32 for weights_channel
-        return self.n_vis * BYTES_PER_VFW + self.n_channels * 4
-
-    @property
-    def flag_size(self):
-        return self.n_vis * BYTES_PER_FLAG
-
-    def net_bandwidth(self, ratio=1.05, overhead=128):
-        return _bandwidth(self.size, self.int_time, ratio, overhead)
-
-    def flag_bandwidth(self, ratio=1.05, overhead=128):
-        return _bandwidth(self.flag_size, self.int_time, ratio, overhead)
-
-
-class BeamformerInfo:
-    """Query properties of an SDP beamformer stream.
-
-    Each stream corresponds to a single-pol beam. It supports both the
-    ``sdp.beamformer_engineering`` and ``sdp.beamformer`` stream types.
-    """
-    def __init__(self, config, name, src_name):
-        self.raw = config['outputs'][name]
-        if src_name not in self.raw['src_streams']:
-            raise KeyError('{} not a source of {}'.format(src_name, name))
-        self.src_info = TiedArrayChannelisedVoltageInfo(config, src_name)
-        requested_channels = tuple(self.raw.get('output_channels', (0, self.src_info.n_channels)))
-        # Round to fit the endpoints, as required by bf_ingest.
-        channels_per_endpoint = self.src_info.n_channels // self.src_info.n_endpoints
-        self.output_channels = (_round_down(requested_channels[0], channels_per_endpoint),
-                                _round_up(requested_channels[1], channels_per_endpoint))
-        if self.output_channels != requested_channels:
-            logger.info('Rounding output channels for %s from %s to %s',
-                        name, requested_channels, self.output_channels)
-
-    @property
-    def n_channels(self):
-        return self.output_channels[1] - self.output_channels[0]
-
-    @property
-    def size(self):
-        """Size of single frame in bytes"""
-        return self.src_info.size * self.n_channels // self.src_info.n_channels
-
-    @property
-    def int_time(self):
-        """Interval between heaps, in seconds"""
-        return self.src_info.int_time
-
-    @property
-    def n_substreams(self):
-        return self.n_channels // self.src_info.n_channels_per_substream
-
-    def net_bandwidth(self, ratio=1.05, overhead=128):
-        """Network bandwidth in bits per second"""
-        heap_size = self.size / self.n_substreams
-        return _bandwidth(heap_size, self.int_time, ratio, overhead) * self.n_substreams
-
-
-def find_node(g, name):
+def find_node(g: networkx.MultiDiGraph, name: str) -> scheduler.LogicalNode:
     for node in g:
         if node.name == name:
             return node
     raise KeyError('no node called ' + name)
 
 
-def _make_telstate(g, config):
+def _make_telstate(g: networkx.MultiDiGraph,
+                   configuration: product_config.Configuration) -> scheduler.LogicalNode:
     # Pointing sensors can account for substantial memory per antennas over a
     # long-lived subarray.
     n_antennas = 0
-    for stream in config['inputs'].values():
-        if stream['type'] == 'cbf.antenna_channelised_voltage':
-            n_antennas += len(stream['antennas'])
+    for stream in configuration.streams:
+        # Note: counts both real and simulated antennas
+        if isinstance(stream, product_config.AntennaChannelisedVoltageStreamBase):
+            n_antennas += len(stream.antennas)
 
     telstate = SDPLogicalTask('telstate')
     # redis is nominally single-threaded, but has some helper threads
     # for background tasks so can occasionally exceed 1 CPU.
-    telstate.cpus = 1.2 if not is_develop(config) else 0.2
+    telstate.cpus = 1.2 if not configuration.options.develop else 0.2
     telstate.mem = 2048 + 400 * n_antennas
     telstate.disk = telstate.mem
     telstate.image = 'katsdptelstate'
@@ -429,7 +221,9 @@ def _make_telstate(g, config):
     return telstate
 
 
-def _make_cam2telstate(g, config, name):
+def _make_cam2telstate(g: networkx.MultiDiGraph,
+                       configuration: product_config.Configuration,
+                       stream: product_config.CamHttpStream) -> scheduler.LogicalNode:
     cam2telstate = SDPLogicalTask('cam2telstate')
     cam2telstate.image = 'katsdpcam2telstate'
     cam2telstate.command = ['cam2telstate.py']
@@ -437,20 +231,20 @@ def _make_cam2telstate(g, config, name):
     cam2telstate.mem = 256
     cam2telstate.ports = ['port', 'aiomonitor_port', 'aioconsole_port']
     cam2telstate.wait_ports = ['port']
-    url = config['inputs'][name]['url']
+    url = stream.url
     antennas = set()
-    for input_ in config['inputs'].values():
-        if input_['type'] == 'cbf.antenna_channelised_voltage':
-            antennas.update(input_['antennas'])
+    for input_ in configuration.by_class(product_config.AntennaChannelisedVoltageStream):
+        antennas.update(input_.antennas)
     g.add_node(cam2telstate, config=lambda task, resolver: {
-        'url': url,
+        'url': str(url),
         'aiomonitor': True,
         'receptors': ','.join(sorted(antennas))
     })
     return cam2telstate
 
 
-def _make_meta_writer(g, config):
+def _make_meta_writer(g: networkx.MultiDiGraph,
+                      configuration: product_config.Configuration) -> scheduler.LogicalNode:
     meta_writer = SDPLogicalTask('meta_writer')
     meta_writer.image = 'katsdpmetawriter'
     meta_writer.command = ['meta_writer.py']
@@ -459,13 +253,13 @@ def _make_meta_writer(g, config):
     # meta_writer.mem = 256
     # Temporary workaround for SR-1695, until the machines can have their
     # kernels upgraded: give it the same memory as telescore state
-    meta_writer.mem = find_node(g, 'telstate').mem
+    meta_writer.mem = find_node(g, 'telstate').mem    # type: ignore
     meta_writer.ports = ['port']
     meta_writer.volumes = [OBJ_DATA_VOL]
     meta_writer.interfaces = [scheduler.InterfaceRequest('sdp_10g')]
     # Actual required bandwidth is minimal, but bursty. Use 1 Gb/s,
     # except in development mode where it might not be available.
-    bandwidth = 1e9 if not is_develop(config) else 10e6
+    bandwidth = 1e9 if not configuration.options.develop else 10e6
     meta_writer.interfaces[0].bandwidth_out = bandwidth
     meta_writer.transitions = {
         CaptureBlockState.BURNDOWN: [
@@ -483,92 +277,87 @@ def _make_meta_writer(g, config):
     return meta_writer
 
 
-def _make_cbf_simulator(g, config, name):
-    type_ = config['inputs'][name]['type']
-    settings = config['inputs'][name]['simulate']
-    assert type_ in ('cbf.baseline_correlation_products', 'cbf.tied_array_channelised_voltage')
+def _make_cbf_simulator(g: networkx.MultiDiGraph,
+                        configuration: product_config.Configuration,
+                        stream: Union[
+                            product_config.SimBaselineCorrelationProductsStream,
+                            product_config.SimTiedArrayChannelisedVoltageStream
+                        ]) -> scheduler.LogicalNode:
     # Determine number of simulators to run.
     n_sim = 1
-    if type_ == 'cbf.baseline_correlation_products':
-        info = BaselineCorrelationProductsInfo(config, name)
-        while info.n_vis / n_sim > _N32_32:
+    if isinstance(stream, product_config.SimBaselineCorrelationProductsStream):
+        while stream.n_vis / n_sim > _N32_32:
             n_sim *= 2
-    else:
-        info = TiedArrayChannelisedVoltageInfo(config, name)
-    ibv = not is_develop(config)
+    ibv = not configuration.options.develop
 
     def make_cbf_simulator_config(task, resolver):
-        substreams = info.n_channels // info.n_channels_per_substream
+        substreams = stream.n_channels // stream.n_channels_per_substream
         conf = {
-            'cbf_channels': info.n_channels,
-            'cbf_adc_sample_rate': info.adc_sample_rate,
-            'cbf_bandwidth': info.bandwidth,
-            'cbf_substreams': substreams,
+            'cbf_channels': stream.n_channels,
+            'cbf_adc_sample_rate': stream.adc_sample_rate,
+            'cbf_bandwidth': stream.bandwidth,
+            'cbf_substreams': stream.n_substreams,
             'cbf_ibv': ibv,
-            'cbf_sync_time': settings.get('start_time', time.time()),
-            'cbf_sim_clock_ratio': settings['clock_ratio'],
+            'cbf_sync_time': configuration.simulation.start_time or time.time(),
+            'cbf_sim_clock_ratio': configuration.simulation.clock_ratio,
             'servers': n_sim
         }
-        sources = settings['sources']
+        sources = configuration.simulation.sources
         if sources:
-            conf['cbf_sim_sources'] = [{'description': description} for description in sources]
-        if type_ == 'cbf.baseline_correlation_products':
+            conf['cbf_sim_sources'] = [{'description': str(s)} for s in sources]
+        if isinstance(stream, product_config.SimBaselineCorrelationProducts):
             conf.update({
-                'cbf_int_time': info.int_time,
+                'cbf_int_time': stream.int_time,
                 'max_packet_size': 2088
             })
         else:
             conf.update({
-                'beamformer_timesteps': info.raw['spectra_per_heap'],
-                'beamformer_bits': info.raw['beng_out_bits_per_sample']
+                'beamformer_timesteps': stream.spectra_per_heap,
+                'beamformer_bits': stream.out_bits_per_sample
             })
         if 'center_freq' in settings:
-            conf['cbf_center_freq'] = float(settings['center_freq'])
-        if 'antennas' in settings:
-            conf['cbf_antennas'] = [{'description': value} for value in settings['antennas']]
-        else:
-            conf['antenna_mask'] = ','.join(info.antennas)
+            conf['cbf_center_freq'] = float(stream.centre_frequency)
+        conf['cbf_antennas'] = [{'description': str(ant)} for ant in stream.antenna_objects]
         return conf
 
-    sim_group = LogicalGroup('sim.' + name)
+    sim_group = LogicalGroup('sim.' + stream.name)
     g.add_node(sim_group, config=make_cbf_simulator_config)
-    multicast = find_node(g, 'multicast.' + name)
+    multicast = find_node(g, 'multicast.' + stream.name)
     g.add_edge(sim_group, multicast, port='spead', depends_resolve=True,
                config=lambda task, resolver, endpoint: {'cbf_spead': str(endpoint)})
     g.add_edge(multicast, sim_group, depends_init=True, depends_ready=True)
 
     for i in range(n_sim):
-        sim = SDPLogicalTask('sim.{}.{}'.format(name, i + 1))
+        sim = SDPLogicalTask('sim.{}.{}'.format(stream.name, i + 1))
         sim.image = 'katcbfsim'
         # create-*-stream is passed on the command-line instead of telstate
         # for now due to SR-462.
-        if type_ == 'cbf.baseline_correlation_products':
-            sim.command = ['cbfsim.py', '--create-fx-stream', escape_format(name)]
+        if isinstance(stream, product_config.SimBaselineCorrelationProductsStream):
+            sim.command = ['cbfsim.py', '--create-fx-stream', escape_format(stream.name)]
             # It's mostly GPU work, so not much CPU requirement. Scale for 2 CPUs for
             # 16 antennas, 32K, and cap it there (threads for compute and network).
             # cbf_vis is an overestimate since the simulator is not constrained to
             # power-of-two antenna counts like the real CBF.
-            scale = info.n_vis / n_sim / _N16_32
+            scale = stream.n_vis / n_sim / _N16_32
             sim.cpus = 2 * min(1.0, scale)
             # 4 entries per Jones matrix, complex64 each
-            gains_size = info.n_antennas * info.n_channels * 4 * 8
+            gains_size = stream.n_antennas * stream.n_channels * 4 * 8
             # Factor of 4 is conservative; only actually double-buffered
-            sim.mem = (4 * _mb(info.size) + _mb(gains_size)) / n_sim + 512
+            sim.mem = (4 * _mb(stream.size) + _mb(gains_size)) / n_sim + 512
             sim.cores = [None, None]
             sim.gpus = [scheduler.GPURequest()]
             # Scale for 20% at 16 ant, 32K channels
             sim.gpus[0].compute = min(1.0, 0.2 * scale)
-            sim.gpus[0].mem = (2 * _mb(info.size) + _mb(gains_size)) / n_sim + 256
+            sim.gpus[0].mem = (2 * _mb(stream.size) + _mb(gains_size)) / n_sim + 256
         else:
-            info = TiedArrayChannelisedVoltageInfo(config, name)
-            sim.command = ['cbfsim.py', '--create-beamformer-stream', escape_format(name)]
+            sim.command = ['cbfsim.py', '--create-beamformer-stream', escape_format(stream.name)]
             # The beamformer simulator only simulates data shape, not content. The
             # CPU load thus scales only with network bandwidth. Scale for 2 CPUs at
             # L band, and cap it there since there are only 2 threads. Using 1.999
             # instead of 2.0 is to ensure rounding errors don't cause a tiny fraction
             # extra of CPU to be used.
-            sim.cpus = min(2.0, 1.999 * info.size / info.int_time / 1712000000.0 / n_sim)
-            sim.mem = 4 * _mb(info.size) / n_sim + 512
+            sim.cpus = min(2.0, 1.999 * stream.size / stream.int_time / 1712000000.0 / n_sim)
+            sim.mem = 4 * _mb(stream.size) / n_sim + 512
 
         sim.ports = ['port']
         if ibv:
@@ -577,14 +366,15 @@ def _make_cbf_simulator(g, config, name):
             # 1024.
             sim.taskinfo.container.docker.parameters = [{"key": "ulimit", "value": "nofile=8192"}]
         sim.interfaces = [scheduler.InterfaceRequest('cbf', infiniband=ibv)]
-        sim.interfaces[0].bandwidth_out = info.net_bandwidth()
+        sim.interfaces[0].bandwidth_out = stream.net_bandwidth()
         sim.transitions = {
             CaptureBlockState.CAPTURING: [
-                KatcpTransition('capture-start', name, settings.get('start_time', '{time}'),
+                KatcpTransition('capture-start', stream.name,
+                                configuration.simulation.start_time or '{time}',
                                 timeout=30)
             ],
             CaptureBlockState.BURNDOWN: [
-                KatcpTransition('capture-stop', name, timeout=60)
+                KatcpTransition('capture-stop', stream.name, timeout=60)
             ]
         }
 
@@ -597,8 +387,11 @@ def _make_cbf_simulator(g, config, name):
     return sim_group
 
 
-def _make_timeplot(g, name, description,
-                   cpus, timeplot_buffer_mb, bandwidth, extra_config):
+def _make_timeplot(g: networkx.MultiDiGraph, name: str, description: str,
+                   cpus: float,
+                   timeplot_buffer_mb: float,
+                   bandwidth: float,
+                   extra_config: dict) -> scheduler.LogicalNode:
     """Common backend code for creating a single timeplot server."""
     multicast = find_node(g, 'multicast.timeplot.' + name)
     timeplot = SDPLogicalTask('timeplot.' + name)
@@ -638,55 +431,63 @@ def _make_timeplot(g, name, description,
     return timeplot
 
 
-def _make_timeplot_correlator(g, config, spectral_name):
-    spectral_info = L0Info(config, spectral_name)
-    n_ingest = n_ingest_nodes(config, spectral_name)
+def _make_timeplot_correlator(g: networkx.MultiDiGraph,
+                              configuration: product_config.Configuration,
+                              stream: product_config.VisStream) -> scheduler.LogicalNode:
+    n_ingest = stream.n_servers
 
     # Exact requirement not known (also depends on number of users). Give it
     # 2 CPUs (max it can use) for 16 antennas, 32K channels and scale from there.
     # Lower bound (from inspection) to cater for fixed overheads.
-    cpus = max(2 * min(1.0, spectral_info.n_vis / _N16_32), 0.3)
+    cpus = max(2 * min(1.0, stream.n_baselines * stream.n_spectral_channels / _N16_32), 0.3)
 
     # Give timeplot enough memory for 256 time samples, but capped at 16GB.
     # This formula is based on data.py in katsdpdisp.
     percentiles = 5 * 8
-    timeplot_slot = spectral_info.n_channels * (spectral_info.n_baselines + percentiles) * 8
+    timeplot_slot = stream.n_spectral_channels * (stream.n_baselines + percentiles) * 8
     timeplot_buffer = min(256 * timeplot_slot, 16 * 1024**3)
 
     return _make_timeplot(
-        g, name=spectral_name, description=spectral_name,
+        g, name=stream.name, description=stream.name,
         cpus=cpus, timeplot_buffer_mb=timeplot_buffer / 1024**2,
-        bandwidth=_correlator_timeplot_bandwidth(spectral_info, n_ingest) * n_ingest,
-        extra_config={'l0_name': spectral_name,
-                      'max_custom_signals': TIMEPLOT_MAX_CUSTOM_SIGNALS})
+        bandwidth=_correlator_timeplot_bandwidth(stream) * n_ingest,
+        extra_config={
+            'l0_name': stream.name,
+            'max_custom_signals': TIMEPLOT_MAX_CUSTOM_SIGNALS
+        }
+    )
 
 
-def _make_timeplot_beamformer(g, config, name):
+def _make_timeplot_beamformer(
+        g: networkx.MultiDiGraph,
+        configuration: product_config.Configuration,
+        stream: product_config.TiedArrayChannelisedVoltageStreamBase) -> \
+            Tuple[scheduler.LogicalNode, scheduler.LogicalNode]:
     """Make timeplot server for the beamformer, plus a beamformer capture to feed it."""
-    info = TiedArrayChannelisedVoltageInfo(config, name)
-    develop = is_develop(config)
+    develop = configuration.options.develop
     beamformer = _make_beamformer_engineering_pol(
-        g, info, 'bf_ingest_timeplot.{}'.format(name), name, True, False, 0, develop)
+        g, stream, f'bf_ingest_timeplot.{stream.name}', stream.name, True, False, 0, develop)
     beamformer.critical = False
 
     # It's a low-demand setup (only one signal). The CPU and memory numbers
     # could potentially be reduced further.
     timeplot = _make_timeplot(
-        g, name=name, description=name,
+        g, name=stream.name, description=stream.name,
         cpus=0.5, timeplot_buffer_mb=128,
-        bandwidth=_beamformer_timeplot_bandwidth(info),
+        bandwidth=_beamformer_timeplot_bandwidth(stream),
         extra_config={'max_custom_signals': 2})
 
     return beamformer, timeplot
 
 
-def _correlator_timeplot_frame_size(spectral_info, n_cont_channels, n_ingest):
+def _correlator_timeplot_frame_size(stream: product_config.VisStream,
+                                    n_cont_channels: int) -> int:
     """Approximate size of the data sent from one ingest process to timeplot, per heap"""
     # This is based on _init_ig_sd from katsdpingest/ingest_session.py
     n_perc_signals = 5 * 8
-    n_spec_channels = spectral_info.n_channels // n_ingest
-    n_cont_channels //= n_ingest
-    n_bls = spectral_info.n_baselines
+    n_spec_channels = stream.n_spectral_channels // stream.n_servers
+    n_cont_channels //= stream.n_servers
+    n_bls = stream.n_baselines
     # sd_data + sd_flags
     ans = n_spec_channels * TIMEPLOT_MAX_CUSTOM_SIGNALS * (BYTES_PER_VIS + BYTES_PER_FLAG)
     ans += TIMEPLOT_MAX_CUSTOM_SIGNALS * 4          # sd_data_index
@@ -702,31 +503,32 @@ def _correlator_timeplot_frame_size(spectral_info, n_cont_channels, n_ingest):
     return ans
 
 
-def _correlator_timeplot_continuum_factor(spectral_info, n_ingest):
+def _correlator_timeplot_continuum_factor(stream: product_config.VisStream) -> int:
     factor = 1
     # Aim for about 256 signal display coarse channels
-    while (spectral_info.n_channels % (factor * n_ingest * 2) == 0
-           and spectral_info.n_channels // factor >= 384):
+    while (stream.n_spectral_channels % (factor * stream.n_servers * 2) == 0
+           and stream.n_spectral_channels // factor >= 384):
         factor *= 2
     return factor
 
 
-def _correlator_timeplot_bandwidth(spectral_info, n_ingest):
+def _correlator_timeplot_bandwidth(stream: product_config.VisStream) -> float:
     """Bandwidth for the correlator timeplot stream from a single ingest"""
-    sd_continuum_factor = _correlator_timeplot_continuum_factor(spectral_info, n_ingest)
+    sd_continuum_factor = _correlator_timeplot_continuum_factor(stream)
     sd_frame_size = _correlator_timeplot_frame_size(
-        spectral_info, spectral_info.n_channels // sd_continuum_factor, n_ingest)
+        stream, stream.n_spectral_channels // sd_continuum_factor)
     # The rates are low, so we allow plenty of padding in case the calculation is
     # missing something.
-    return _bandwidth(sd_frame_size, spectral_info.int_time, ratio=1.2, overhead=4096)
+    return _bandwidth(sd_frame_size, stream.int_time, ratio=1.2, overhead=4096)
 
 
-def _beamformer_timeplot_bandwidth(info):
+def _beamformer_timeplot_bandwidth(
+        stream: product_config.TiedArrayChannelisedVoltageStreamBase) -> float:
     """Bandwidth for the beamformer timeplot stream.
 
     Parameters
     ----------
-    info : :class:`TiedArrayChannelisedVoltageInfo`
+    info
         Info about the single-pol beam.
     """
     # XXX The beamformer signal displays are still in development, but the
@@ -735,21 +537,15 @@ def _beamformer_timeplot_bandwidth(info):
     return 1e6    # 1 MB/s
 
 
-def n_ingest_nodes(config, name):
-    """Number of processes used to implement ingest for a particular output."""
-    # TODO: adjust based on the number of antennas and channels
-    return 4 if not is_develop(config) else 2
-
-
-def n_cal_nodes(config, name, l0_name):
+def n_cal_nodes(configuration: product_config.Configuration,
+                stream: product_config.CalStream) -> int:
     """Number of processes used to implement cal for a particular output."""
     # Use single cal for 4K or less: it doesn't need the performance, and
     # a unified cal report is more convenient (revisit once split cal supports
     # a unified cal report).
-    info = L0Info(config, l0_name)
-    if is_develop(config):
+    if configuration.options.develop:
         return 2
-    elif info.n_channels <= 4096:
+    elif stream.vis.n_channels <= 4096:
         return 1
     else:
         return 4
@@ -792,58 +588,51 @@ def _adjust_ingest_output_channels(config, names):
         output['output_channels'] = assigned
 
 
-def _make_ingest(g, config, spectral_name, continuum_name):
-    develop = is_develop(config)
+def _make_ingest(g: networkx.MultiDiGraph, configuration: product_config.Configuration,
+                 spectral: Optional[product_config.VisStream],
+                 continuum: Optional[product_config.VisStream]) -> scheduler.LogicalNode:
+    develop = configuration.options.develop
 
-    if not spectral_name and not continuum_name:
-        raise ValueError('At least one of spectral_name or continuum_name must be given')
-    continuum_info = L0Info(config, continuum_name) if continuum_name else None
-    spectral_info = L0Info(config, spectral_name) if spectral_name else None
-    if spectral_info is None:
-        spectral_info = copy.copy(continuum_info)
-        # Make a copy of the info, then override continuum_factor
-        spectral_info.raw = dict(spectral_info.raw)
-        spectral_info.raw['continuum_factor'] = 1
-    name = spectral_name if spectral_name else continuum_name
-    src = spectral_info.raw['src_streams'][0]
-    src_info = spectral_info.src_info
+    primary = spectral if spectral is not None else continuum
+    if primary is None:
+        raise ValueError('At least one of spectral or continuum must be given')
+    name = primary.name
+    src = primary.baseline_correlation_products
     # Number of ingest nodes.
-    n_ingest = n_ingest_nodes(config, name)
+    n_ingest = primary.n_servers
 
     # Virtual ingest node which depends on the real ingest nodes, so that other
     # services can declare dependencies on ingest rather than individual nodes.
     ingest_group = LogicalGroup('ingest.' + name)
 
-    sd_continuum_factor = _correlator_timeplot_continuum_factor(spectral_info, n_ingest)
-    sd_spead_rate = _correlator_timeplot_bandwidth(spectral_info, n_ingest)
-    output_channels_str = '{}:{}'.format(*spectral_info.output_channels)
+    sd_continuum_factor = _correlator_timeplot_continuum_factor(primary)
+    sd_spead_rate = _correlator_timeplot_bandwidth(primary)
+    output_channels_str = '{}:{}'.format(*primary.output_channels)
     group_config = {
-        'continuum_factor': continuum_info.raw['continuum_factor'] if continuum_name else 1,
+        'continuum_factor': continuum.continuum_factor if continuum is not None else 1,
         'sd_continuum_factor': sd_continuum_factor,
         'sd_spead_rate': sd_spead_rate,
         'cbf_ibv': not develop,
         'cbf_name': src,
         'servers': n_ingest,
-        'l0_spectral_name': spectral_name,
-        'l0_continuum_name': continuum_name,
-        'antenna_mask': src_info.antennas,
-        'output_int_time': spectral_info.int_time,
-        'sd_int_time': spectral_info.int_time,
+        'antenna_mask': primary.antennas,
+        'output_int_time': primary.int_time,
+        'sd_int_time': primary.int_time,
         'output_channels': output_channels_str,
         'sd_output_channels': output_channels_str,
         'use_data_suspect': True,
         'aiomonitor': True
     }
-    if spectral_name:
-        group_config.update(l0_spectral_name=spectral_name)
-    if continuum_name:
-        group_config.update(l0_continuum_name=continuum_name)
-    if src_info.raw['simulate']:
-        group_config.update(clock_ratio=src_info.raw['simulate']['clock_ratio'])
+    if spectral is not None:
+        group_config.update(l0_spectral_name=spectral.name)
+    if continuum is not None:
+        group_config.update(l0_continuum_name=continuum.name)
+    if isinstance(src, product_config.SimBaselineCorrelationProductsStream):
+        group_config.update(clock_ratio=configuration.simulation.clock_ratio)
     g.add_node(ingest_group, config=lambda task, resolver: group_config)
 
-    if spectral_name:
-        spectral_multicast = LogicalMulticast('multicast.' + spectral_name, n_ingest)
+    if spectral is not None:
+        spectral_multicast = LogicalMulticast('multicast.' + spectral.name, n_ingest)
         g.add_node(spectral_multicast)
         g.add_edge(ingest_group, spectral_multicast, port='spead', depends_resolve=True,
                    config=lambda task, resolver, endpoint: {'l0_spectral_spead': str(endpoint)})
@@ -854,14 +643,14 @@ def _make_ingest(g, config, spectral_name, continuum_name):
         g.add_edge(ingest_group, timeplot_multicast, port='spead', depends_resolve=True,
                    config=lambda task, resolver, endpoint: {'sdisp_spead': str(endpoint)})
         g.add_edge(timeplot_multicast, ingest_group, depends_init=True, depends_ready=True)
-    if continuum_name:
-        continuum_multicast = LogicalMulticast('multicast.' + continuum_name, n_ingest)
+    if continuum is not None:
+        continuum_multicast = LogicalMulticast('multicast.' + continuum.name, n_ingest)
         g.add_node(continuum_multicast)
         g.add_edge(ingest_group, continuum_multicast, port='spead', depends_resolve=True,
                    config=lambda task, resolver, endpoint: {'l0_continuum_spead': str(endpoint)})
         g.add_edge(continuum_multicast, ingest_group, depends_init=True, depends_ready=True)
 
-    src_multicast = find_node(g, 'multicast.' + src)
+    src_multicast = find_node(g, 'multicast.' + src.name)
     g.add_edge(ingest_group, src_multicast, port='spead', depends_resolve=True,
                config=lambda task, resolver, endpoint: {'cbf_spead': str(endpoint)})
 
@@ -876,14 +665,14 @@ def _make_ingest(g, config, spectral_name, continuum_name):
         if not develop:
             ingest.gpus[-1].name = INGEST_GPU_NAME
         # Scale for a full GPU for 32 antennas, 32K channels on one node
-        scale = src_info.n_vis / _N32_32 / n_ingest
+        scale = src.n_vis / _N32_32 / n_ingest
         ingest.gpus[0].compute = scale
         # Refer to
         # https://docs.google.com/spreadsheets/d/13LOMcUDV1P0wyh_VSgTOcbnhyfHKqRg5rfkQcmeXmq0/edit
         # We use slightly higher multipliers to be safe, as well as
         # conservatively using src_info instead of spectral_info.
         ingest.gpus[0].mem = \
-            (70 * src_info.n_vis + 168 * src_info.n_channels) / n_ingest / 1024**2 + 128
+            (70 * src.n_vis + 168 * src.n_channels) / n_ingest / 1024**2 + 128
         # Provide 4 CPUs for 32 antennas, 32K channels (the number in a NUMA
         # node of an ingest machine). It might not actually need this much.
         # Cores are reserved solely to get NUMA affinity with the NIC.
@@ -891,17 +680,17 @@ def _make_ingest(g, config, spectral_name, continuum_name):
         ingest.cores = [None] * ingest.cpus
         # Scale factor of 32 may be overly conservative: actual usage may be
         # only half this. This also leaves headroom for buffering L0 output.
-        ingest.mem = 32 * _mb(src_info.size) / n_ingest + 4096
+        ingest.mem = 32 * _mb(src.size) / n_ingest + 4096
         ingest.transitions = CAPTURE_TRANSITIONS
         ingest.interfaces = [
             scheduler.InterfaceRequest('cbf', affinity=not develop, infiniband=not develop),
             scheduler.InterfaceRequest('sdp_10g')]
-        ingest.interfaces[0].bandwidth_in = src_info.net_bandwidth() / n_ingest
+        ingest.interfaces[0].bandwidth_in = src.net_bandwidth() / n_ingest
         net_bandwidth = 0.0
-        if spectral_name:
-            net_bandwidth += spectral_info.net_bandwidth() + sd_spead_rate * n_ingest
-        if continuum_name:
-            net_bandwidth += continuum_info.net_bandwidth()
+        if spectral is not None:
+            net_bandwidth += spectral.net_bandwidth() + sd_spead_rate * n_ingest
+        if continuum is not None:
+            net_bandwidth += continuum.net_bandwidth()
         ingest.interfaces[1].bandwidth_out = net_bandwidth / n_ingest
 
         def make_ingest_config(task, resolver, server_id=i):
@@ -909,10 +698,10 @@ def _make_ingest(g, config, spectral_name, continuum_name):
                 'cbf_interface': task.interfaces['cbf'].name,
                 'server_id': server_id
             }
-            if spectral_name:
+            if spectral is not None:
                 conf.update(l0_spectral_interface=task.interfaces['sdp_10g'].name)
                 conf.update(sdisp_interface=task.interfaces['sdp_10g'].name)
-            if continuum_name:
+            if continuum is not None:
                 conf.update(l0_continuum_interface=task.interfaces['sdp_10g'].name)
             return conf
         g.add_node(ingest, config=make_ingest_config)
@@ -928,24 +717,12 @@ def _make_ingest(g, config, spectral_name, continuum_name):
     return ingest_group
 
 
-def _make_cal(g, config, name, l0_name, flags_names):
-    info = L0Info(config, l0_name)
-    if info.n_antennas < 4:
-        # Only possible to calibrate with at least 4 antennas
-        return None
-
-    settings = config['outputs'][name]
-    # We want ~25 min of data in the buffer, to allow for a single batch of
-    # 15 minutes.
-    buffer_time = settings.get('buffer_time', 25.0 * 60.0)
-    # Some pathological observations use more than this, but they can override
-    # the default.
-    max_scans = settings.get('max_scans', 1000)
-    parameters = settings['parameters']
-    models = settings['models']
-    if models:
-        raise NotImplementedError('cal models are not yet supported')
-    n_cal = n_cal_nodes(config, name, l0_name)
+def _make_cal(g: networkx.MultiDiGraph,
+              configuration: product_config.Configuration,
+              stream: product_config.CalStream,
+              flags_streams: Sequence[product_config.FlagsStream]) -> scheduler.LogicalNode:
+    vis = stream.vis
+    n_cal = n_cal_nodes(configuration, stream)
 
     # Some of the scaling in cal is non-linear, so we need to give smaller
     # arrays more CPU than might be suggested by linear scaling. In particular,
@@ -953,14 +730,14 @@ def _make_cal(g, config, name, l0_name, flags_names):
     # (which tends to dominate runtime) scales as if there were 8K channels.
     # Longer integration times are also less efficient (because there are fixed
     # costs per scan, so we scale as if for 4s dumps if longer dumps are used.
-    effective_vis = info.n_baselines * min(8192, info.n_channels)
-    effective_int = min(info.int_time, 4.0)
+    effective_vis = vis.n_baselines * min(8192, vis.n_channels)
+    effective_int = min(vis.int_time, 4.0)
     # This scale factor gives 34 total CPUs for 64A, 32K, 4+s integration, which
     # will get clamped down slightly.
     cpus = 2e-6 * effective_vis / effective_int / n_cal
     # Always (except in development mode) have at least a whole CPU for the
     # pipeline.
-    if not is_develop(config):
+    if not configuration.options.develop:
         cpus = max(cpus, 1)
     # Reserve a separate CPU for the accumulator
     cpus += 1
@@ -973,9 +750,8 @@ def _make_cal(g, config, name, l0_name, flags_names):
     # - excision flags (single bit each)
     # - weights (float32)
     # There are also timestamps, but they're insignificant compared to the rest.
-    slots = int(math.ceil(buffer_time / info.int_time))
-    slot_size = info.n_vis * 13.125 / n_cal
-    buffer_size = slots * slot_size
+    slot_size = vis.n_vis * 13.125 / n_cal
+    buffer_size = stream.slots * slot_size
     # Processing operations come in a few flavours:
     # - average over time: need O(1) extra slots
     # - average over frequency: needs far less memory than the above
@@ -985,9 +761,9 @@ def _make_cal(g, config, name, l0_name, flags_names):
     # of the HH and VV products for each scan. We allow a factor of 2 for
     # operations that work on it (which cancels the factor of 1/2 for only
     # having 2 of the 4 pol products). The scaling by n_cal is because there
-    # are 1024 channels *per node* while info.n_channels is over all nodes.
-    extra = max(workers / slots, min(16 * workers, info.n_baselines) / info.n_baselines) * 4
-    extra += max_scans * 1024 * n_cal / (slots * info.n_channels)
+    # are 1024 channels *per node* while vis.n_channels is over all nodes.
+    extra = max(workers / stream.slots, min(16 * workers, vis.n_baselines) / vis.n_baselines) * 4
+    extra += stream.max_scans * 1024 * n_cal / (stream.slots * vis.n_channels)
 
     # Extra memory allocation for tasks that deal with bandpass calibration
     # solutions in telescope state. The exact size of these depends on how
@@ -997,26 +773,27 @@ def _make_cal(g, config, name, l0_name, flags_names):
     # - 8 bytes per value (complex64)
     # - 200 solutions
     # - 3: conservative estimate of bloat from text-based pickling
-    telstate_extra = info.n_channels * info.n_pols * info.n_antennas * 8 * 3 * 200
+    telstate_extra = vis.n_channels * vis.n_pols * vis.n_antennas * 8 * 3 * 200
 
     group_config = {
         'buffer_maxsize': buffer_size,
-        'max_scans': max_scans,
+        'max_scans': stream.max_scans,
         'workers': workers,
-        'l0_name': l0_name,
+        'l0_name': vis.name,
         'servers': n_cal,
         'aiomonitor': True
     }
-    group_config.update(parameters)
-    if info.src_info.raw['simulate']:
-        group_config.update(clock_ratio=info.src_info.raw['simulate']['clock_ratio'])
+    group_config.update(stream.parameters)
+    if isinstance(vis.baseline_correlation_products,
+                  product_config.SimBaselineCorrelationProductsStream):
+        group_config.update(clock_ratio=configuration.simulation.clock_ratio)
 
     # Virtual node which depends on the real cal nodes, so that other services
     # can declare dependencies on cal rather than individual nodes.
-    cal_group = LogicalGroup(name)
+    cal_group = LogicalGroup(stream.name)
     g.add_node(cal_group, telstate_extra=telstate_extra,
                config=lambda task, resolver: group_config)
-    src_multicast = find_node(g, 'multicast.' + l0_name)
+    src_multicast = find_node(g, 'multicast.' + vis.name)
     g.add_edge(cal_group, src_multicast, port='spead',
                depends_resolve=True, depends_init=True, depends_ready=True,
                config=lambda task, resolver, endpoint: {
@@ -1026,26 +803,24 @@ def _make_cal(g, config, name, l0_name, flags_names):
     # Flags output
     flags_streams_base = []
     flags_multicasts = {}
-    for flags_name in flags_names:
-        flags_config = config['outputs'][flags_name]
-        flags_src_stream = flags_config['src_streams'][0]
-        cf = config['outputs'][flags_src_stream]['continuum_factor']
-        cf //= config['outputs'][l0_name]['continuum_factor']
+    for flags_stream in flags_streams:
+        flags_vis = flags_stream.vis
+        cf = flags_vis.continuum_factor // vis.continuum_factor
         flags_streams_base.append({
-            'name': flags_name,
-            'src_stream': flags_src_stream,
+            'name': flags_stream.name,
+            'src_stream': flags_vis.name,
             'continuum_factor': cf,
-            'rate_ratio': FLAGS_RATE_RATIO
+            'rate_ratio': flags_stream.rate_ratio
         })
 
-        flags_multicast = LogicalMulticast('multicast.' + flags_name, n_cal)
-        flags_multicasts[flags_name] = flags_multicast
+        flags_multicast = LogicalMulticast('multicast.' + flags_stream.name, n_cal)
+        flags_multicasts[flags_stream] = flags_multicast
         g.add_node(flags_multicast)
         g.add_edge(flags_multicast, cal_group, depends_init=True, depends_ready=True)
 
     dask_prefix = '/gui/{0.subarray_product.subarray_product_id}/{0.name}/cal-diagnostics'
     for i in range(1, n_cal + 1):
-        cal = SDPLogicalTask('{}.{}'.format(name, i))
+        cal = SDPLogicalTask('{}.{}'.format(stream.name, i))
         cal.image = 'katsdpcal'
         cal.command = ['run_cal.py']
         cal.cpus = cpus
@@ -1053,8 +828,8 @@ def _make_cal(g, config, name, l0_name, flags_names):
         cal.volumes = [DATA_VOL]
         cal.interfaces = [scheduler.InterfaceRequest('sdp_10g')]
         # Note: these scale the fixed overheads too, so is not strictly accurate.
-        cal.interfaces[0].bandwidth_in = info.net_bandwidth() / n_cal
-        cal.interfaces[0].bandwidth_out = info.flag_bandwidth() * FLAGS_RATE_RATIO / n_cal
+        cal.interfaces[0].bandwidth_in = vis.net_bandwidth() / n_cal
+        cal.interfaces[0].bandwidth_out = vis.flag_bandwidth() * FLAGS_RATE_RATIO / n_cal
         cal.ports = ['port', 'dask_diagnostics', 'aiomonitor_port', 'aioconsole_port']
         cal.wait_ports = ['port']
         cal.gui_urls = [{
@@ -1101,7 +876,7 @@ def _make_cal(g, config, name, l0_name, flags_names):
             g.add_edge(cal, flags_multicast, port='spead', depends_resolve=True,
                        config=add_flags_endpoint)
 
-    g.graph['archived_streams'].append(name)
+    g.graph['archived_streams'].append(stream.name)
     return cal_group
 
 
@@ -1125,24 +900,24 @@ def _writer_mem_mb(dump_size, obj_size, n_substreams, workers, buffer_dumps, max
     return 2 * _mb(memory_pool + write_queue + accum_buffers + socket_buffers) + 512
 
 
-def _writer_max_accum_dumps(config, name, bytes_per_vis, max_channels):
+def _writer_max_accum_dumps(stream: product_config.VisStream,
+                            bytes_per_vis: int,
+                            max_channels: Optional[int]) -> int:
     """Compute value of --obj-max-dumps for data writers.
 
     If `max_channels` is not ``None``, it indicates the maximum number of
     channels per chunk.
     """
-    info = L0Info(config, name)
     # Allow time accumulation up to 5 minutes (to bound data loss) or 32GB
     # (to bound memory usage).
-    limit = min(300.0 / info.int_time, 32 * 1024**3 / (info.n_vis * bytes_per_vis))
+    limit = min(300.0 / stream.int_time, 32 * 1024**3 / (stream.n_vis * bytes_per_vis))
     # Compute how many are needed to allow weights/flags to achieve the target
     # object size. The scaling by n_ingest_nodes is because this is also the
     # number of substreams, and katsdpdatawriter doesn't weld substreams.
-    n_ingest = n_ingest_nodes(config, name)
-    n_channels = info.n_channels // n_ingest
+    n_channels = stream.n_channels // stream.n_servers
     if max_channels is not None and max_channels < n_channels:
         n_channels = max_channels
-    flag_size = info.n_baselines * n_channels
+    flag_size = stream.n_baselines * n_channels
     needed = WRITER_OBJECT_SIZE / flag_size
     # katsdpdatawriter only uses powers of two. While it would be legal to
     # pass a non-power-of-two as the max, we would be wasting memory.
@@ -1152,10 +927,14 @@ def _writer_max_accum_dumps(config, name, bytes_per_vis, max_channels):
     return max_accum_dumps
 
 
-def _make_vis_writer(g, config, name, s3_name, local, prefix=None, max_channels=None):
-    info = L0Info(config, name)
-
-    output_name = prefix + '.' + name if prefix is not None else name
+def _make_vis_writer(g: networkx.MultiDiGraph,
+                     configuration: product_config.Configuration,
+                     stream: product_config.VisStream,
+                     s3_name: str,
+                     local: bool,
+                     prefix: Optional[str] = None,
+                     max_channels: Optional[int] = None):
+    output_name = prefix + '.' + stream.name if prefix is not None else stream.name
     g.graph['archived_streams'].append(output_name)
     vis_writer = SDPLogicalTask('vis_writer.' + output_name)
     vis_writer.image = 'katsdpdatawriter'
@@ -1163,29 +942,29 @@ def _make_vis_writer(g, config, name, s3_name, local, prefix=None, max_channels=
     # Don't yet have a good idea of real CPU usage. For now assume that 32
     # antennas, 32K channels requires two CPUs (one for capture, one for
     # writing) and scale from there, while capping at 3.
-    vis_writer.cpus = min(3, 2 * info.n_vis / _N32_32)
+    vis_writer.cpus = min(3, 2 * stream.n_vis / _N32_32)
 
     workers = 4 if local else 50
-    max_accum_dumps = _writer_max_accum_dumps(config, name, BYTES_PER_VFW, max_channels)
+    max_accum_dumps = _writer_max_accum_dumps(stream, BYTES_PER_VFW, max_channels)
     # Buffer enough data for 45 seconds. We've seen the disk system throw a fit
     # and hang for 30 seconds at a time, and this should allow us to ride that
     # out.
-    buffer_dumps = max(max_accum_dumps, int(math.ceil(45.0 / info.int_time)))
-    src_multicast = find_node(g, 'multicast.' + name)
+    buffer_dumps = max(max_accum_dumps, int(math.ceil(45.0 / stream.int_time)))
+    src_multicast = find_node(g, 'multicast.' + stream.name)
     n_substreams = src_multicast.n_addresses
 
     # Double the memory allocation to be on the safe side. This gives some
     # headroom for page cache etc.
-    vis_writer.mem = _writer_mem_mb(info.size, WRITER_OBJECT_SIZE, n_substreams,
+    vis_writer.mem = _writer_mem_mb(stream.size, WRITER_OBJECT_SIZE, n_substreams,
                                     workers, buffer_dumps, max_accum_dumps)
     vis_writer.ports = ['port', 'aiomonitor_port', 'aioconsole_port']
     vis_writer.wait_ports = ['port']
     vis_writer.interfaces = [scheduler.InterfaceRequest('sdp_10g')]
-    vis_writer.interfaces[0].bandwidth_in = info.net_bandwidth()
+    vis_writer.interfaces[0].bandwidth_in = stream.net_bandwidth()
     if local:
         vis_writer.volumes = [OBJ_DATA_VOL]
     else:
-        vis_writer.interfaces[0].backwidth_out = info.net_bandwidth()
+        vis_writer.interfaces[0].backwidth_out = stream.net_bandwidth()
         # Creds are passed on the command-line so that they are redacted from telstate.
         vis_writer.command.extend([
             '--s3-access-key', '{resolver.s3_config[%s][write][access_key]}' % s3_name,
@@ -1195,7 +974,7 @@ def _make_vis_writer(g, config, name, s3_name, local, prefix=None, max_channels=
 
     def make_vis_writer_config(task, resolver):
         conf = {
-            'l0_name': name,
+            'l0_name': stream.name,
             'l0_interface': task.interfaces['sdp_10g'].name,
             'obj_size_mb': WRITER_OBJECT_SIZE / 1e6,
             'obj_max_dumps': max_accum_dumps,
@@ -1223,33 +1002,37 @@ def _make_vis_writer(g, config, name, s3_name, local, prefix=None, max_channels=
     return vis_writer
 
 
-def _make_flag_writer(g, config, name, l0_name, s3_name, local, prefix=None, max_channels=None):
-    info = L0Info(config, l0_name)
-
-    output_name = prefix + '.' + name if prefix is not None else name
+def _make_flag_writer(g: networkx.MultiDiGraph,
+                      configuration: product_config.Configuration,
+                      stream: product_config.FlagsStream,
+                      s3_name: str,
+                      local: bool,
+                      prefix: Optional[str] = None,
+                      max_channels: Optional[int] = None) -> scheduler.LogicalNode:
+    output_name = prefix + '.' + stream.name if prefix is not None else stream.name
     g.graph['archived_streams'].append(output_name)
     flag_writer = SDPLogicalTask('flag_writer.' + output_name)
     flag_writer.image = 'katsdpdatawriter'
     flag_writer.command = ['flag_writer.py']
 
-    flags_src = find_node(g, 'multicast.' + name)
+    flags_src = find_node(g, 'multicast.' + stream.name)
     n_substreams = flags_src.n_addresses
     workers = 4
-    max_accum_dumps = _writer_max_accum_dumps(config, l0_name, BYTES_PER_FLAG, max_channels)
+    max_accum_dumps = _writer_max_accum_dumps(stream.vis, BYTES_PER_FLAG, max_channels)
     # Buffer enough data for 45 seconds of real time. We've seen the disk
     # system throw a fit and hang for 30 seconds at a time, and this should
     # allow us to ride that out.
-    buffer_dumps = max(max_accum_dumps, int(math.ceil(45.0 / info.int_time * FLAGS_RATE_RATIO)))
+    buffer_dumps = max(max_accum_dumps, int(math.ceil(45.0 / stream.int_time * stream.rate_ratio)))
 
     # Don't yet have a good idea of real CPU usage. This formula is
     # copied from the vis writer.
-    flag_writer.cpus = min(3, 2 * info.n_vis / _N32_32)
-    flag_writer.mem = _writer_mem_mb(info.flag_size, WRITER_OBJECT_SIZE, n_substreams,
+    flag_writer.cpus = min(3, 2 * stream.n_vis / _N32_32)
+    flag_writer.mem = _writer_mem_mb(stream.size, WRITER_OBJECT_SIZE, n_substreams,
                                      workers, buffer_dumps, max_accum_dumps)
     flag_writer.ports = ['port', 'aiomonitor_port', 'aioconsole_port']
     flag_writer.wait_ports = ['port']
     flag_writer.interfaces = [scheduler.InterfaceRequest('sdp_10g')]
-    flag_writer.interfaces[0].bandwidth_in = info.flag_bandwidth() * FLAGS_RATE_RATIO
+    flag_writer.interfaces[0].bandwidth_in = stream.net_bandwidth() * stream.rate_ratio
     if local:
         flag_writer.volumes = [OBJ_DATA_VOL]
     else:
@@ -1274,7 +1057,7 @@ def _make_flag_writer(g, config, name, l0_name, s3_name, local, prefix=None, max
 
     def make_flag_writer_config(task, resolver):
         conf = {
-            'flags_name': name,
+            'flags_name': stream.name,
             'flags_interface': task.interfaces['sdp_10g'].name,
             'obj_size_mb': WRITER_OBJECT_SIZE / 1e6,
             'obj_max_dumps': max_accum_dumps,
@@ -1291,7 +1074,7 @@ def _make_flag_writer(g, config, name, l0_name, s3_name, local, prefix=None, max
             conf['s3_write_url'] = resolver.s3_config[s3_name]['write']['url']
         if prefix is not None:
             conf['new_name'] = output_name
-            conf['rename_src'] = {l0_name: prefix + '.' + l0_name}
+            conf['rename_src'] = {stream.vis.name: prefix + '.' + stream.vis.name}
         if max_channels is not None:
             conf['obj_max_channels'] = max_channels
         return conf
@@ -1438,20 +1221,21 @@ def _make_beamformer_engineering(g, config, name):
     return nodes
 
 
-def build_logical_graph(config):
+def build_logical_graph(configuration: product_config.Configuration,
+                        config_dict: dict) -> networkx.MultiDiGraph:
     # Note: a few lambdas in this function have default arguments e.g.
     # stream=stream. This is needed because capturing a loop-local variable in
     # a lambda captures only the final value of the variable, not the value it
     # had in the loop iteration where the lambda occurred.
 
-    # Copy the config, because we make some changes to it as we go
-    config = copy.deepcopy(config)
-
-    archived_streams = []
+    archived_streams: List[str] = []
     # Immutable keys to add to telstate on startup. There is no telstate yet
     # on which to call telstate.join, so nested keys must be expressed as
     # tuples which are joined later.
-    init_telstate = {'sdp_archived_streams': archived_streams, 'sdp_config': config}
+    init_telstate: Dict[Union[str, Tuple[str, ...]], Any] = {
+        'sdp_archived_streams': archived_streams,
+        'sdp_config': config_dict
+    }
     g = networkx.MultiDiGraph(
         archived_streams=archived_streams,  # For access as g.graph['archived_streams']
         init_telstate=init_telstate,        # ditto
@@ -1459,131 +1243,106 @@ def build_logical_graph(config):
     )
 
     # telstate node
-    telstate = _make_telstate(g, config)
+    telstate = _make_telstate(g, configuration)
 
-    # Make a list of input streams of each type and add SPEAD endpoints to
-    # the graph.
-    inputs = {}
+    # Add SPEAD endpoints to the graph.
     input_multicast = []
-    for name, input_ in config['inputs'].items():
-        inputs.setdefault(input_['type'], []).append(name)
-        url = input_['url']
-        parts = urllib.parse.urlsplit(url)
-        if parts.scheme == 'spead':
-            node = LogicalMulticast('multicast.' + name,
-                                    endpoint=Endpoint(parts.hostname, parts.port))
-            g.add_node(node)
-            input_multicast.append(node)
+    for stream in configuration.streams:
+        if isinstance(stream, product_config.CbfStream):
+            url = stream.url
+            if url.scheme == 'spead':
+                node = LogicalMulticast('multicast.' + stream.name,
+                                        endpoint=Endpoint(url.host, url.port))
+                g.add_node(node)
+                input_multicast.append(node)
 
     # cam2telstate node (optional: if we're simulating, we don't need it)
-    if 'cam.http' in inputs:
-        cam2telstate = _make_cam2telstate(g, config, inputs['cam.http'][0])
+    cam_http = configuration.by_class(product_config.CamHttpStream)
+    cam2telstate: Optional[scheduler.LogicalNode] = None
+    if cam_http:
+        cam2telstate = _make_cam2telstate(g, configuration, cam_http[0])
         for node in input_multicast:
             g.add_edge(node, cam2telstate, depends_ready=True)
-    else:
-        cam2telstate = None
 
     # meta_writer node
-    meta_writer = _make_meta_writer(g, config)
+    meta_writer = _make_meta_writer(g, configuration)
 
-    # Find all input streams that are actually used. At the moment only the
-    # direct dependencies are gathered because those are the only ones that
-    # can have the simulate flag anyway.
-    inputs_used = set()
-    for output in config['outputs'].values():
-        inputs_used.update(output['src_streams'])
-
-    # Simulators for input streams where requested
-    cbf_streams = inputs.get('cbf.baseline_correlation_products', [])
-    cbf_streams.extend(inputs.get('cbf.tied_array_channelised_voltage', []))
-    for name in cbf_streams:
-        if name in inputs_used and config['inputs'][name]['simulate'] is not False:
-            _make_cbf_simulator(g, config, name)
-
-    # Group outputs by type
-    outputs = {}
-    for name, output in config['outputs'].items():
-        outputs.setdefault(output['type'], []).append(name)
+    # Simulators
+    for stream in configuration.by_class(product_config.SimBaselineCorrelationProductsStream):
+        _make_cbf_simulator(g, configuration, stream)
+    for stream in configuration.by_class(product_config.SimTiedArrayChannelisedVoltageStream):
+        _make_cbf_simulator(g, configuration, stream)
 
     # Pair up spectral and continuum L0 outputs
     l0_done = set()
-    for name in outputs.get('sdp.vis', []):
-        if config['outputs'][name]['continuum_factor'] == 1:
-            for name2 in outputs['sdp.vis']:
-                if name2 not in l0_done and config['outputs'][name2]['continuum_factor'] > 1:
-                    # Temporarily alter it to check if they're the same other
-                    # than continuum_factor and archive.
-                    cont_factor = config['outputs'][name2]['continuum_factor']
-                    archive = config['outputs'][name2]['archive']
-                    config['outputs'][name2]['continuum_factor'] = 1
-                    config['outputs'][name2]['archive'] = config['outputs'][name]['archive']
-                    match = (config['outputs'][name] == config['outputs'][name2])
-                    config['outputs'][name2]['continuum_factor'] = cont_factor
-                    config['outputs'][name2]['archive'] = archive
-                    if match:
-                        _adjust_ingest_output_channels(config, [name, name2])
-                        _make_ingest(g, config, name, name2)
-                        _make_timeplot_correlator(g, config, name)
-                        l0_done.add(name)
-                        l0_done.add(name2)
+    for stream in configuration.by_class(product_config.VisStream):
+        if stream.continuum_factor == 1:
+            for stream2 in configuration.by_class(product_config.VisStream):
+                if (stream2 not in l0_done and stream2.continuum_factor > 1
+                    and stream2.compatible(stream)):
+                        _adjust_ingest_output_channels(config, [name, name2])  # TODO
+                        _make_ingest(g, configuration, stream, stream2)
+                        _make_timeplot_correlator(g, configuration, stream)
+                        l0_done.add(stream)
+                        l0_done.add(stream2)
                         break
 
     l0_spectral_only = False
     l0_continuum_only = False
-    for name in set(outputs.get('sdp.vis', [])) - l0_done:
-        is_spectral = config['outputs'][name]['continuum_factor'] == 1
+    for stream in set(configuration.by_class(product_config.VisStream)) - l0_done:
+        is_spectral = stream.continuum_factor == 1
         if is_spectral:
             l0_spectral_only = True
         else:
             l0_continuum_only = True
-        _adjust_ingest_output_channels(config, [name])
+        _adjust_ingest_output_channels(configuration, [stream])
         if is_spectral:
-            _make_ingest(g, config, name, None)
-            _make_timeplot_correlator(g, config, name)
+            _make_ingest(g, configuration, stream, None)
+            _make_timeplot_correlator(g, configuration, stream)
         else:
-            _make_ingest(g, config, None, name)
+            _make_ingest(g, configuration, None, stream)
     if l0_continuum_only and l0_spectral_only:
         logger.warning('Both continuum-only and spectral-only L0 streams found - '
                        'perhaps they were intended to be matched?')
 
-    for name in outputs.get('sdp.vis', []):
-        if config['outputs'][name]['archive']:
-            _make_vis_writer(g, config, name, 'archive', local=True)
+    for stream in configuration.by_class(product_config.VisStream):
+        if stream.archive:
+            _make_vis_writer(g, configuration, stream, 'archive', local=True)
 
-    have_cal = set()
-    for name in outputs.get('sdp.cal', []):
-        src_name = config['outputs'][name]['src_streams'][0]
-        # Check for a corresponding flags outputs
-        flags_names = []
-        for name2 in outputs.get('sdp.flags', []):
-            if config['outputs'][name2]['calibration'][0] == name:
-                flags_names.append(name2)
-        if _make_cal(g, config, name, src_name, flags_names):
-            have_cal.add(name)
-            for flags_name in flags_names:
-                if config['outputs'][flags_name]['archive']:
-                    # Pass l0 name to flag writer to allow calc of bandwidths and sizes
-                    flags_l0_name = config['outputs'][flags_name]['src_streams'][0]
-                    _make_flag_writer(g, config, flags_name, flags_l0_name, 'archive', local=True)
-    for name in outputs.get('sdp.beamformer_engineering', []):
-        _make_beamformer_engineering(g, config, name)
+    for stream in configuration.by_class(product_config.CalStream):
+        src = stream.vis
+        # Check for all corresponding flags outputs
+        flags = []
+        for flags_stream in configuration.by_class(product_config.FlagsStream):
+            if flags_stream.cal is stream:
+                flags.append(flags_stream)
+        _make_cal(g, configuration, stream, flags)
+        for flags_stream in flags:
+            if flags_stream.archive:
+                _make_flag_writer(g, configuration, flags_stream, 'archive', local=True)
+
+    for stream in configuration.by_class(product_config.BeamformerEngineeringStream):
+        _make_beamformer_engineering(g, configuration, stream)
 
     # Collect all tied-array-channelised-voltage streams and make signal displays for them
-    for name in inputs.get('cbf.tied_array_channelised_voltage', []):
-        if name in inputs_used:
-            _make_timeplot_beamformer(g, config, name)
+    for stream in configuration.by_class(product_config.TiedArrayChannelisedVoltageStream):
+        _make_timeplot_beamformer(g, configuration, stream)
 
-    for name in outputs.get('sdp.continuum_image', []):
-        _make_imager_writers(g, config, have_cal, 'continuum', name)
-    for name in outputs.get('sdp.spectral_image', []):
-        _make_imager_writers(g, config, have_cal, 'spectral', name, SPECTRAL_OBJECT_CHANNELS)
+    for stream in configuration.by_class(product_config.ContinuumImageStream):
+        _make_imager_writers(g, configuration, 'continuum', stream)
+    for stream in configuration.by_class(product_config.SpectralImageStream):
+        _make_imager_writers(g, configuration, 'spectral', stream, SPECTRAL_OBJECT_CHANNELS)
     # Imagers are mostly handled in build_postprocess_logical_graph, but we create
     # capture block-independent metadata here.
-    for type_ in ['sdp.continuum_image', 'sdp.spectral_image']:
-        for name in outputs.get(type_, []):
-            g.graph['archived_streams'].append(name)
-            g.graph['init_telstate'][(name, 'src_streams')] = config['outputs'][name]['src_streams']
-            g.graph['init_telstate'][(name, 'stream_type')] = type_
+    image_classes: List[Type[product_config.Stream]] = [
+        product_config.ContinuumImageStream,
+        product_config.SpectralImageStream
+    ]
+    for cls_ in image_classes:
+        for stream in configuration.by_class(cls_):
+            archived_streams.append(stream.name)
+            init_telstate[(stream.name, 'src_streams')] = [s.name for s in stream.src_streams]
+            init_telstate[(stream.name, 'stream_type')] = stream.stream_type
 
     # Count large allocations in telstate, which affects memory usage of
     # telstate itself and any tasks that dump the contents of telstate.
@@ -1601,7 +1360,7 @@ def build_logical_graph(config):
                 node.command.extend([
                     '--telstate', '{endpoints[telstate_telstate]}',
                     '--name', node.name])
-                node.wrapper = config['config'].get('wrapper')
+                node.wrapper = configuration.options.wrapper
                 g.add_edge(node, telstate, port='telstate',
                            depends_ready=True, depends_kill=True)
             # Make sure meta_writer is the last task to be handled in capture-done
@@ -1623,7 +1382,12 @@ def build_logical_graph(config):
                 request.bandwidth_in = round(request.bandwidth_in)
                 request.bandwidth_out = round(request.bandwidth_out)
             # Apply host overrides
-            force_host = config['config']['service_overrides'].get(node.name, {}).get('host')
+            force_host: Optional[str] = None
+            try:
+                service_override = configuration.options.service_overrides[node.name]
+                force_host = service_override.host
+            except KeyError:
+                pass
             if force_host is not None:
                 node.host = force_host
     return g

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -299,10 +299,7 @@ class AntennaChannelisedVoltageStreamBase(Stream):
         self.bandwidth = bandwidth
         self.centre_frequency = centre_frequency
         self.adc_sample_rate = adc_sample_rate
-        if n_samples_between_spectra is None:
-            self.n_samples_between_spectra: int = round(n_channels * adc_sample_rate // bandwidth)
-        else:
-            self.n_samples_between_spectra = n_samples_between_spectra
+        self.n_samples_between_spectra = n_samples_between_spectra
 
 
 class AntennaChannelisedVoltageStream(CbfStream, AntennaChannelisedVoltageStreamBase):
@@ -754,7 +751,7 @@ class SimTiedArrayChannelisedVoltageStream(TiedArrayChannelisedVoltageStreamBase
             name, src_streams,
             n_endpoints=config['n_endpoints'],
             n_channels_per_substream=config.get('n_chans_per_substream'),
-            spectra_per_heap=config.get('spectra_per_heap', 256)
+            spectra_per_heap=config.get('spectra_per_heap', KATCBFSIM_SPECTRA_PER_HEAP)
         )
 
 
@@ -769,7 +766,7 @@ class VisStream(Stream):
 
     def __init__(self, name: str, src_streams: Sequence[Stream], *,
                  int_time: float,
-                 output_channels: Optional[Tuple[int, int]],
+                 output_channels: Optional[Tuple[int, int]] = None,
                  continuum_factor: int,
                  excise: bool,
                  archive: bool,
@@ -1133,7 +1130,7 @@ class SpectralImageStream(ImageStream):
     _valid_src_types: ClassVar[_ValidTypes] = ['sdp.flags', 'sdp.continuum_image']
 
     def __init__(self, name: str, src_streams: Sequence[Stream], *,
-                 output_channels: Optional[Tuple[int, int]],
+                 output_channels: Optional[Tuple[int, int]] = None,
                  parameters: Mapping[str, Any],
                  min_time: float) -> None:
         super().__init__(name, src_streams, min_time=min_time)

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -545,6 +545,7 @@ class BaselineCorrelationProductsStream(CbfStream, BaselineCorrelationProductsSt
         self.instrument_dev_name = instrument_dev_name
 
     if TYPE_CHECKING:
+        # Refine the return type for mypy
         @property
         def antenna_channelised_voltage(self) -> AntennaChannelisedVoltageStream: ...
 
@@ -593,6 +594,7 @@ class SimBaselineCorrelationProductsStream(BaselineCorrelationProductsStreamBase
         )
 
     if TYPE_CHECKING:
+        # Refine the return type for mypy
         @property
         def antenna_channelised_voltage(self) -> SimAntennaChannelisedVoltageStream: ...
 
@@ -667,6 +669,7 @@ class TiedArrayChannelisedVoltageStream(CbfStream, TiedArrayChannelisedVoltageSt
         self.instrument_dev_name = instrument_dev_name
 
     if TYPE_CHECKING:
+        # Refine the return type for mypy
         @property
         def antenna_channelised_voltage(self) -> AntennaChannelisedVoltageStream: ...
 
@@ -711,6 +714,7 @@ class SimTiedArrayChannelisedVoltageStream(TiedArrayChannelisedVoltageStreamBase
         )
 
     if TYPE_CHECKING:
+        # Refine the return type for mypy
         @property
         def antenna_channelised_voltage(self) -> SimAntennaChannelisedVoltageStream: ...
 

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -811,6 +811,11 @@ class VisStream(Stream):
         return self.output_channels[1] - self.output_channels[0]
 
     @property
+    def n_spectral_vis(self) -> int:
+        """Number of visibilities per dump in the output, before continuum averaging."""
+        return self.n_spectral_chans * self.n_baselines
+
+    @property
     def antennas(self) -> Sequence[str]:
         return self.baseline_correlation_products.antennas
 

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -879,15 +879,11 @@ class VisStream(Stream):
         """Determine whether the configurations are mostly the same.
 
         Specifically, they must be the same other than the values of
-        ``continuum_factor`` and ``archive``.
+        ``name``, ``continuum_factor`` and ``archive``.
         """
-        return (
-            self.src_streams[0] is other.src_streams[0]
-            and self.int_time == other.int_time
-            and self.output_channels == other.output_channels
-            and self.excise == other.excise
-            and self.n_servers == other.n_servers
-        )
+        return all(getattr(self, name) == getattr(other, name)
+                   for name in vars(self)
+                   if name not in ['name', 'continuum_factor', 'archive'])
 
 
 class BeamformerStreamBase(Stream):

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -1106,9 +1106,9 @@ class ContinuumImageStream(ImageStream):
     _valid_src_types: ClassVar[_ValidTypes] = {'sdp.flags'}
 
     def __init__(self, name: str, src_streams: Sequence[Stream], *,
-                 uvblavg_parameters: Mapping[str, Any] = {},
-                 mfimage_parameters: Mapping[str, Any] = {},
-                 max_realtime: Optional[float] = None,
+                 uvblavg_parameters: Mapping[str, Any],
+                 mfimage_parameters: Mapping[str, Any],
+                 max_realtime: Optional[float],
                  min_time: float) -> None:
         super().__init__(name, src_streams, min_time=min_time)
         self.uvblavg_parameters = dict(uvblavg_parameters)

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -1151,6 +1151,10 @@ class SpectralImageStream(ImageStream):
         return self.output_channels[1] - self.output_channels[0]
 
     @property
+    def flags(self) -> FlagsStream:
+        return cast(FlagsStream, self.src_streams[0])
+
+    @property
     def continuum(self) -> Optional[ContinuumImageStream]:
         try:
             return cast(ContinuumImageStream, self.src_streams[1])

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -401,7 +401,7 @@ class SimAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase):
                 antennas.append(katpoint.Antenna(desc))
             except Exception as exc:
                 # katpoint can throw all kinds of exceptions
-                raise ValueError('Invalid antenna description {desc!r}: {exc}') from exc
+                raise ValueError(f'Invalid antenna description {desc!r}: {exc}') from exc
         return cls(
             name, src_streams,
             antennas=antennas,

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -124,31 +124,31 @@ class _SubSensor(_Sensor):
 
 
 def _normalise_output_channels(
-        n_channels: int,
+        n_chans: int,
         output_channels: Optional[Tuple[int, int]],
         alignment: int = 1) -> Tuple[int, int]:
     """Provide default for and validate `output_channels`, and align.
 
-    If `output_channels` is ``None``, it will default to (0, `n_channels`). Otherwise,
+    If `output_channels` is ``None``, it will default to (0, `n_chans`). Otherwise,
     it will be widened so that both ends are multiples of `alignment`.
 
     Raises
     ------
     ValueError
-        If the output range is empty or overflows (0, `n_channels`).
+        If the output range is empty or overflows (0, `n_chans`).
     ValueError
-        If `n_channels` is not a multiple of `alignment`
+        If `n_chans` is not a multiple of `alignment`
     """
-    if n_channels % alignment != 0:
-        raise ValueError(f'n_channels ({n_channels}) '
+    if n_chans % alignment != 0:
+        raise ValueError(f'n_chans ({n_chans}) '
                          f'is not a multiple of required alignment ({alignment})')
     c = output_channels    # Just for less typing
     if c is None:
-        return (0, n_channels)
+        return (0, n_chans)
     elif c[0] >= c[1]:
         raise ValueError(f'output_channels is empty ({c[0]}:{c[1]})')
-    elif c[0] < 0 or c[1] > n_channels:
-        raise ValueError(f'output_channels ({c[0]}:{c[1]}) overflows valid range 0:{n_channels}')
+    elif c[0] < 0 or c[1] > n_chans:
+        raise ValueError(f'output_channels ({c[0]}:{c[1]}) overflows valid range 0:{n_chans}')
     else:
         return (c[0] // alignment * alignment,
                 (c[1] + alignment - 1) // alignment * alignment)
@@ -309,7 +309,7 @@ class AntennaChannelisedVoltageStreamBase(Stream):
     def __init__(self, name: str, src_streams: Sequence[Stream], *,
                  antennas: Iterable[str],
                  band: str,
-                 n_channels: int,
+                 n_chans: int,
                  bandwidth: float,
                  adc_sample_rate: float,
                  centre_frequency: float,
@@ -317,7 +317,7 @@ class AntennaChannelisedVoltageStreamBase(Stream):
         super().__init__(name, src_streams)
         self.antennas = list(antennas)
         self.band = band
-        self.n_channels = n_channels
+        self.n_chans = n_chans
         self.bandwidth = bandwidth
         self.centre_frequency = centre_frequency
         self.adc_sample_rate = adc_sample_rate
@@ -341,7 +341,7 @@ class AntennaChannelisedVoltageStream(CbfStream, AntennaChannelisedVoltageStream
                  url: yarl.URL,
                  antennas: Iterable[str],
                  band: str,
-                 n_channels: int,
+                 n_chans: int,
                  bandwidth: float,
                  adc_sample_rate: float,
                  centre_frequency: float,
@@ -351,7 +351,7 @@ class AntennaChannelisedVoltageStream(CbfStream, AntennaChannelisedVoltageStream
             name, src_streams,
             antennas=antennas,
             band=band,
-            n_channels=n_channels,
+            n_chans=n_chans,
             bandwidth=bandwidth,
             adc_sample_rate=adc_sample_rate,
             centre_frequency=centre_frequency,
@@ -372,7 +372,7 @@ class AntennaChannelisedVoltageStream(CbfStream, AntennaChannelisedVoltageStream
             url=yarl.URL(config['url']),
             antennas=config['antennas'],
             band=sensors['band'],
-            n_channels=sensors['n_chans'],
+            n_chans=sensors['n_chans'],
             bandwidth=sensors['bandwidth'],
             adc_sample_rate=sensors['adc_sample_rate'],
             centre_frequency=sensors['centre_frequency'],
@@ -389,7 +389,7 @@ class SimAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase):
     def __init__(self, name: str, src_streams: Sequence[Stream], *,
                  antennas: Iterable[katpoint.Antenna],
                  band: str,
-                 n_channels: int,
+                 n_chans: int,
                  bandwidth: float,
                  adc_sample_rate: float,
                  centre_frequency: float) -> None:
@@ -397,12 +397,12 @@ class SimAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase):
         ratio = adc_sample_rate / (2 * bandwidth)
         if abs(ratio - round(ratio)) > 1e-6:
             raise ValueError('ADC Nyquist frequency is not a multiple of bandwidth')
-        n_samples_between_spectra = round(n_channels * adc_sample_rate // bandwidth)
+        n_samples_between_spectra = round(n_chans * adc_sample_rate // bandwidth)
         super().__init__(
             name, src_streams,
             antennas=[antenna.name for antenna in self.antenna_objects],
             band=band,
-            n_channels=n_channels,
+            n_chans=n_chans,
             bandwidth=bandwidth,
             centre_frequency=centre_frequency,
             adc_sample_rate=adc_sample_rate,
@@ -427,7 +427,7 @@ class SimAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase):
             name, src_streams,
             antennas=antennas,
             band=config['band'],
-            n_channels=config['n_chans'],
+            n_chans=config['n_chans'],
             bandwidth=config['bandwidth'],
             adc_sample_rate=config['adc_sample_rate'],
             centre_frequency=config['centre_frequency']
@@ -442,21 +442,21 @@ class CbfPerChannelStream(Stream):
 
     def __init__(self, name: str, src_streams: Sequence[Stream], *,
                  n_endpoints: int,
-                 n_channels_per_substream: int,
+                 n_chans_per_substream: int,
                  bits_per_sample: int) -> None:
         super().__init__(name, src_streams)
         self.n_endpoints = n_endpoints
-        self.n_channels_per_substream = n_channels_per_substream
+        self.n_chans_per_substream = n_chans_per_substream
         self.bits_per_sample = bits_per_sample
 
-        if self.n_channels % self.n_endpoints != 0:
+        if self.n_chans % self.n_endpoints != 0:
             raise ValueError(
-                f'n_channels ({self.n_channels}) is not '
+                f'n_chans ({self.n_chans}) is not '
                 f'a multiple of endpoints ({self.n_endpoints})')
-        if self.n_channels_per_endpoint % self.n_channels_per_substream != 0:
+        if self.n_chans_per_endpoint % self.n_chans_per_substream != 0:
             raise ValueError(
-                f'channels per endpoint ({self.n_channels_per_endpoint}) '
-                f'is not a multiple of channels per substream ({self.n_channels_per_substream})'
+                f'channels per endpoint ({self.n_chans_per_endpoint}) '
+                f'is not a multiple of channels per substream ({self.n_chans_per_substream})'
             )
 
     @property
@@ -469,17 +469,17 @@ class CbfPerChannelStream(Stream):
         return self.antenna_channelised_voltage.antennas
 
     @property
-    def n_channels(self) -> int:
+    def n_chans(self) -> int:
         """Number of channels."""
-        return self.antenna_channelised_voltage.n_channels
+        return self.antenna_channelised_voltage.n_chans
 
     @property
-    def n_channels_per_endpoint(self) -> int:
-        return self.n_channels // self.n_endpoints
+    def n_chans_per_endpoint(self) -> int:
+        return self.n_chans // self.n_endpoints
 
     @property
     def n_substreams(self) -> int:
-        return self.n_channels // self.n_channels_per_substream
+        return self.n_chans // self.n_chans_per_substream
 
     @property
     def n_antennas(self) -> int:
@@ -528,13 +528,13 @@ class BaselineCorrelationProductsStreamBase(CbfPerChannelStream):
     def __init__(self, name: str, src_streams: Sequence[Stream], *,
                  int_time: float,
                  n_endpoints: int,
-                 n_channels_per_substream: int,
+                 n_chans_per_substream: int,
                  n_baselines: int,
                  bits_per_sample: int):
         super().__init__(
             name, src_streams,
             n_endpoints=n_endpoints,
-            n_channels_per_substream=n_channels_per_substream,
+            n_chans_per_substream=n_chans_per_substream,
             bits_per_sample=bits_per_sample
         )
         self._int_time = int_time
@@ -546,7 +546,7 @@ class BaselineCorrelationProductsStreamBase(CbfPerChannelStream):
 
     @property
     def n_vis(self) -> int:
-        return self.n_baselines * self.n_channels
+        return self.n_baselines * self.n_chans
 
     @property
     def size(self) -> int:
@@ -569,7 +569,7 @@ class BaselineCorrelationProductsStream(CbfStream, BaselineCorrelationProductsSt
     def __init__(self, name: str, src_streams: Sequence[Stream], *,
                  url: yarl.URL,
                  int_time: float,
-                 n_channels_per_substream: int,
+                 n_chans_per_substream: int,
                  n_baselines: int,
                  bits_per_sample: int,
                  instrument_dev_name: str) -> None:
@@ -577,7 +577,7 @@ class BaselineCorrelationProductsStream(CbfStream, BaselineCorrelationProductsSt
             name, src_streams,
             int_time=int_time,
             n_endpoints=_url_n_endpoints(url),
-            n_channels_per_substream=n_channels_per_substream,
+            n_chans_per_substream=n_chans_per_substream,
             n_baselines=n_baselines,
             bits_per_sample=bits_per_sample
         )
@@ -600,7 +600,7 @@ class BaselineCorrelationProductsStream(CbfStream, BaselineCorrelationProductsSt
             name, src_streams,
             int_time=sensors['int_time'],
             url=yarl.URL(config['url']),
-            n_channels_per_substream=sensors['n_chans_per_substream'],
+            n_chans_per_substream=sensors['n_chans_per_substream'],
             n_baselines=sensors['n_bls'],
             bits_per_sample=sensors['xeng_out_bits_per_sample'],
             instrument_dev_name=config['instrument_dev_name']
@@ -616,23 +616,23 @@ class SimBaselineCorrelationProductsStream(BaselineCorrelationProductsStreamBase
     def __init__(self, name: str, src_streams: Sequence[Stream], *,
                  int_time: float,
                  n_endpoints: int,
-                 n_channels_per_substream: Optional[int] = None) -> None:
+                 n_chans_per_substream: Optional[int] = None) -> None:
         acv = cast(AntennaChannelisedVoltageStream, src_streams[0])
-        if n_channels_per_substream is not None:
-            ncps = n_channels_per_substream
+        if n_chans_per_substream is not None:
+            ncps = n_chans_per_substream
         else:
-            ncps = acv.n_channels // n_endpoints
+            ncps = acv.n_chans // n_endpoints
         n_antennas = len(acv.antennas)
         # Round the int_time the same way katcbfsim does, so that we have
         # an accurate value.
-        heap_time = acv.n_channels / acv.bandwidth * KATCBFSIM_SPECTRA_PER_HEAP
+        heap_time = acv.n_chans / acv.bandwidth * KATCBFSIM_SPECTRA_PER_HEAP
         acc_heaps = max(1, round(int_time / heap_time))
         int_time = acc_heaps * heap_time
         super().__init__(
             name, src_streams,
             int_time=int_time,
             n_endpoints=n_endpoints,
-            n_channels_per_substream=ncps,
+            n_chans_per_substream=ncps,
             n_baselines=n_antennas * (n_antennas + 1) * 2,
             bits_per_sample=32
         )
@@ -653,7 +653,7 @@ class SimBaselineCorrelationProductsStream(BaselineCorrelationProductsStreamBase
             name, src_streams,
             int_time=config['int_time'],
             n_endpoints=config['n_endpoints'],
-            n_channels_per_substream=config.get('n_chans_per_substream')
+            n_chans_per_substream=config.get('n_chans_per_substream')
         )
 
 
@@ -662,13 +662,13 @@ class TiedArrayChannelisedVoltageStreamBase(CbfPerChannelStream):
 
     def __init__(self, name: str, src_streams: Sequence[Stream], *,
                  n_endpoints: int,
-                 n_channels_per_substream: int,
+                 n_chans_per_substream: int,
                  spectra_per_heap: int,
                  bits_per_sample: int) -> None:
         super().__init__(
             name, src_streams,
             n_endpoints=n_endpoints,
-            n_channels_per_substream=n_channels_per_substream,
+            n_chans_per_substream=n_chans_per_substream,
             bits_per_sample=bits_per_sample
         )
         self.spectra_per_heap = spectra_per_heap
@@ -676,7 +676,7 @@ class TiedArrayChannelisedVoltageStreamBase(CbfPerChannelStream):
     @property
     def size(self) -> int:
         """Size of frame in bytes."""
-        return self.bits_per_sample * 2 * self.spectra_per_heap * self.n_channels // 8
+        return self.bits_per_sample * 2 * self.spectra_per_heap * self.n_chans // 8
 
     @property
     def int_time(self) -> float:
@@ -697,14 +697,14 @@ class TiedArrayChannelisedVoltageStream(CbfStream, TiedArrayChannelisedVoltageSt
 
     def __init__(self, name: str, src_streams: Sequence[Stream], *,
                  url: yarl.URL,
-                 n_channels_per_substream: int,
+                 n_chans_per_substream: int,
                  spectra_per_heap: int,
                  bits_per_sample: int,
                  instrument_dev_name: str) -> None:
         super().__init__(
             name, src_streams,
             n_endpoints=_url_n_endpoints(url),
-            n_channels_per_substream=n_channels_per_substream,
+            n_chans_per_substream=n_chans_per_substream,
             spectra_per_heap=spectra_per_heap,
             bits_per_sample=bits_per_sample,
         )
@@ -726,7 +726,7 @@ class TiedArrayChannelisedVoltageStream(CbfStream, TiedArrayChannelisedVoltageSt
         return cls(
             name, src_streams,
             url=yarl.URL(config['url']),
-            n_channels_per_substream=sensors['n_chans_per_substream'],
+            n_chans_per_substream=sensors['n_chans_per_substream'],
             spectra_per_heap=sensors['spectra_per_heap'],
             bits_per_sample=sensors['beng_out_bits_per_sample'],
             instrument_dev_name=config['instrument_dev_name']
@@ -741,17 +741,17 @@ class SimTiedArrayChannelisedVoltageStream(TiedArrayChannelisedVoltageStreamBase
 
     def __init__(self, name: str, src_streams: Sequence[Stream], *,
                  n_endpoints: int,
-                 n_channels_per_substream: Optional[int] = None,
+                 n_chans_per_substream: Optional[int] = None,
                  spectra_per_heap: int) -> None:
         acv = cast(AntennaChannelisedVoltageStream, src_streams[0])
-        if n_channels_per_substream is not None:
-            ncps = n_channels_per_substream
+        if n_chans_per_substream is not None:
+            ncps = n_chans_per_substream
         else:
-            ncps = acv.n_channels // n_endpoints
+            ncps = acv.n_chans // n_endpoints
         super().__init__(
             name, src_streams,
             n_endpoints=n_endpoints,
-            n_channels_per_substream=ncps,
+            n_chans_per_substream=ncps,
             spectra_per_heap=spectra_per_heap,
             bits_per_sample=8
         )
@@ -771,7 +771,7 @@ class SimTiedArrayChannelisedVoltageStream(TiedArrayChannelisedVoltageStreamBase
         return cls(
             name, src_streams,
             n_endpoints=config['n_endpoints'],
-            n_channels_per_substream=config.get('n_chans_per_substream'),
+            n_chans_per_substream=config.get('n_chans_per_substream'),
             spectra_per_heap=config.get('spectra_per_heap', KATCBFSIM_SPECTRA_PER_HEAP)
         )
 
@@ -793,7 +793,7 @@ class VisStream(Stream):
                  archive: bool,
                  n_servers: int) -> None:
         super().__init__(name, src_streams)
-        cbf_channels = self.baseline_correlation_products.n_channels
+        cbf_channels = self.baseline_correlation_products.n_chans
         cbf_int_time = self.baseline_correlation_products.int_time
         self.int_time = max(1, round(int_time / cbf_int_time)) * cbf_int_time
         c = _normalise_output_channels(cbf_channels, output_channels, n_servers * continuum_factor)
@@ -808,12 +808,12 @@ class VisStream(Stream):
         return cast(BaselineCorrelationProductsStreamBase, self.src_streams[0])
 
     @property
-    def n_channels(self) -> int:
+    def n_chans(self) -> int:
         rng = self.output_channels
         return (rng[1] - rng[0]) // self.continuum_factor
 
     @property
-    def n_spectral_channels(self) -> int:
+    def n_spectral_chans(self) -> int:
         """Number of CBF channels that are in the output, before continuum averaging."""
         return self.output_channels[1] - self.output_channels[0]
 
@@ -836,13 +836,13 @@ class VisStream(Stream):
 
     @property
     def n_vis(self) -> int:
-        return self.n_baselines * self.n_channels
+        return self.n_baselines * self.n_chans
 
     @property
     def size(self) -> int:
         """Size of each frame in bytes."""
         # complex64 for vis, uint8 for weights and flags, float32 for weights_channel
-        return self.n_vis * BYTES_PER_VFW + self.n_channels * 4
+        return self.n_vis * BYTES_PER_VFW + self.n_chans * 4
 
     @property
     def flag_size(self):
@@ -916,8 +916,8 @@ class BeamformerStreamBase(Stream):
         ]
 
     @property
-    def n_channels(self) -> int:
-        return self.antenna_channelised_voltage.n_channels
+    def n_chans(self) -> int:
+        return self.antenna_channelised_voltage.n_chans
 
 
 class BeamformerStream(BeamformerStreamBase):
@@ -944,15 +944,15 @@ class BeamformerEngineeringStream(BeamformerStreamBase):
                  store: str,
                  output_channels: Optional[Tuple[int, int]] = None) -> None:
         super().__init__(name, src_streams)
-        cbf_channels = self.antenna_channelised_voltage.n_channels
+        cbf_channels = self.antenna_channelised_voltage.n_chans
         c = _normalise_output_channels(cbf_channels, output_channels)
         for tacv in self.tied_array_channelised_voltage:
-            c = _normalise_output_channels(cbf_channels, c, tacv.n_channels_per_endpoint)
+            c = _normalise_output_channels(cbf_channels, c, tacv.n_chans_per_endpoint)
         self.output_channels = c
         self.store = store
 
     @property
-    def n_channels(self) -> int:
+    def n_chans(self) -> int:
         return self.output_channels[1] - self.output_channels[0]
 
     @classmethod
@@ -1055,8 +1055,8 @@ class FlagsStream(Stream):
         return self.vis.n_vis
 
     @property
-    def n_channels(self) -> int:
-        return self.vis.n_channels
+    def n_chans(self) -> int:
+        return self.vis.n_chans
 
     @property
     def n_baselines(self) -> int:
@@ -1148,11 +1148,11 @@ class SpectralImageStream(ImageStream):
                  min_time: float) -> None:
         super().__init__(name, src_streams, min_time=min_time)
         self.parameters = dict(parameters)
-        vis_channels = self.vis.n_channels
+        vis_channels = self.vis.n_chans
         self.output_channels = _normalise_output_channels(vis_channels, output_channels)
 
     @property
-    def n_channels(self) -> int:
+    def n_chans(self) -> int:
         return self.output_channels[1] - self.output_channels[0]
 
     @property

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -781,11 +781,11 @@ class VisStream(Stream):
         c = _normalise_output_channels(cbf_channels, output_channels)
         if cbf_channels % continuum_factor != 0:
             raise ValueError(
-                f'CBF channels ({cbf_channels}) not a multiple of '
+                f'CBF channels ({cbf_channels}) is not a multiple of '
                 f'continuum_factor ({continuum_factor})')
         if c[0] % continuum_factor != 0 or c[1] % continuum_factor != 0:
             raise ValueError(
-                f'Channel range {c[0]}:{c[1]} is not a multiple of '
+                f'Channel range ({c[0]}:{c[1]}) is not a multiple of '
                 f'continuum_factor ({continuum_factor})')
         # TODO: review this - seems the old code would instead adjust the channel
         # range to ensure alignment.
@@ -945,9 +945,13 @@ class BeamformerEngineeringStream(BeamformerStreamBase):
             for ch in c:
                 if ch % tacv.n_channels_per_endpoint != 0:
                     raise ValueError(
-                        f'Channel range {c[0]}:{c[1]} is not aligned to the multicast streams')
+                        f'Channel range ({c[0]}:{c[1]}) is not aligned to the multicast streams')
         self.output_channels = c
         self.store = store
+
+    @property
+    def n_channels(self) -> int:
+        return self.output_channels[1] - self.output_channels[0]
 
     @classmethod
     def from_config(cls,

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -430,11 +430,12 @@ class CbfPerChannelStream(Stream):
 
         if self.n_channels % self.n_endpoints != 0:
             raise ValueError(
-                f'n_channels ({self.n_channels}) not a multiple of endpoints ({self.n_endpoints})')
+                f'n_channels ({self.n_channels}) is not '
+                f'a multiple of endpoints ({self.n_endpoints})')
         if self.n_channels_per_endpoint % self.n_channels_per_substream != 0:
             raise ValueError(
-                f'channels per endpoints ({self.n_channels_per_endpoint}) '
-                f'not a multiple of channels per substream ({self.n_channels_per_substream})'
+                f'channels per endpoint ({self.n_channels_per_endpoint}) '
+                f'is not a multiple of channels per substream ({self.n_channels_per_substream})'
             )
 
     @property

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -140,7 +140,6 @@ def _normalise_output_channels(
     else:
         return (c[0] // alignment * alignment,
                 (c[1] + alignment - 1) // alignment * alignment)
-        return c
 
 
 def data_rate(size: float, time: float, ratio: float = 1.05, overhead: float = 128) -> float:

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -256,6 +256,11 @@ class Stream:
 
     stream_type: ClassVar[str]
     _class_sensors: ClassVar[Sequence[_Sensor]] = []
+    # Types that are accepted for ``src_streams``. If it is a set, then any
+    # element of ``src_streams`` may have any of the types in the set. If
+    # it is a list, then the ith element of ``src_streams`` must have the
+    # ith type in the list. The list may be longer than ``src_streams``
+    # e.g. if there are optional elements.
     _valid_src_types: ClassVar[_ValidTypes] = set()
 
     def __init__(self, name: str, src_streams: Sequence['Stream']) -> None:

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -1062,7 +1062,7 @@ class FlagsStream(Stream):
         return self.vis.flag_size
 
     def net_bandwidth(self, ratio: float = 1.05, overhead: int = 128) -> float:
-        return self.vis.flag_bandwidth(ratio, overhead)
+        return self.vis.flag_bandwidth(ratio, overhead) * self.rate_ratio
 
     @classmethod
     def from_config(cls,

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -317,6 +317,7 @@ class AntennaChannelisedVoltageStream(CbfStream, AntennaChannelisedVoltageStream
     ]
 
     def __init__(self, name: str, src_streams: Sequence[Stream], *,
+                 url: yarl.URL,
                  antennas: Iterable[str],
                  band: str,
                  n_channels: int,
@@ -335,6 +336,7 @@ class AntennaChannelisedVoltageStream(CbfStream, AntennaChannelisedVoltageStream
             centre_frequency=centre_frequency,
             n_samples_between_spectra=n_samples_between_spectra
         )
+        self.url = url
         self.instrument_dev_name = instrument_dev_name
 
     @classmethod
@@ -346,6 +348,7 @@ class AntennaChannelisedVoltageStream(CbfStream, AntennaChannelisedVoltageStream
                     sensors: Mapping[str, Any]) -> 'AntennaChannelisedVoltageStream':
         return cls(
             name, src_streams,
+            url=yarl.URL(config['url']),
             antennas=config['antennas'],
             band=sensors['band'],
             n_channels=sensors['n_chans'],
@@ -542,8 +545,8 @@ class BaselineCorrelationProductsStream(CbfStream, BaselineCorrelationProductsSt
     _valid_src_types: ClassVar[_ValidTypes] = {'cbf.antenna_channelised_voltage'}
 
     def __init__(self, name: str, src_streams: Sequence[Stream], *,
-                 int_time: float,
                  url: yarl.URL,
+                 int_time: float,
                  n_channels_per_substream: int,
                  n_baselines: int,
                  bits_per_sample: int,

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -214,7 +214,7 @@ class Simulation:
     @classmethod
     def from_config(cls, config: Mapping[str, Any]) -> 'Simulation':
         sources = []
-        for i, desc in enumerate(config.get('sources', [])):
+        for i, desc in enumerate(config.get('sources', []), 1):
             try:
                 source = katpoint.Target(desc)
             except Exception as exc:

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -603,7 +603,6 @@ class SimBaselineCorrelationProductsStream(BaselineCorrelationProductsStreamBase
                  int_time: float,
                  n_endpoints: int,
                  n_channels_per_substream: Optional[int] = None) -> None:
-        # TODO: round int_time to nearest suitable multiple
         acv = cast(AntennaChannelisedVoltageStream, src_streams[0])
         if n_channels_per_substream is not None:
             ncps = n_channels_per_substream

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -1278,7 +1278,7 @@ class Configuration:
                 streams[name] = stream_cls.from_config(
                     options, name, stream_config, src_streams, sensors[name])
             except ValueError as exc:
-                raise ValueError(f'Configuration error for {name}: {exc}') from exc
+                raise ValueError(f'Configuration error for stream {name}: {exc}') from exc
         return cls(options=options, simulation=simulation, streams=streams.values())
 
 

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -1050,6 +1050,14 @@ class FlagsStream(Stream):
         return self.vis.n_vis
 
     @property
+    def n_channels(self) -> int:
+        return self.vis.n_channels
+
+    @property
+    def n_baselines(self) -> int:
+        return self.vis.n_baselines
+
+    @property
     def size(self) -> int:
         return self.vis.flag_size
 

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -155,8 +155,8 @@ def _normalise_output_channels(
         return c
 
 
-def bandwidth(size: float, time: float, ratio: float = 1.05, overhead: float = 128) -> float:
-    """Convert a heap size to a bandwidth in bits per second.
+def data_rate(size: float, time: float, ratio: float = 1.05, overhead: float = 128) -> float:
+    """Convert a heap size to a data rate in bits per second.
 
     Parameters
     ----------
@@ -502,10 +502,10 @@ class CbfPerChannelStream(Stream):
     def int_time(self) -> float:
         """Time between heaps, in seconds."""
 
-    def net_bandwidth(self, ratio: float = 1.05, overhead: int = 128) -> float:
+    def data_rate(self, ratio: float = 1.05, overhead: int = 128) -> float:
         """Network bandwidth in bits per second."""
         heap_size = self.size / self.n_substreams
-        return bandwidth(heap_size, self.int_time, ratio, overhead) * self.n_substreams
+        return data_rate(heap_size, self.int_time, ratio, overhead) * self.n_substreams
 
 
 class BaselineCorrelationProductsStreamBase(CbfPerChannelStream):
@@ -835,11 +835,11 @@ class VisStream(Stream):
         """Size of the flags in each frame, in bytes."""
         return self.n_vis * BYTES_PER_FLAG
 
-    def net_bandwidth(self, ratio: float = 1.05, overhead: int = 128) -> float:
-        return bandwidth(self.size, self.int_time, ratio, overhead)
+    def data_rate(self, ratio: float = 1.05, overhead: int = 128) -> float:
+        return data_rate(self.size, self.int_time, ratio, overhead)
 
-    def flag_bandwidth(self, ratio: float = 1.05, overhead: int = 128) -> float:
-        return bandwidth(self.flag_size, self.int_time, ratio, overhead)
+    def flag_data_rate(self, ratio: float = 1.05, overhead: int = 128) -> float:
+        return data_rate(self.flag_size, self.int_time, ratio, overhead)
 
     @classmethod
     def from_config(cls,
@@ -1052,8 +1052,8 @@ class FlagsStream(Stream):
     def size(self) -> int:
         return self.vis.flag_size
 
-    def net_bandwidth(self, ratio: float = 1.05, overhead: int = 128) -> float:
-        return self.vis.flag_bandwidth(ratio, overhead) * self.rate_ratio
+    def data_rate(self, ratio: float = 1.05, overhead: int = 128) -> float:
+        return self.vis.flag_data_rate(ratio, overhead) * self.rate_ratio
 
     @classmethod
     def from_config(cls,

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -1244,7 +1244,9 @@ class Configuration:
                     except Exception as exc:
                         raise SensorFailure(f'Could not get value for {full_name}: {exc}') from exc
                     if sample.status not in {'nominal', 'warn', 'error'}:
-                        raise SensorFailure(f'Sensor {full_name} has status {sample.status}')
+                        raise SensorFailure(
+                            f'Sensor {full_name} has expected status {sample.status}'
+                        )
                     if not isinstance(sample.value, sensor.type):
                         actual_type = type(sample.value)
                         raise SensorFailure(

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -878,7 +878,7 @@ class VisStream(Stream):
     def compatible(self, other: 'VisStream') -> bool:
         """Determine whether the configurations are mostly the same.
 
-        Specifically, they must be the same other than the vlaues of
+        Specifically, they must be the same other than the values of
         ``continuum_factor`` and ``archive``.
         """
         return (

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -52,7 +52,7 @@ def _url_n_endpoints(url: Union[str, yarl.URL]) -> int:
 
     Parameters
     ----------
-    url : str
+    url
         URL of the form spead://host[+N]:port
 
     Raises

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -238,14 +238,6 @@ class Stream:
         self.name = name
         self.src_streams = list(src_streams)
 
-    def ancestors(self, stream_class: Type[_S]) -> List[_S]:
-        ans: List[_S] = []
-        for stream in self.src_streams:
-            if isinstance(stream, stream_class):
-                ans.append(stream)
-            ans.extend(stream.ancestors(stream_class))
-        return ans
-
     @classmethod
     @abstractmethod
     def from_config(cls: Type[_S],

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -563,7 +563,7 @@ class BaselineCorrelationProductsStream(CbfStream, BaselineCorrelationProductsSt
         self.url = url
         self.instrument_dev_name = instrument_dev_name
 
-    if TYPE_CHECKING:
+    if TYPE_CHECKING:     # pragma: nocover
         # Refine the return type for mypy
         @property
         def antenna_channelised_voltage(self) -> AntennaChannelisedVoltageStream: ...
@@ -612,7 +612,7 @@ class SimBaselineCorrelationProductsStream(BaselineCorrelationProductsStreamBase
             bits_per_sample=32
         )
 
-    if TYPE_CHECKING:
+    if TYPE_CHECKING:     # pragma: nocover
         # Refine the return type for mypy
         @property
         def antenna_channelised_voltage(self) -> SimAntennaChannelisedVoltageStream: ...
@@ -687,7 +687,7 @@ class TiedArrayChannelisedVoltageStream(CbfStream, TiedArrayChannelisedVoltageSt
         self.url = url
         self.instrument_dev_name = instrument_dev_name
 
-    if TYPE_CHECKING:
+    if TYPE_CHECKING:     # pragma: nocover
         # Refine the return type for mypy
         @property
         def antenna_channelised_voltage(self) -> AntennaChannelisedVoltageStream: ...
@@ -732,7 +732,7 @@ class SimTiedArrayChannelisedVoltageStream(TiedArrayChannelisedVoltageStreamBase
             bits_per_sample=8
         )
 
-    if TYPE_CHECKING:
+    if TYPE_CHECKING:     # pragma: nocover
         # Refine the return type for mypy
         @property
         def antenna_channelised_voltage(self) -> SimAntennaChannelisedVoltageStream: ...

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -64,7 +64,7 @@ def _url_n_endpoints(url: Union[str, yarl.URL]) -> int:
     if url.scheme != 'spead':
         raise ValueError(f'non-spead URL {url}')
     if url.host is None:
-        raise ValueError(f'URL {url} has no port')
+        raise ValueError(f'URL {url} has no host')
     if url.port is None:
         raise ValueError(f'URL {url} has no port')
     return len(endpoint_list_parser(None)(url.host))

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -273,7 +273,7 @@ class Stream:
 
 
 class CamHttpStream(Stream):
-    """A cam.http stream."""
+    """A stream for obtaining sensor values from katportal."""
 
     stream_type: ClassVar[str] = 'cam.http'
 

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -3,15 +3,13 @@
 import collections.abc
 import logging
 import itertools
-import json
 import copy
 import math
 from abc import ABC, abstractmethod
 from distutils.version import StrictVersion
 from typing import (
     Tuple, List, Dict, Mapping, AbstractSet, Sequence, Iterable,
-    Union, ClassVar, Type, TypeVar, Optional, Any, AnyStr, cast,
-    TYPE_CHECKING
+    Union, ClassVar, Type, TypeVar, Optional, Any, cast, TYPE_CHECKING
 )
 
 import networkx
@@ -1508,19 +1506,3 @@ def _upgrade(config):
 
     _validate(config)     # Should never fail if the input was valid
     return config
-
-
-async def parse(config_bytes: AnyStr) -> Configuration:
-    """Load and validate a config dictionary.
-
-    Raises
-    ------
-    ValueError
-        if `config_bytes` is not valid JSON
-    jsonschema.ValidationError
-        if the config doesn't conform to the schema
-    ValueError
-        if semantic constraints are violated
-    """
-    config = json.loads(config_bytes)
-    return await Configuration.from_config(config)

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -451,6 +451,11 @@ class CbfPerChannelStream(Stream):
         return self.antenna_channelised_voltage.bandwidth
 
     @property
+    def centre_frequency(self) -> float:
+        """Sky centre frequency, in Hz."""
+        return self.antenna_channelised_voltage.centre_frequency
+
+    @property
     def adc_sample_rate(self):
         """ADC sample rate, in Hz."""
         return self.antenna_channelised_voltage.adc_sample_rate
@@ -954,7 +959,7 @@ class CalStream(Stream):
         return cls(
             name, src_streams,
             parameters=config.get('parameters', {}),
-            buffer_time=config.get('buffer_time', DEFAULT_CAL_BUFFER_TIME),  # TODO: make constant
+            buffer_time=config.get('buffer_time', DEFAULT_CAL_BUFFER_TIME),
             max_scans=config.get('max_scans', DEFAULT_CAL_MAX_SCANS)
         )
 

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -1095,6 +1095,13 @@ class SpectralImageStream(ImageStream):
     def n_channels(self) -> int:
         return self.output_channels[1] - self.output_channels[0]
 
+    @property
+    def continuum(self) -> Optional[ContinuumImageStream]:
+        try:
+            return cast(ContinuumImageStream, self.src_streams[1])
+        except IndexError:
+            return None
+
     @classmethod
     def from_config(cls,
                     options: Options,

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -10,7 +10,8 @@ from abc import ABC, abstractmethod
 from distutils.version import StrictVersion
 from typing import (
     Tuple, List, Dict, Mapping, AbstractSet, Sequence, Iterable,
-    Union, ClassVar, Type, TypeVar, Optional, Any, AnyStr, cast
+    Union, ClassVar, Type, TypeVar, Optional, Any, AnyStr, cast,
+    TYPE_CHECKING
 )
 
 import networkx
@@ -543,6 +544,10 @@ class BaselineCorrelationProductsStream(CbfStream, BaselineCorrelationProductsSt
         self.url = url
         self.instrument_dev_name = instrument_dev_name
 
+    if TYPE_CHECKING:
+        @property
+        def antenna_channelised_voltage(self) -> AntennaChannelisedVoltageStream: ...
+
     @classmethod
     def from_config(cls,
                     options: Options,
@@ -586,6 +591,10 @@ class SimBaselineCorrelationProductsStream(BaselineCorrelationProductsStreamBase
             n_baselines=n_antennas * (n_antennas + 1) * 2,
             bits_per_sample=32
         )
+
+    if TYPE_CHECKING:
+        @property
+        def antenna_channelised_voltage(self) -> SimAntennaChannelisedVoltageStream: ...
 
     @classmethod
     def from_config(cls,
@@ -657,6 +666,10 @@ class TiedArrayChannelisedVoltageStream(CbfStream, TiedArrayChannelisedVoltageSt
         self.url = url
         self.instrument_dev_name = instrument_dev_name
 
+    if TYPE_CHECKING:
+        @property
+        def antenna_channelised_voltage(self) -> AntennaChannelisedVoltageStream: ...
+
     @classmethod
     def from_config(cls,
                     options: Options,
@@ -696,6 +709,10 @@ class SimTiedArrayChannelisedVoltageStream(TiedArrayChannelisedVoltageStreamBase
             spectra_per_heap=spectra_per_heap,
             bits_per_sample=8
         )
+
+    if TYPE_CHECKING:
+        @property
+        def antenna_channelised_voltage(self) -> SimAntennaChannelisedVoltageStream: ...
 
     @classmethod
     def from_config(cls,

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -173,6 +173,20 @@ def data_rate(size: float, time: float, ratio: float = 1.05, overhead: float = 1
 
 
 class ServiceOverride:
+    """Debugging tool to modify how a service is run.
+
+    Parameters
+    ----------
+    config
+        Override the command-line arguments passed to the service through
+        telescope state, using :func:`override`.
+    taskinfo
+        Override the task information given to Mesos to launch it, using
+        :func:`override`.
+    host
+        Force the task to run on a specific host.
+    """
+
     def __init__(self, *,
                  config: Mapping[str, Any] = {},
                  taskinfo: Mapping[str, Any] = {},

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -1342,7 +1342,6 @@ def _validate(config):
     if inputs and not have_cam_http:
         raise ValueError('A cam.http stream is required if there are any inputs')
 
-    has_flags = set()
     for name, output in outputs.items():
         try:
             # Names of inputs and outputs must be disjoint
@@ -1362,14 +1361,6 @@ def _validate(config):
                         raise ValueError('calibration ({}) has wrong type {}'
                                          .format(calibration,
                                                  outputs[calibration]['type']))
-                if version < '2.2':
-                    if calibration in has_flags:
-                        raise ValueError('calibration ({}) already has a flags output'
-                                         .format(calibration))
-                    if output['src_streams'] != outputs[calibration]['src_streams']:
-                        raise ValueError('calibration ({}) has different src_streams'
-                                         .format(calibration))
-                    has_flags.add(calibration)
 
         except ValueError as error:
             raise ValueError('{}: {}'.format(name, error)) from error
@@ -1437,8 +1428,7 @@ def validate_capture_block(product, capture_block):
 def _upgrade(config):
     """Convert a config dictionary to the newest version and return it.
 
-    It is assumed to already have passed :func:`_validate`. The following
-    changes are made:
+    It is assumed to already have passed :func:`_validate`.
     """
     config = copy.deepcopy(config)
     config.setdefault('inputs', {})

--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -998,6 +998,7 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
         await self.exec_transitions(CaptureBlockState.BURNDOWN, False, capture_block)
 
     async def postprocess_impl(self, capture_block: CaptureBlock) -> None:
+        assert self.telstate is not None
         try:
             await self.exec_transitions(CaptureBlockState.POSTPROCESSING, False, capture_block)
             capture_block.state = CaptureBlockState.POSTPROCESSING

--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -168,7 +168,7 @@ class Resolver(scheduler.Resolver):
                  image_resolver: scheduler.ImageResolver,
                  task_id_allocator: scheduler.TaskIDAllocator,
                  http_url: Optional[str],
-                 service_overrides: dict,
+                 service_overrides: Mapping[str, product_config.ServiceOverride],
                  s3_config: dict,
                  localhost: bool) -> None:
         super().__init__(image_resolver, task_id_allocator, http_url)
@@ -323,18 +323,20 @@ class SDPSubarrayProductBase:
     forced deconfiguration to abort them.
     """
     def __init__(self, sched: Optional[scheduler.Scheduler],
-                 config: dict,
+                 configuration: product_config.Configuration,
+                 config_dict: dict,
                  resolver: Resolver,
                  subarray_product_id: str,
                  sdp_controller: 'DeviceServer') -> None:
         #: Current background task (can only be one)
         self._async_task: Optional[asyncio.Task] = None
         self.sched = sched
-        self.config = config
+        self.configuration = configuration
+        self.config_dict = config_dict
         self.resolver = resolver
         self.subarray_product_id = subarray_product_id
         self.sdp_controller = sdp_controller
-        self.logical_graph = generator.build_logical_graph(config)
+        self.logical_graph = generator.build_logical_graph(configuration)
         self.telstate_endpoint = ""
         self.telstate: Optional[katsdptelstate.TelescopeState] = None
         self.capture_blocks: Dict[str, CaptureBlock] = {}  # live capture blocks, indexed by name
@@ -875,10 +877,13 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
                    for logical in logical_graph}
         return networkx.relabel_nodes(logical_graph, mapping)
 
-    def __init__(self, sched: scheduler.Scheduler, config: dict,
+    def __init__(self, sched: scheduler.Scheduler,
+                 configuration: product_config.Configuration,
+                 config_dict: dict,
                  resolver: Resolver, subarray_product_id: str,
                  sdp_controller: 'DeviceServer', telstate_name: str = 'telstate') -> None:
-        super().__init__(sched, config, resolver, subarray_product_id, sdp_controller)
+        super().__init__(sched, configuration, config_dict, resolver,
+                         subarray_product_id, sdp_controller)
         # Priority is lower (higher number) than the default queue
         self.batch_queue = scheduler.LaunchQueue(
             sdp_controller.batch_role, 'batch', priority=BATCH_PRIORITY)
@@ -1045,11 +1050,13 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
         # Provide attributes to describe the relationships between CBF streams
         # and instruments. This could be extracted from sdp_config, but these
         # specific sensors are easier to mock.
-        for name, stream in self.config['inputs'].items():
-            if stream['type'].startswith('cbf.'):
-                for suffix in ['src_streams', 'instrument_dev_name']:
-                    if suffix in stream:
-                        init_telstate[(name, suffix)] = stream[suffix]
+        for name, stream in self.configuration.streams:
+            if isinstance(stream, product_config.CbfStream):
+                init_telstate[(name, 'instrument_dev_name')] = stream.instrument_dev_name
+                if stream.src_streams:
+                    init_telstate[(name, 'src_streams'] = [
+                        src_stream.name for src_stream in stream.src_streams
+                    ]
 
         logger.debug("Launching telstate. Initial values %s", init_telstate)
         await self.sched.launch(self.physical_graph, self.resolver, boot)
@@ -1326,7 +1333,8 @@ class DeviceServer(aiokatcp.DeviceServer):
         self.master_controller.close()
         await self.master_controller.wait_closed()
 
-    async def configure_product(self, name: str, config: dict) -> None:
+    async def configure_product(self, name: str, configuration: product_config.Configuration,
+                                config_dict: dict) -> None:
         """Configure a subarray product in response to a request.
 
         Raises
@@ -1358,10 +1366,10 @@ class DeviceServer(aiokatcp.DeviceServer):
             else:
                 self.halt(False)
 
-        logger.debug('config is %s', json.dumps(config, indent=2, sort_keys=True))
+        logger.debug('config is %s', json.dumps(config_dict, indent=2, sort_keys=True))
         logger.info("Launching subarray product.")
 
-        image_tag = config['config'].get('image_tag')
+        image_tag = configuration.options.image_tag
         if image_tag is not None:
             resolver_factory_args = dict(tag=image_tag)
         else:
@@ -1370,7 +1378,7 @@ class DeviceServer(aiokatcp.DeviceServer):
             self.image_resolver_factory(**resolver_factory_args),
             scheduler.TaskIDAllocator(name + '-'),
             self.sched.http_url if self.sched else '',
-            config['config'].get('service_overrides', {}),
+            configuration.options.service_overrides,
             self.s3_config,
             self.localhost)
 
@@ -1380,7 +1388,7 @@ class DeviceServer(aiokatcp.DeviceServer):
             product_cls = SDPSubarrayProductInterface
         else:
             product_cls = SDPSubarrayProduct
-        product = product_cls(self.sched, config, resolver, name, self)
+        product = product_cls(self.sched, configuration, config_dict, resolver, name, self)
         if self.graph_dir is not None:
             product.write_graphs(self.graph_dir)
         self.product = product   # Prevents another attempt to configure
@@ -1408,8 +1416,7 @@ class DeviceServer(aiokatcp.DeviceServer):
             raise FailReply('Already configured or configuring')
         try:
             config_dict = load_json_dict(config)
-            product_config.validate(config_dict)
-            config_dict = product_config.normalise(config_dict)
+            configuration = await product_config.Configuration.from_config(config_dict)
         except product_config.SensorFailure as exc:
             retmsg = f"Error retrieving sensor data from CAM: {exc}"
             logger.error(retmsg)
@@ -1419,7 +1426,7 @@ class DeviceServer(aiokatcp.DeviceServer):
             logger.error(retmsg)
             raise FailReply(retmsg) from exc
 
-        await self.configure_product(name, config_dict)
+        await self.configure_product(name, configuration, config_dict)
 
     def _get_product(self) -> SDPSubarrayProductBase:
         """Check that self.product exists (i.e. ?product-configure has been called).

--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -173,7 +173,7 @@ from abc import abstractmethod
 import random
 import typing
 # Note: don't include Dict here, because it conflicts with addict.Dict.
-from typing import Optional, Mapping, Union, ClassVar, Type
+from typing import List, Optional, Mapping, Union, ClassVar, Type
 
 import pkg_resources
 import docker
@@ -1354,6 +1354,13 @@ class LogicalTask(LogicalNode, ResourceRequestsContainer):
         command being passed to it.
     """
     RESOURCE_REQUESTS = GLOBAL_RESOURCES
+
+    # Type annotations for mypy. This are actually provided by the metaclass
+    cpus: float
+    mem: float
+    disk: float
+    ports: List[Optional[str]]
+    cores: List[Optional[str]]
 
     def __init__(self, name):
         LogicalNode.__init__(self, name)

--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -1979,6 +1979,10 @@ class PhysicalTask(PhysicalNode):
         Statistics collector of the scheduler. It is only set when
         the task is being launched.
     """
+
+    cores: typing.Dict[str, int]
+    ports: typing.Dict[str, int]
+
     def __init__(self, logical_task):
         super().__init__(logical_task)
         self.interfaces = {}

--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -102,7 +102,14 @@
         }
     },
     "type": "object",
-    "required": ["inputs", "outputs", "config", "version"],
+    "required": [
+{% if version < "3.0" %}
+        "inputs",
+        "config",
+{% endif %}
+        "outputs",
+        "version"
+    ],
     "additionalProperties": false,
     "properties": {
         "inputs": {
@@ -393,7 +400,13 @@
                                     },
                                     "archive": {"type": "boolean"}
                                 },
-                                "required": ["src_streams", "calibration", "archive"],
+                                "required": [
+                                    "src_streams",
+{% if version < "3.0" %}
+                                    "calibration",
+{% endif %}
+                                    "archive"
+                                ],
                                 "additionalProperties": false
                             }
                         },
@@ -473,12 +486,12 @@
                                         "items": {"type": "string"}
                                     },
                                     "band": {"type": "string"},
-                                    "center_freq": {"$ref": "#/definitions/positive_number"},
                                     "bandwidth": {"$ref": "#/definitions/positive_number"},
-                                    "adc_sample_rate": {"$ref": "#/definitions/positive_number"}
+                                    "adc_sample_rate": {"$ref": "#/definitions/positive_number"},
+                                    "centre_frequency": {"$ref": "#/definitions/positive_number"}
                                 },
                                 "additionalProperties": false,
-                                "required": ["n_chans", "antennas", "band", "center_freq", "bandwidth", "adc_sample_rate"]
+                                "required": ["n_chans", "antennas", "band", "bandwidth", "adc_sample_rate", "centre_frequency"]
                             }
                         },
                         {
@@ -547,7 +560,7 @@
             "antennas": {
                 "type": "array",
                 "items": {"type": "string"}
-            },
+            }
         },
 {% endif %}
         "version": {

--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -488,10 +488,11 @@
                                     "type": {},
                                     "src_streams": {"$ref": "#/definitions/singleton"},
                                     "int_time": {"$ref": "#/definitions/positive_number"},
-                                    "n_chans_per_substream": {"$ref": "#/definitions/positive_integer"}
+                                    "n_chans_per_substream": {"$ref": "#/definitions/positive_integer"},
+                                    "n_endpoints": {"$ref": "#/definitions/positive_integer"}
                                 },
                                 "additionalProperties": false,
-                                "required": ["src_streams", "int_time"]
+                                "required": ["src_streams", "int_time", "n_endpoints"]
                             }
                         },
                         {
@@ -501,10 +502,11 @@
                                     "type": {},
                                     "src_streams": {"$ref": "#/definitions/singleton"},
                                     "spectra_per_heap": {"$ref": "#/definitions/positive_integer"},
-                                    "n_chans_per_substream": {"$ref": "#/definitions/positive_integer"}
+                                    "n_chans_per_substream": {"$ref": "#/definitions/positive_integer"},
+                                    "n_endpoints": {"$ref": "#/definitions/positive_integer"}
                                 },
                                 "additionalProperties": false,
-                                "required": ["src_streams"]
+                                "required": ["src_streams", "n_endpoints"]
                             }
                         }
                     ]

--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -6,13 +6,14 @@
     "properties": {
         "version": {
             "type": "string",
-            "enum": ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6"]
+            "enum": ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "3.0"]
         }
     }
 }
 {% endmacro %}
 
 {% macro validate(version) %}
+{% set input_additional = "false" if version >= "3.0" else "true" %}
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
@@ -65,6 +66,11 @@
             "$ref": "#/definitions/pair",
             "items": {"$ref": "#/definitions/nonneg_integer"}
         },
+        "clock_ratio": {
+            "type": "number",
+            "minimum": 0.0,
+            "default": 1.0
+        },
         "simulate": {
             "oneOf": [
                 {"type": "boolean"},
@@ -72,7 +78,7 @@
                     "type": "object",
                     "properties": {
 {% if version >= "2.4" %}
-                        "clock_ratio": {"type": "number", "minimum": 0.0, "default": 1.0},
+                        "clock_ratio": {"$ref": "#/definitions/clock_ratio"},
                         "start_time": {"$ref": "#/definitions/positive_number"},
 {% endif %}
                         "sources": {
@@ -107,7 +113,18 @@
                     "type": "object",
                     "required": ["type", "url"],
                     "properties": {
+{% if version >= "3.0" %}
+                        "type": {
+                            "enum": [
+                                "cbf.antenna_channelised_voltage",
+                                "cbf.baseline_correlation_products",
+                                "cbf.tied_array_channelised_voltage",
+                                "cam.http"
+                            ]
+                        },
+{% else %}
                         "type": {"$ref": "#/definitions/stream_type"},
+{% endif %}
                         "url": {"type": "string", "format": "uri"},
                         "src_streams": {"$ref": "#/definitions/src_streams"}
                     },
@@ -116,11 +133,14 @@
                             "if": {"properties": {"type": {"const": "cbf.antenna_channelised_voltage"}}},
                             "then": {
                                 "properties": {
+                                    "type": {},
+                                    "url": {},
                                     "antennas": {
                                         "type": "array",
                                         "minItems": 1,
                                         "items": {"type": "string"}
                                     },
+{% if version < "3.0" %}
                                     "n_chans": {"$ref": "#/definitions/nonneg_integer"},
                                     "n_samples_between_spectra": {
                                         "$ref": "#/definitions/nonneg_integer"
@@ -128,12 +148,20 @@
                                     "n_pols": {"type": "integer", "enum": [1, 2]},
                                     "adc_sample_rate": {"type": "number"},
                                     "bandwidth": {"type": "number"},
+{% endif %}
                                     "instrument_dev_name": {"type": "string"}
                                 },
+                                "additionalProperties": {{ input_additional }},
                                 "required": [
                                     "antennas",
-                                    "n_chans", "n_samples_between_spectra", "n_pols",
-                                    "adc_sample_rate", "bandwidth", "instrument_dev_name"
+{% if version < "3.0" %}
+                                    "n_chans",
+                                    "n_samples_between_spectra",
+                                    "n_pols",
+                                    "adc_sample_rate",
+                                    "bandwidth",
+{% endif %}
+                                    "instrument_dev_name"
                                 ]
                             }
                         },
@@ -141,19 +169,29 @@
                             "if": {"properties": {"type": {"const": "cbf.baseline_correlation_products"}}},
                             "then": {
                                 "properties": {
+                                    "type": {},
+                                    "url": {},
                                     "src_streams": {"$ref": "#/definitions/singleton"},
+{% if version < "3.0" %}
                                     "int_time": {"type": "number"},
                                     "n_bls": {"$ref": "#/definitions/nonneg_integer"},
                                     "xeng_out_bits_per_sample": {"const": 32},
                                     "n_chans_per_substream": {
                                         "$ref": "#/definitions/nonneg_integer"
                                     },
-                                    "instrument_dev_name": {"type": "string"},
-                                    "simulate": {"$ref": "#/definitions/simulate"}
+                                    "simulate": {"$ref": "#/definitions/simulate"},
+{% endif %}
+                                    "instrument_dev_name": {"type": "string"}
                                 },
+                                "additionalProperties": {{ input_additional }},
                                 "required": [
-                                    "src_streams", "int_time", "n_bls",
-                                    "xeng_out_bits_per_sample", "n_chans_per_substream",
+                                    "src_streams",
+{% if version < "3.0" %}
+                                    "int_time",
+                                    "n_bls",
+                                    "xeng_out_bits_per_sample",
+                                    "n_chans_per_substream",
+{% endif %}
                                     "instrument_dev_name"
                                 ]
                             }
@@ -162,7 +200,10 @@
                             "if": {"properties": {"type": {"const": "cbf.tied_array_channelised_voltage"}}},
                             "then": {
                                 "properties": {
+                                    "type": {},
+                                    "url": {},
                                     "src_streams": {"$ref": "#/definitions/singleton"},
+{% if version < "3.0" %}
                                     "beng_out_bits_per_sample": {"const": 8},
                                     "spectra_per_heap": {
                                         "$ref": "#/definitions/nonneg_integer"
@@ -170,19 +211,32 @@
                                     "n_chans_per_substream": {
                                         "$ref": "#/definitions/nonneg_integer"
                                     },
-                                    "instrument_dev_name": {"type": "string"},
-                                    "simulate": {"$ref": "#/definitions/simulate"}
+                                    "simulate": {"$ref": "#/definitions/simulate"},
+{% endif %}
+                                    "instrument_dev_name": {"type": "string"}
                                 },
+                                "additionalProperties": {{ input_additional }},
                                 "required": [
-                                    "src_streams", "beng_out_bits_per_sample",
+                                    "src_streams",
+{% if version < "3.0" %}
+                                    "beng_out_bits_per_sample",
                                     "spectra_per_heap",
-                                    "n_chans_per_substream", "instrument_dev_name"
+                                    "n_chans_per_substream",
+{% endif %}
+                                    "instrument_dev_name"
                                 ]
                             }
                         },
                         {
                             "if": {"properties": {"type": {"const": "cam.http"}}},
-                            "then": {}
+                            "then": {
+                                "properties": {
+                                    "type": {},
+                                    "url": {}
+                                },
+                                "additionalProperties": {{ input_additional }},
+                                "required": []
+                            }
                         }
                     ]
                 }
@@ -198,6 +252,11 @@
                     "properties": {
                         "type": {
                             "enum": [
+{% if version >= "3.0" %}
+                                "sim.cbf.antenna_channelised_voltage",
+                                "sim.cbf.baseline_correlation_products",
+                                "sim.cbf.tied_array_channelised_voltage",
+{% endif %}
                                 "sdp.vis",
                                 "sdp.cal",
                                 "sdp.flags",
@@ -331,9 +390,7 @@
                                 "required": ["src_streams", "calibration", "archive"],
                                 "additionalProperties": false
                             }
-                        }
-{% if version >= "2.2" %}
-                        ,
+                        },
                         {
                             "if": {"properties": {"type": {"const": "sdp.continuum_image"}}},
                             "then": {
@@ -350,10 +407,7 @@
                                 "required": ["src_streams"],
                                 "additionalProperties": false
                             }
-                        }
-{% endif %}
-{% if version >= "2.4" %}
-                        ,
+                        },
                         {
                             "if": {"properties": {"type": {"const": "sdp.spectral_image"}}},
                             "then": {
@@ -400,8 +454,53 @@
                                 "required": ["src_streams"],
                                 "additionalProperties": false
                             }
+                        },
+                        {
+                            "if": {"properties": {"type": {"const": "sim.cbf.antenna_channelised_voltage"}}},
+                            "then": {
+                                "properties": {
+                                    "type": {},
+                                    "n_chans": {"$ref": "#/definitions/positive_integer"},
+                                    "antennas": {
+                                        "type": "array",
+                                        "minItems": 1,
+                                        "items": {"type": "string"}
+                                    },
+                                    "band": {"type": "string"},
+                                    "center_freq": {"$ref": "#/definitions/positive_number"},
+                                    "bandwidth": {"$ref": "#/definitions/positive_number"},
+                                    "adc_sample_rate": {"$ref": "#/definitions/positive_number"}
+                                },
+                                "additionalProperties": false,
+                                "required": ["n_chans", "antennas", "band", "center_freq", "bandwidth", "adc_sample_rate"]
+                            }
+                        },
+                        {
+                            "if": {"properties": {"type": {"const": "sim.cbf.baseline_correlation_products"}}},
+                            "then": {
+                                "properties": {
+                                    "type": {},
+                                    "src_streams": {"$ref": "#/definitions/singleton"},
+                                    "int_time": {"$ref": "#/definitions/positive_number"},
+                                    "n_chans_per_substream": {"$ref": "#/definitions/positive_integer"}
+                                },
+                                "additionalProperties": false,
+                                "required": ["src_streams", "int_time"]
+                            }
+                        },
+                        {
+                            "if": {"properties": {"type": {"const": "sim.cbf.tied_array_channelised_voltage"}}},
+                            "then": {
+                                "properties": {
+                                    "type": {},
+                                    "src_streams": {"$ref": "#/definitions/singleton"},
+                                    "spectra_per_heap": {"$ref": "#/definitions/positive_integer"},
+                                    "n_chans_per_substream": {"$ref": "#/definitions/positive_integer"}
+                                },
+                                "additionalProperties": false,
+                                "required": ["src_streams"]
+                            }
                         }
-{% endif %}
                     ]
                 }
             }
@@ -429,6 +528,20 @@
                 }
             }
         },
+{% if version >= "3.0" %}
+        "simulation": {
+            "clock_ratio": {"$ref": "#/definitions/clock_ratio"},
+            "start_time": {"$ref": "#/definitions/positive_number"},
+            "sources": {
+                "type": "array",
+                    "items": {"type": "string"}
+            },
+            "antennas": {
+                "type": "array",
+                "items": {"type": "string"}
+            },
+        },
+{% endif %}
         "version": {
             "type": "string",
             "const": "{{version}}"

--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -6,7 +6,7 @@
     "properties": {
         "version": {
             "type": "string",
-            "enum": ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "3.0"]
+            "enum": ["2.4", "2.5", "2.6", "3.0"]
         }
     }
 }
@@ -77,10 +77,8 @@
                 {
                     "type": "object",
                     "properties": {
-{% if version >= "2.4" %}
                         "clock_ratio": {"$ref": "#/definitions/clock_ratio"},
                         "start_time": {"$ref": "#/definitions/positive_number"},
-{% endif %}
                         "sources": {
                             "type": "array",
                             "items": {"type": "string"}
@@ -267,12 +265,8 @@
                                 "sdp.vis",
                                 "sdp.cal",
                                 "sdp.flags",
-{% if version >= "2.2" %}
                                 "sdp.continuum_image",
-{% endif %}
-{% if version >= "2.4" %}
                                 "sdp.spectral_image",
-{% endif %}
                                 "sdp.beamformer",
                                 "sdp.beamformer_engineering"
                             ]
@@ -374,9 +368,7 @@
                                         "additionalProperties": {"type": "string"}
                                     },
 {% endif %}
-{% if version >= "2.1" %}
                                     "max_scans": {"$ref": "#/definitions/positive_integer"},
-{% endif %}
                                     "buffer_time": {"$ref": "#/definitions/positive_number"}
                                 },
                                 "required": ["src_streams"],
@@ -540,9 +532,7 @@
                         "additionalProperties": false,
                         "properties": {
                             "config": { "type": "object" },
-{% if version >= "2.3" %}
                             "host": { "type": "string" },
-{% endif %}
                             "taskinfo": { "type": "object" }
                         }
                     }

--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -361,10 +361,12 @@
                                         },
                                         "additionalProperties": false
                                     },
+{% if version < "3.0" %}
                                     "models": {
                                         "type": "object",
                                         "additionalProperties": {"type": "string"}
                                     },
+{% endif %}
 {% if version >= "2.1" %}
                                     "max_scans": {"$ref": "#/definitions/positive_integer"},
 {% endif %}
@@ -379,8 +381,12 @@
                             "then": {
                                 "properties": {
                                     "type": {},
+{% if version < "3.0" %}
                                     "src_streams": {"$ref": "#/definitions/singleton"},
                                     "calibration": {"$ref": "#/definitions/singleton"},
+{% else %}
+                                    "src_streams": {"%ref": "#/definitions/pair"},
+{% endif %}
                                     "rate_ratio": {
                                         "type": "number",
                                         "exclusiveMinimum": 1.0

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -1,7 +1,5 @@
 """Tests for :mod:`katsdpcontroller.product_config`."""
 
-import copy
-import logging
 from unittest import mock
 from typing import Dict, Optional, Any
 
@@ -11,8 +9,8 @@ import yarl
 import katpoint
 import katportalclient
 from nose.tools import (
-    assert_equal, assert_almost_equal, assert_in, assert_is, assert_is_none,
-    assert_true, assert_false, assert_raises, assert_raises_regex, assert_logs
+    assert_equal, assert_almost_equal, assert_is, assert_is_none, assert_is_instance,
+    assert_true, assert_false, assert_raises, assert_raises_regex
 )
 
 from .. import product_config
@@ -923,6 +921,82 @@ class Fixture(asynctest.TestCase):
 
     def setUp(self):
         self.config = {
+            "version": "3.0",
+            "inputs": {
+                "camdata": {
+                    "type": "cam.http",
+                    "url": "http://10.8.67.235/api/client/1"
+                },
+                "i0_antenna_channelised_voltage": {
+                    "type": "cbf.antenna_channelised_voltage",
+                    "url": "spead://239.2.1.150+15:7148",
+                    "antennas": ["m000", "m001", "m003", "m063"],
+                    "instrument_dev_name": "i0"
+                },
+                "i0_baseline_correlation_products": {
+                    "type": "cbf.baseline_correlation_products",
+                    "url": "spead://239.9.3.1+15:7148",
+                    "src_streams": ["i0_antenna_channelised_voltage"],
+                    "instrument_dev_name": "i0"
+                },
+                "i0_tied_array_channelised_voltage_0x": {
+                    "type": "cbf.tied_array_channelised_voltage",
+                    "url": "spead://239.9.3.30+15:7148",
+                    "src_streams": ["i0_antenna_channelised_voltage"],
+                    "instrument_dev_name": "i0"
+                },
+                "i0_tied_array_channelised_voltage_0y": {
+                    "type": "cbf.tied_array_channelised_voltage",
+                    "url": "spead://239.9.3.46+7:7148",
+                    "src_streams": ["i0_antenna_channelised_voltage"],
+                    "instrument_dev_name": "i0"
+                }
+            },
+            "outputs": {
+                "l0": {
+                    "type": "sdp.vis",
+                    "src_streams": ["i0_baseline_correlation_products"],
+                    "output_int_time": 4.0,
+                    "output_channels": [0, 4096],
+                    "continuum_factor": 1,
+                    "archive": True
+                },
+                "beamformer_engineering": {
+                    "type": "sdp.beamformer_engineering",
+                    "src_streams": [
+                        "i0_tied_array_channelised_voltage_0x",
+                        "i0_tied_array_channelised_voltage_0y"
+                    ],
+                    "output_channels": [0, 4096],
+                    "store": "ssd"
+                },
+                "cal": {
+                    "type": "sdp.cal",
+                    "src_streams": ["l0"]
+                },
+                "sdp_l1_flags": {
+                    "type": "sdp.flags",
+                    "src_streams": ["l0", "cal"],
+                    "archive": True
+                },
+                "continuum_image": {
+                    "type": "sdp.continuum_image",
+                    "src_streams": ["sdp_l1_flags"],
+                    "uvblavg_parameters": {},
+                    "mfimage_parameters": {},
+                    "max_realtime": 10000.0,
+                    "min_time": 20 * 60
+                },
+                "spectral_image": {
+                    "type": "sdp.spectral_image",
+                    "src_streams": ["sdp_l1_flags", "continuum_image"],
+                    "output_channels": [100, 4000],
+                    "min_time": 3600.0
+                }
+            },
+            "config": {}
+        }
+        self.config_v2 = {
             "version": "2.6",
             "inputs": {
                 "camdata": {
@@ -1020,194 +1094,172 @@ class Fixture(asynctest.TestCase):
             },
             "config": {}
         }
+        self.config_sim: Dict[str, Any] = {
+            'version': '3.0',
+            'outputs': {
+                'acv': {
+                    'type': 'sim.cbf.antenna_channelised_voltage',
+                    'antennas': [
+                        _M000.description,
+                        _M002.description
+                    ],
+                    'band': 'l',
+                    'bandwidth': 856e6,
+                    'centre_frequency': 1284e6,
+                    'adc_sample_rate': 1712e6,
+                    'n_chans': 4096
+                },
+                'vis': {
+                    'type': 'sdp.vis',
+                    'src_streams': ['bcp'],
+                    'output_int_time': 2.0,
+                    'continuum_factor': 1,
+                    'archive': True
+                },
+                # Deliberately list the streams out of order, to check that
+                # they get properly ordered
+                'bcp': {
+                    'type': 'sim.cbf.baseline_correlation_products',
+                    'src_streams': ['acv'],
+                    'n_endpoints': 16,
+                    'int_time': 0.5
+                }
+            }
+        }
 
 
 class TestValidate(Fixture):
-    """Tests for :func:`~katsdpcontroller.product_config.validate`"""
+    """Tests for :func:`~katsdpcontroller.product_config._validate`"""
 
-    def test_good(self):
-        product_config.validate(self.config)
+    def test_good(self) -> None:
+        product_config._validate(self.config)
 
-    def test_bad_version(self):
+    def test_good_v2(self) -> None:
+        product_config._validate(self.config_v2)
+
+    def test_good_sim(self) -> None:
+        product_config._validate(self.config_v2)
+
+    def test_bad_version(self) -> None:
         self.config["version"] = "1.10"
         with assert_raises(jsonschema.ValidationError):
-            product_config.validate(self.config)
+            product_config._validate(self.config)
 
-    def test_input_bad_property(self):
+    def test_input_bad_property(self) -> None:
         """Test that the error message on an invalid input is sensible"""
-        del self.config["inputs"]["i0_antenna_channelised_voltage"]["n_pols"]
-        with assert_raises(jsonschema.ValidationError) as cm:
-            product_config.validate(self.config)
-        assert_in("'n_pols' is a required property", str(cm.exception))
+        del self.config["inputs"]["i0_antenna_channelised_voltage"]["instrument_dev_name"]
+        with assert_raises_regex(jsonschema.ValidationError,
+                                 "'instrument_dev_name' is a required property"):
+            product_config._validate(self.config)
 
-    def test_output_bad_property(self):
+    def test_output_bad_property(self) -> None:
         """Test that the error message on an invalid output is sensible"""
         del self.config["outputs"]["l0"]["continuum_factor"]
-        with assert_raises(jsonschema.ValidationError) as cm:
-            product_config.validate(self.config)
-        assert_in("'continuum_factor' is a required property", str(cm.exception))
+        with assert_raises_regex(jsonschema.ValidationError,
+                                 "'continuum_factor' is a required property"):
+            product_config._validate(self.config)
 
-    def test_input_missing_stream(self):
+    def test_input_missing_stream(self) -> None:
         """An input whose ``src_streams`` reference does not exist"""
-        del self.config["inputs"]["i0_antenna_channelised_voltage"]
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("Unknown source i0_antenna_channelised_voltage", str(cm.exception))
+        self.config["inputs"]["i0_baseline_correlation_products"]["src_streams"] = ["blah"]
+        with assert_raises_regex(ValueError,
+                                 "Unknown source blah in i0_baseline_correlation_products"):
+            product_config._validate(self.config)
 
-    def test_input_not_spead(self):
-        """A CBF stream has a non-spead URL scheme"""
-        self.config["inputs"]["i0_baseline_correlation_products"]["url"] = "http://dummy/"
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("non-spead URL", str(cm.exception))
-
-    def test_input_no_spead_port(self):
-        """A CBF stream has a spead URL but with no port"""
-        self.config["inputs"]["i0_baseline_correlation_products"]["url"] = "spead://239.9.3.1+15"
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("has no port", str(cm.exception))
-
-    def test_input_bad_n_endpoints(self):
-        """Number of endpoints doesn't divide into number of channels"""
-        self.config["inputs"]["i0_baseline_correlation_products"]["url"] = \
-            "spead://239.9.3.1+14:7148"
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("not a multiple of endpoints", str(cm.exception))
-
-    def test_output_missing_stream(self):
+    def test_output_missing_stream(self) -> None:
         """An output whose ``src_streams`` reference does not exist"""
         del self.config["inputs"]["i0_baseline_correlation_products"]
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("Unknown source i0_baseline_correlation_products", str(cm.exception))
+        with assert_raises_regex(ValueError,
+                                 "Unknown source i0_baseline_correlation_products in l0"):
+            product_config._validate(self.config)
 
-    def test_stream_wrong_type(self):
+    def test_stream_wrong_type(self) -> None:
         """An entry in ``src_streams`` refers to the wrong type"""
         self.config["outputs"]["l0"]["src_streams"] = ["i0_antenna_channelised_voltage"]
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("has wrong type", str(cm.exception))
+        with assert_raises_regex(ValueError, "has wrong type"):
+            product_config._validate(self.config)
 
-    def test_stream_name_conflict(self):
+    def test_stream_name_conflict(self) -> None:
         """An input and an output have the same name"""
         self.config["outputs"]["i0_antenna_channelised_voltage"] = self.config["outputs"]["l0"]
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("cannot be both an input and an output", str(cm.exception))
+        with assert_raises_regex(ValueError,
+                                 "cannot be both an input and an output"):
+            product_config._validate(self.config)
 
-    def test_bad_channel_range(self):
-        self.config["outputs"]["l0"]["output_channels"] = [10, 10]  # Empty range
-        with assert_raises(ValueError):
-            product_config.validate(self.config)
-        self.config["outputs"]["l0"]["output_channels"] = [10, 4097]   # Overflows
-        with assert_raises(ValueError):
-            product_config.validate(self.config)
-
-    def test_bad_continuum_factor(self):
-        self.config["outputs"]["l0"]["continuum_factor"] = 3
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("not a multiple of continuum_factor", str(cm.exception))
-
-    def test_too_few_continuum_channels(self):
-        self.config["outputs"]["l0"]["continuum_factor"] = 4096
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("not a multiple of number of ingests", str(cm.exception))
-
-    def test_multiple_cam_http(self):
+    def test_multiple_cam_http(self) -> None:
         self.config["inputs"]["camdata2"] = self.config["inputs"]["camdata"]
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("have more than one cam.http", str(cm.exception))
+        with assert_raises_regex(ValueError, "have more than one cam.http"):
+            product_config._validate(self.config)
 
-    def test_bad_n_chans_per_substream(self):
-        self.config["inputs"]["i0_baseline_correlation_products"]["n_chans_per_substream"] = 123
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("not a multiple of", str(cm.exception))
+    def test_missing_cam_http(self) -> None:
+        del self.config["inputs"]["camdata"]
+        with assert_raises_regex(ValueError, "cam.http stream is required"):
+            product_config._validate(self.config)
 
-    def test_mismatched_beamformer_pols(self):
-        self.config["inputs"]["myacv"] = self.config["inputs"]["i0_antenna_channelised_voltage"]
-        self.config["inputs"]["i0_tied_array_channelised_voltage_0y"]["src_streams"] = ["myacv"]
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("streams do not come from the same channeliser", str(cm.exception))
+    def test_calibration_does_not_exist(self) -> None:
+        self.config_v2["outputs"]["sdp_l1_flags"]["calibration"] = ["bad"]
+        with assert_raises_regex(ValueError, "does not exist"):
+            product_config._validate(self.config_v2)
 
-    def test_v2_1_multiple_flags_per_cal(self):
-        self.config["version"] = "2.1"
-        self.config["outputs"]["flags2"] = {
-            "type": "sdp.flags",
-            "src_streams": ["l0"],
-            "calibration": ["cal"],
-            "archive": True
+    def test_calibration_wrong_type(self) -> None:
+        self.config_v2["outputs"]["sdp_l1_flags"]["calibration"] = ["l0"]
+        with assert_raises_regex(ValueError, "has wrong type"):
+            product_config._validate(self.config_v2)
+
+    def test_cal_models(self) -> None:
+        self.config_v2["outputs"]["cal"]["models"] = {"foo": "bar"}
+        with assert_raises_regex(ValueError, "no longer supports models"):
+            product_config._validate(self.config_v2)
+
+    def test_simulate_v2(self) -> None:
+        self.config_v2["inputs"]["i0_baseline_correlation_products"]["simulate"] = {}
+        with assert_raises_regex(ValueError, "simulation is not supported"):
+            product_config._validate(self.config_v2)
+
+
+class TestUpgrade(Fixture):
+    """Test :func:`~katsdpcontroller.product_config._upgrade`."""
+
+    def test_simple(self) -> None:
+        upgraded = product_config._upgrade(self.config_v2)
+        # Uncomment to debug differences
+        # import json
+        # with open('actual.json', 'w') as f:
+        #     json.dump(upgraded, f, indent=2, sort_keys=True)
+        # with open('expected.json', 'w') as f:
+        #     json.dump(self.config, f, indent=2, sort_keys=True)
+        assert_equal(upgraded, self.config)
+
+    def test_upgrade_v3(self) -> None:
+        upgraded = product_config._upgrade(self.config)
+        assert_equal(upgraded, self.config)
+
+    def test_few_antennas(self) -> None:
+        del self.config_v2['inputs']['i0_antenna_channelised_voltage']['antennas'][2:]
+        upgraded = product_config._upgrade(self.config_v2)
+        del self.config['inputs']['i0_antenna_channelised_voltage']['antennas'][2:]
+        del self.config['outputs']['cal']
+        del self.config['outputs']['sdp_l1_flags']
+        del self.config['outputs']['continuum_image']
+        del self.config['outputs']['spectral_image']
+        assert_equal(upgraded, self.config)
+
+    def test_unknown_input(self) -> None:
+        self.config_v2['inputs']['xyz'] = {
+            'type': 'custom',
+            'url': 'http://test.invalid/'
         }
-        # Remove outputs not valid in 2.1
-        del self.config["outputs"]["continuum_image"]
-        del self.config["outputs"]["spectral_image"]
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("already has a flags output", str(cm.exception))
-
-    def test_calibration_does_not_exist(self):
-        self.config["outputs"]["sdp_l1_flags"]["calibration"] = ["bad"]
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("does not exist", str(cm.exception))
-
-    def test_calibration_wrong_type(self):
-        self.config["outputs"]["sdp_l1_flags"]["calibration"] = ["l0"]
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("has wrong type", str(cm.exception))
-
-    def test_flags_mismatched_src_streams(self):
-        self.config["outputs"]["another_l0"] = copy.copy(self.config["outputs"]["l0"])
-        self.config["outputs"]["another_l0"]["output_int_time"] = 5.0
-        self.config["outputs"]["sdp_l1_flags"]["src_streams"] = ["another_l0"]
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("does not match", str(cm.exception))
-
-    def test_flags_bad_continuum_factor(self):
-        self.config["outputs"]["another_l0"] = copy.copy(self.config["outputs"]["l0"])
-        self.config["outputs"]["l0"]["continuum_factor"] = 2
-        self.config["outputs"]["sdp_l1_flags"]["src_streams"] = ["another_l0"]
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("bad continuum_factor", str(cm.exception))
-
-    def test_spectral_image_output_channels(self):
-        self.config["outputs"]["l0"]["continuum_factor"] = 2
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("Channel range 100:4000 is invalid", str(cm.exception))
-
-        del self.config["outputs"]["l0"]["output_channels"]
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("Channel range 100:4000 is invalid", str(cm.exception))
-
-    def test_v2_1_flags_wrong_src_streams(self):
-        self.config["version"] = "2.1"
-        self.config["outputs"]["another_l0"] = self.config["outputs"]["l0"]
-        self.config["outputs"]["sdp_l1_flags"]["src_streams"] = ["another_l0"]
-        # Remove outputs not valid in 2.1
-        del self.config["outputs"]["continuum_image"]
-        del self.config["outputs"]["spectral_image"]
-        with assert_raises(ValueError) as cm:
-            product_config.validate(self.config)
-        assert_in("has different src_streams", str(cm.exception))
+        upgraded = product_config._upgrade(self.config_v2)
+        assert_equal(upgraded, self.config)
 
 
-class TestUpdateFromSensors(Fixture):
-    """Tests for :func:`~katsdpcontroller.product_config.update_from_sensors`"""
-    def setUp(self):
+class TestConfiguration(Fixture):
+    """Test :class:`~.Configuration`."""
+
+    def setUp(self) -> None:
         super().setUp()
         # Create dummy sensors. Some deliberately have different values to
-        # self.config to ensure that the changes are picked up.
+        # self.config_v2 to ensure that the changes are picked up.
         self.client = fake_katportalclient.KATPortalClient(
             components={'cbf': 'cbf_1', 'sub': 'subarray_1'},
             sensors={
@@ -1215,6 +1267,8 @@ class TestUpdateFromSensors(Fixture):
                 'cbf_1_i0_adc_sample_rate': 1088e6,
                 'cbf_1_i0_antenna_channelised_voltage_n_samples_between_spectra': 2048,
                 'subarray_1_streams_i0_antenna_channelised_voltage_bandwidth': 544e6,
+                'subarray_1_streams_i0_antenna_channelised_voltage_centre_frequency': 816e6,
+                'subarray_1_band': 'u',
                 'cbf_1_i0_baseline_correlation_products_int_time': 0.25,
                 'cbf_1_i0_baseline_correlation_products_n_bls': 40,
                 'cbf_1_i0_baseline_correlation_products_xeng_out_bits_per_sample': 32,
@@ -1234,103 +1288,62 @@ class TestUpdateFromSensors(Fixture):
         patcher.start()
         self.addCleanup(patcher.stop)
 
-    async def test_basic(self):
-        with assert_logs(product_config.logger, logging.WARNING):
-            config = await product_config.update_from_sensors(self.config)
-        acv = config['inputs']['i0_antenna_channelised_voltage']
-        assert_equal(acv['n_chans'], 1024)
-        assert_equal(acv['adc_sample_rate'], 1088e6)
-        assert_equal(acv['bandwidth'], 544e6)
-        assert_equal(acv['n_samples_between_spectra'], 2048)
-        bcp = config['inputs']['i0_baseline_correlation_products']
-        assert_equal(bcp['int_time'], 0.25)
-        assert_equal(bcp['n_bls'], 40)
-        assert_equal(bcp['xeng_out_bits_per_sample'], 32)
-        assert_equal(bcp['n_chans_per_substream'], 64)
-        beam_x = config['inputs']['i0_tied_array_channelised_voltage_0x']
-        assert_equal(beam_x['beng_out_bits_per_sample'], 8)
-        assert_equal(beam_x['n_chans_per_substream'], 64)
-        assert_equal(beam_x['spectra_per_heap'], 256)
-        # Ensure that the original was not modified
-        assert_equal(self.config['inputs']['i0_antenna_channelised_voltage']['n_chans'], 4096)
+    async def test_sim(self) -> None:
+        """Test with no sensors required."""
+        config = await Configuration.from_config(self.config_sim)
+        streams = sorted(config.streams, key=lambda stream: stream.name)
+        assert_equal(streams[0].name, 'acv')
+        assert_is_instance(config.streams[0], SimAntennaChannelisedVoltageStream)
+        assert_equal(streams[1].name, 'bcp')
+        assert_is_instance(config.streams[1], SimBaselineCorrelationProductsStream)
+        assert_equal(streams[2].name, 'vis')
+        assert_is_instance(config.streams[2], VisStream)
+        assert_is(streams[2].src_streams[0], config.streams[1])
+        assert_is(streams[1].src_streams[0], config.streams[0])
 
-    async def test_no_cam_http(self):
-        del self.config['inputs']['camdata']
-        config = await product_config.update_from_sensors(self.config)
-        # Ensure that nothing happened
-        assert_equal(config['inputs']['i0_antenna_channelised_voltage']['n_chans'], 4096)
+    async def test_cyclic(self) -> None:
+        self.config_sim['outputs']['bcp']['src_streams'] = ['vis']
+        with assert_raises(ValueError):
+            await Configuration.from_config(self.config_sim)
 
-    async def test_simulate(self):
-        self.config['inputs']['i0_baseline_correlation_products']['simulate'] = {}
-        # Needed to make the config valid after i0_antenna_channelised_voltage is overridden
-        self.config['inputs']['i0_baseline_correlation_products']['n_chans_per_substream'] = 64
-        config = await product_config.update_from_sensors(self.config)
-        # Ensure that nothing happened on i0_baseline_correlation_products
-        assert_equal(config['inputs']['i0_baseline_correlation_products']['int_time'], 0.499)
+    async def test_bad_stream(self) -> None:
+        self.config['outputs']['l0']['continuum_factor'] = 3
+        with assert_raises_regex(ValueError, 'Configuration error for l0: '):
+            await Configuration.from_config(self.config)
 
-    async def test_connection_failed(self):
+    async def test_sensors(self) -> None:
+        """Test which needs to apply sensors."""
+        config = await Configuration.from_config(self.config)
+        bcp = config.by_class(BaselineCorrelationProductsStream)[0]
+        assert_equal(bcp.n_channels, 1024)
+        assert_equal(bcp.bandwidth, 544e6)
+        assert_equal(bcp.antenna_channelised_voltage.band, 'u')
+        assert_equal(bcp.int_time, 0.25)
+
+    async def test_connection_failed(self) -> None:
         with mock.patch.object(self.client, 'sensor_subarray_lookup',
                                side_effect=ConnectionRefusedError):
             with assert_raises(product_config.SensorFailure):
-                await product_config.update_from_sensors(self.config)
+                await Configuration.from_config(self.config)
 
         with mock.patch.object(self.client, 'sensor_value',
                                side_effect=ConnectionRefusedError):
             with assert_raises(product_config.SensorFailure):
-                await product_config.update_from_sensors(self.config)
+                await Configuration.from_config(self.config)
 
     async def test_sensor_not_found(self):
         del self.client.sensors['cbf_1_i0_baseline_correlation_products_n_bls']
         with assert_raises(product_config.SensorFailure):
-            await product_config.update_from_sensors(self.config)
+            await Configuration.from_config(self.config)
 
-    async def test_bad_status(self):
+    async def test_sensor_bad_status(self):
         self.client.sensors['cbf_1_i0_baseline_correlation_products_n_bls'] = \
             katportalclient.SensorSample(1234567890.0, 40, 'unreachable')
         with assert_raises(product_config.SensorFailure):
-            await product_config.update_from_sensors(self.config)
+            await Configuration.from_config(self.config)
 
-    async def test_bad_schema(self):
+    async def test_sensor_bad_type(self):
         self.client.sensors['cbf_1_i0_baseline_correlation_products_n_bls'] = \
             katportalclient.SensorSample(1234567890.0, 'not a number', 'nominal')
         with assert_raises(product_config.SensorFailure):
-            await product_config.update_from_sensors(self.config)
-
-
-class TestNormalise(Fixture):
-    """Tests for :func:`~katsdpcontroller.product_config.normalise`"""
-
-    def test_latest(self):
-        # Adjust some things to get full test coverage
-        expected = copy.deepcopy(self.config)
-        self.config["inputs"]["i0_baseline_correlation_products"]["simulate"] = True
-        del self.config["outputs"]["l0"]["output_channels"]
-        del self.config["outputs"]["beamformer_engineering"]["output_channels"]
-        del self.config["outputs"]["continuum_image"]["uvblavg_parameters"]
-        del self.config["outputs"]["continuum_image"]["mfimage_parameters"]
-        del self.config["outputs"]["spectral_image"]["output_channels"]
-
-        expected["inputs"]["i0_baseline_correlation_products"]["simulate"] = {
-            "clock_ratio": 1.0,
-            "sources": []
-        }
-        expected["inputs"]["i0_tied_array_channelised_voltage_0x"]["simulate"] = False
-        expected["inputs"]["i0_tied_array_channelised_voltage_0y"]["simulate"] = False
-        expected["outputs"]["l0"]["excise"] = True
-        expected["outputs"]["l0"]["output_channels"] = [0, 4096]
-        expected["outputs"]["beamformer_engineering"]["output_channels"] = [0, 4096]
-        expected["outputs"]["cal"]["parameters"] = {}
-        expected["outputs"]["cal"]["models"] = {}
-        expected["outputs"]["spectral_image"]["output_channels"] = [0, 4096]
-        expected["outputs"]["spectral_image"]["parameters"] = {}
-        expected["config"]["develop"] = False
-        expected["config"]["service_overrides"] = {}
-
-        config = product_config.normalise(self.config)
-        # Uncomment to debug differences
-        # import json
-        # with open('actual.json', 'w') as f:
-        #     json.dump(config, f, indent=2, sort_keys=True)
-        # with open('expected.json', 'w') as f:
-        #     json.dump(expected, f, indent=2, sort_keys=True)
-        assert_equal(config, expected)
+            await Configuration.from_config(self.config)

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -567,6 +567,7 @@ class TestVisStream:
         assert_is(vis.baseline_correlation_products, self.bcp)
         assert_equal(vis.n_chans, 1984)
         assert_equal(vis.n_spectral_chans, 3968)
+        assert_equal(vis.n_spectral_vis, 3968 * 12)
         assert_equal(vis.antennas, ['m000', 'm002'])
         assert_equal(vis.n_antennas, 2)
         assert_equal(vis.n_pols, 2)

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -248,7 +248,7 @@ class TestAntennaChannelisedVoltageStream:
         config = {
             'type': 'cbf.antenna_channelised_voltage',
             'url': 'spead://239.0.0.0+7:7148',
-            'antennas': ['m000', 'm001'],
+            'antennas': ['m000', 'another_antenna'],
             'instrument_dev_name': 'narrow1'
         }
         sensors = {
@@ -265,7 +265,7 @@ class TestAntennaChannelisedVoltageStream:
         assert_equal(acv.name, 'narrow1_acv')
         assert_equal(acv.src_streams, [])
         assert_equal(acv.url, yarl.URL('spead://239.0.0.0+7:7148'))
-        assert_equal(acv.antennas, ['m000', 'm001'])
+        assert_equal(acv.antennas, ['m000', 'another_antenna'])
         assert_equal(acv.band, 'l')
         assert_equal(acv.n_chans, 32768)
         assert_equal(acv.bandwidth, 107e6)
@@ -322,7 +322,8 @@ class TestSimAntennaChannelisedVoltageStream:
             )
 
 
-def make_antenna_channelised_voltage(antennas=('m000', 'm002')) -> AntennaChannelisedVoltageStream:
+def make_antenna_channelised_voltage(
+        antennas=('m000', 'another_antenna')) -> AntennaChannelisedVoltageStream:
     return AntennaChannelisedVoltageStream(
         'narrow1_acv', [],
         url=yarl.URL('spead2://239.0.0.0+7:7148'),
@@ -379,7 +380,7 @@ class TestBaselineCorrelationProductsStream:
         assert_equal(bcp.n_vis, 40 * 32768)
         assert_equal(bcp.size, 40 * 32768 * 8)
         assert_is(bcp.antenna_channelised_voltage, self.acv)
-        assert_equal(bcp.antennas, ['m000', 'm002'])
+        assert_equal(bcp.antennas, ['m000', 'another_antenna'])
         assert_equal(bcp.n_chans, 32768)
         assert_equal(bcp.n_chans_per_endpoint, 4096)
         assert_equal(bcp.n_substreams, 16)
@@ -470,7 +471,7 @@ class TestTiedArrayChannelisedVoltageStream:
         assert_equal(tacv.size, 32768 * 256 * 2 * 2)
         assert_is(tacv.antenna_channelised_voltage, self.acv)
         assert_equal(tacv.bandwidth, 107e6)
-        assert_equal(tacv.antennas, ['m000', 'm002'])
+        assert_equal(tacv.antennas, ['m000', 'another_antenna'])
         assert_almost_equal(tacv.int_time * 1712e6, 524288 * 256)
 
 
@@ -569,7 +570,7 @@ class TestVisStream:
         assert_equal(vis.n_chans, 1984)
         assert_equal(vis.n_spectral_chans, 3968)
         assert_equal(vis.n_spectral_vis, 3968 * 12)
-        assert_equal(vis.antennas, ['m000', 'm002'])
+        assert_equal(vis.antennas, ['m000', 'another_antenna'])
         assert_equal(vis.n_antennas, 2)
         assert_equal(vis.n_pols, 2)
         assert_equal(vis.n_baselines, 12)
@@ -642,7 +643,7 @@ class TestBeamformerStream:
         assert_equal(bf.n_chans, 32768)
 
     def test_mismatched_sources(self) -> None:
-        acv = make_antenna_channelised_voltage(antennas=['m012', 'm013'])
+        acv = make_antenna_channelised_voltage(antennas=['m012', 's0013'])
         self.tacv[1] = make_tied_array_channelised_voltage(
             acv, 'beam_0y', yarl.URL('spead://239.10.1.0+255:7148'))
         with assert_raises_regex(ValueError,
@@ -709,7 +710,7 @@ def make_vis(
 
 
 def make_vis_4ant() -> product_config.VisStream:
-    acv = make_antenna_channelised_voltage(['m000', 'm001', 'm002', 'm003'])
+    acv = make_antenna_channelised_voltage(['m000', 'm001', 's0002', 'another_antenna'])
     bcp = make_baseline_correlation_products(acv)
     return make_vis(bcp)
 
@@ -946,7 +947,7 @@ class Fixture(asynctest.TestCase):
                 "i0_antenna_channelised_voltage": {
                     "type": "cbf.antenna_channelised_voltage",
                     "url": "spead://239.2.1.150+15:7148",
-                    "antennas": ["m000", "m001", "m003", "m063"],
+                    "antennas": ["m000", "m001", "s0003", "another_antenna"],
                     "instrument_dev_name": "i0"
                 },
                 "i0_baseline_correlation_products": {
@@ -1022,7 +1023,7 @@ class Fixture(asynctest.TestCase):
                 "i0_antenna_channelised_voltage": {
                     "type": "cbf.antenna_channelised_voltage",
                     "url": "spead://239.2.1.150+15:7148",
-                    "antennas": ["m000", "m001", "m003", "m063"],
+                    "antennas": ["m000", "m001", "s0003", "another_antenna"],
                     "n_chans": 4096,
                     "n_pols": 2,
                     "adc_sample_rate": 1712000000.0,

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -13,7 +13,7 @@ from nose.tools import (
     assert_true, assert_false, assert_raises, assert_raises_regex
 )
 
-from .. import product_config
+from .. import product_config, defaults
 from ..product_config import (
     AntennaChannelisedVoltageStream,
     SimAntennaChannelisedVoltageStream,
@@ -506,7 +506,7 @@ class TestSimTiedArrayChannelisedVoltageStream:
         tacv = SimTiedArrayChannelisedVoltageStream.from_config(
             Options(), 'beam_0x', self.config, [self.acv], {}
         )
-        assert_equal(tacv.spectra_per_heap, product_config.KATCBFSIM_SPECTRA_PER_HEAP)
+        assert_equal(tacv.spectra_per_heap, defaults.KATCBFSIM_SPECTRA_PER_HEAP)
         assert_equal(tacv.n_chans_per_substream, 32)
 
 
@@ -738,8 +738,8 @@ class TestCalStream:
         del self.config['max_scans']
         cal = CalStream.from_config(Options(), 'cal', self.config, [self.vis], {})
         assert_equal(cal.parameters, {})
-        assert_equal(cal.buffer_time, product_config.DEFAULT_CAL_BUFFER_TIME)
-        assert_equal(cal.max_scans, product_config.DEFAULT_CAL_MAX_SCANS)
+        assert_equal(cal.buffer_time, defaults.CAL_BUFFER_TIME)
+        assert_equal(cal.max_scans, defaults.CAL_MAX_SCANS)
 
     def test_too_few_antennas(self) -> None:
         vis = make_vis()
@@ -753,8 +753,8 @@ def make_cal(vis: Optional[VisStream] = None) -> CalStream:
     return CalStream(
         'cal', [vis],
         parameters={},
-        buffer_time=product_config.DEFAULT_CAL_BUFFER_TIME,
-        max_scans=product_config.DEFAULT_CAL_MAX_SCANS
+        buffer_time=defaults.CAL_BUFFER_TIME,
+        max_scans=defaults.CAL_MAX_SCANS
     )
 
 
@@ -786,7 +786,7 @@ class TestFlagsStream:
     def test_defaults(self) -> None:
         del self.config['rate_ratio']
         flags = FlagsStream.from_config(Options(), 'flags', self.config, [self.vis, self.cal], {})
-        assert_equal(flags.rate_ratio, product_config.DEFAULT_FLAGS_RATE_RATIO)
+        assert_equal(flags.rate_ratio, defaults.FLAGS_RATE_RATIO)
 
     def test_incompatible_vis(self) -> None:
         vis = make_vis()
@@ -864,7 +864,7 @@ class TestContinuumImageStream:
         assert_equal(cont.uvblavg_parameters, {})
         assert_equal(cont.mfimage_parameters, {})
         assert_equal(cont.max_realtime, None)
-        assert_equal(cont.min_time, product_config.DEFAULT_CONTINUUM_MIN_TIME)
+        assert_equal(cont.min_time, defaults.CONTINUUM_MIN_TIME)
 
 
 def make_continuum_image(flags: Optional[FlagsStream] = None) -> ContinuumImageStream:
@@ -921,7 +921,7 @@ class TestSpectralImageStream:
             Options(), 'spectral_image', self.config, [self.flags, self.continuum_image], {}
         )
         assert_equal(spec.output_channels, (0, 1024))
-        assert_equal(spec.min_time, product_config.DEFAULT_SPECTRAL_MIN_TIME)
+        assert_equal(spec.min_time, defaults.SPECTRAL_MIN_TIME)
         assert_equal(spec.parameters, {})
 
 

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -145,7 +145,7 @@ class TestNormaliseOutputChannels:
     def test_misalign(self) -> None:
         with assert_raises_regex(
                 ValueError,
-                r'n_channels \(789\) is not a multiple of required alignment \(100\)'):
+                r'n_chans \(789\) is not a multiple of required alignment \(100\)'):
             product_config._normalise_output_channels(789, (100, 200), 100)
 
 
@@ -266,7 +266,7 @@ class TestAntennaChannelisedVoltageStream:
         assert_equal(acv.url, yarl.URL('spead://239.0.0.0+7:7148'))
         assert_equal(acv.antennas, ['m000', 'm001'])
         assert_equal(acv.band, 'l')
-        assert_equal(acv.n_channels, 32768)
+        assert_equal(acv.n_chans, 32768)
         assert_equal(acv.bandwidth, 107e6)
         assert_equal(acv.centre_frequency, 1284e6)
         assert_equal(acv.adc_sample_rate, 1712e6)
@@ -300,7 +300,7 @@ class TestSimAntennaChannelisedVoltageStream:
         assert_equal(acv.antennas, ['m000', 'm002'])
         assert_equal(acv.antenna_objects, [_M000, _M002])
         assert_equal(acv.band, 'l')
-        assert_equal(acv.n_channels, 32768)
+        assert_equal(acv.n_chans, 32768)
         assert_equal(acv.bandwidth, 107e6)
         assert_equal(acv.centre_frequency, 1284e6)
         assert_equal(acv.adc_sample_rate, 1712e6)
@@ -327,7 +327,7 @@ def make_antenna_channelised_voltage(antennas=('m000', 'm002')) -> AntennaChanne
         url=yarl.URL('spead2://239.0.0.0+7:7148'),
         antennas=antennas,
         band='l',
-        n_channels=32768,
+        n_chans=32768,
         bandwidth=107e6,
         adc_sample_rate=1712e6,
         centre_frequency=1284e6,
@@ -345,7 +345,7 @@ def make_sim_antenna_channelised_voltage() -> SimAntennaChannelisedVoltageStream
         centre_frequency=1284,
         bandwidth=256,
         adc_sample_rate=1024,
-        n_channels=512
+        n_chans=512
     )
 
 
@@ -379,8 +379,8 @@ class TestBaselineCorrelationProductsStream:
         assert_equal(bcp.size, 40 * 32768 * 8)
         assert_is(bcp.antenna_channelised_voltage, self.acv)
         assert_equal(bcp.antennas, ['m000', 'm002'])
-        assert_equal(bcp.n_channels, 32768)
-        assert_equal(bcp.n_channels_per_endpoint, 4096)
+        assert_equal(bcp.n_chans, 32768)
+        assert_equal(bcp.n_chans_per_endpoint, 4096)
         assert_equal(bcp.n_substreams, 16)
         assert_equal(bcp.n_antennas, 2)
         assert_equal(bcp.bandwidth, 107e6)
@@ -392,7 +392,7 @@ class TestBaselineCorrelationProductsStream:
     def test_bad_endpoint_count(self) -> None:
         self.config['url'] = 'spead://239.1.0.0+8:7148'
         with assert_raises_regex(ValueError,
-                                 r'n_channels \(32768\) is not a multiple of endpoints \(9\)'):
+                                 r'n_chans \(32768\) is not a multiple of endpoints \(9\)'):
             BaselineCorrelationProductsStream.from_config(
                 Options(), 'narrow2_bcp', self.config, [self.acv], self.sensors
             )
@@ -426,7 +426,7 @@ class TestSimBaselineCorrelationProductsStream:
         )
         # Most properties are assumed to be tested via
         # TestBaselineCorrelationProductsStream and are not re-tested here.
-        assert_equal(bcp.n_channels_per_substream, 8)
+        assert_equal(bcp.n_chans_per_substream, 8)
         assert_equal(bcp.n_substreams, 64)
         # Check that int_time is rounded to nearest multiple of 512
         assert_equal(bcp.int_time, 1024.0)
@@ -436,7 +436,7 @@ class TestSimBaselineCorrelationProductsStream:
         bcp = SimBaselineCorrelationProductsStream.from_config(
             Options(), 'narrow2_bcp', self.config, [self.acv], {}
         )
-        assert_equal(bcp.n_channels_per_substream, 32)
+        assert_equal(bcp.n_chans_per_substream, 32)
         assert_equal(bcp.n_substreams, 16)
 
 
@@ -463,7 +463,7 @@ class TestTiedArrayChannelisedVoltageStream:
         )
         assert_equal(tacv.name, 'beam_0x')
         assert_equal(tacv.bits_per_sample, 16)
-        assert_equal(tacv.n_channels_per_substream, 64)
+        assert_equal(tacv.n_chans_per_substream, 64)
         assert_equal(tacv.spectra_per_heap, 256)
         assert_equal(tacv.instrument_dev_name, 'beam')
         assert_equal(tacv.size, 32768 * 256 * 2 * 2)
@@ -492,7 +492,7 @@ class TestSimTiedArrayChannelisedVoltageStream:
         )
         assert_equal(tacv.name, 'beam_0x')
         assert_equal(tacv.bits_per_sample, 8)
-        assert_equal(tacv.n_channels_per_substream, 4)
+        assert_equal(tacv.n_chans_per_substream, 4)
         assert_equal(tacv.spectra_per_heap, 256)
         assert_equal(tacv.size, 512 * 256 * 2)
         assert_is(tacv.antenna_channelised_voltage, self.acv)
@@ -507,7 +507,7 @@ class TestSimTiedArrayChannelisedVoltageStream:
             Options(), 'beam_0x', self.config, [self.acv], {}
         )
         assert_equal(tacv.spectra_per_heap, product_config.KATCBFSIM_SPECTRA_PER_HEAP)
-        assert_equal(tacv.n_channels_per_substream, 32)
+        assert_equal(tacv.n_chans_per_substream, 32)
 
 
 def make_baseline_correlation_products(
@@ -519,7 +519,7 @@ def make_baseline_correlation_products(
         'narrow1_bcp', [antenna_channelised_voltage],
         url=yarl.URL('spead://239.2.0.0+63:7148'),
         int_time=0.5,
-        n_channels_per_substream=512,
+        n_chans_per_substream=512,
         n_baselines=40,
         bits_per_sample=32,
         instrument_dev_name='narrow1'
@@ -534,7 +534,7 @@ def make_tied_array_channelised_voltage(
     return TiedArrayChannelisedVoltageStream(
         name, [antenna_channelised_voltage],
         url=url,
-        n_channels_per_substream=128,
+        n_chans_per_substream=128,
         spectra_per_heap=256,
         bits_per_sample=8,
         instrument_dev_name='beam'
@@ -565,8 +565,8 @@ class TestVisStream:
         assert_equal(vis.archive, False)
         assert_equal(vis.n_servers, 4)
         assert_is(vis.baseline_correlation_products, self.bcp)
-        assert_equal(vis.n_channels, 1984)
-        assert_equal(vis.n_spectral_channels, 3968)
+        assert_equal(vis.n_chans, 1984)
+        assert_equal(vis.n_spectral_chans, 3968)
         assert_equal(vis.antennas, ['m000', 'm002'])
         assert_equal(vis.n_antennas, 2)
         assert_equal(vis.n_pols, 2)
@@ -587,7 +587,7 @@ class TestVisStream:
         self.config['continuum_factor'] = 3
         with assert_raises_regex(
                 ValueError,
-                r'n_channels \(32768\) is not a multiple of required alignment \(12\)'):
+                r'n_chans \(32768\) is not a multiple of required alignment \(12\)'):
             VisStream.from_config(Options(), 'sdp_l0', self.config, [self.bcp], {})
 
     def test_misaligned_output_channels(self):
@@ -633,7 +633,7 @@ class TestBeamformerStream:
         assert_equal(bf.name, 'beamformer')
         assert_equal(bf.antenna_channelised_voltage.name, 'narrow1_acv')
         assert_equal(bf.tied_array_channelised_voltage, self.tacv)
-        assert_equal(bf.n_channels, 32768)
+        assert_equal(bf.n_chans, 32768)
 
     def test_mismatched_sources(self) -> None:
         acv = make_antenna_channelised_voltage()
@@ -669,7 +669,7 @@ class TestBeamformerEngineeringStream:
         assert_equal(bf.tied_array_channelised_voltage, self.tacv)
         assert_equal(bf.store, 'ram')
         assert_equal(bf.output_channels, (128, 1024))
-        assert_equal(bf.n_channels, 896)
+        assert_equal(bf.n_chans, 896)
 
     def test_defaults(self) -> None:
         del self.config['output_channels']
@@ -677,7 +677,7 @@ class TestBeamformerEngineeringStream:
             Options(), 'beamformer', self.config, self.tacv, {}
         )
         assert_equal(bf.output_channels, (0, 32768))
-        assert_equal(bf.n_channels, 32768)
+        assert_equal(bf.n_chans, 32768)
 
     def test_misaligned_channels(self) -> None:
         self.config['output_channels'] = [1, 2]
@@ -776,7 +776,7 @@ class TestFlagsStream:
         assert_equal(flags.name, 'flags')
         assert_equal(flags.cal, self.cal)
         assert_equal(flags.vis, self.vis)
-        assert_equal(flags.n_channels, self.vis.n_channels)
+        assert_equal(flags.n_chans, self.vis.n_chans)
         assert_equal(flags.n_baselines, self.vis.n_baselines)
         assert_equal(flags.n_vis, self.vis.n_vis)
         assert_equal(flags.size, self.vis.flag_size)
@@ -902,7 +902,7 @@ class TestSpectralImageStream:
         assert_equal(spec.name, 'spectral_image')
         assert_equal(spec.output_channels, (64, 100))
         assert_equal(spec.parameters, {'q_fov': 2.0})
-        assert_equal(spec.n_channels, 36)
+        assert_equal(spec.n_chans, 36)
         assert_is(spec.flags, self.flags)
         assert_is(spec.continuum, self.continuum_image)
 
@@ -1324,7 +1324,7 @@ class TestConfiguration(Fixture):
         """Test which needs to apply sensors."""
         config = await Configuration.from_config(self.config)
         bcp = config.by_class(BaselineCorrelationProductsStream)[0]
-        assert_equal(bcp.n_channels, 1024)
+        assert_equal(bcp.n_chans, 1024)
         assert_equal(bcp.bandwidth, 544e6)
         assert_equal(bcp.antenna_channelised_voltage.band, 'u')
         assert_equal(bcp.int_time, 0.25)

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -387,7 +387,7 @@ class TestBaselineCorrelationProductsStream:
         assert_equal(bcp.centre_frequency, 1284e6)
         assert_equal(bcp.adc_sample_rate, 1712e6)
         assert_equal(bcp.n_samples_between_spectra, 524288)
-        assert_equal(bcp.net_bandwidth(1.0, 0), 40 * 32768 * 8 * 2 * 8)
+        assert_equal(bcp.data_rate(1.0, 0), 40 * 32768 * 8 * 2 * 8)
 
     def test_bad_endpoint_count(self) -> None:
         self.config['url'] = 'spead://239.1.0.0+8:7148'
@@ -573,8 +573,8 @@ class TestVisStream:
         assert_equal(vis.n_baselines, 12)
         assert_equal(vis.size, 1984 * (12 * 10 + 4))
         assert_equal(vis.flag_size, 1984 * 12)
-        assert_equal(vis.net_bandwidth(1.0, 0), vis.size / vis.int_time * 8)
-        assert_equal(vis.flag_bandwidth(1.0, 0), vis.flag_size / vis.int_time * 8)
+        assert_equal(vis.data_rate(1.0, 0), vis.size / vis.int_time * 8)
+        assert_equal(vis.flag_data_rate(1.0, 0), vis.flag_size / vis.int_time * 8)
 
     def test_defaults(self) -> None:
         del self.config['output_channels']
@@ -780,7 +780,7 @@ class TestFlagsStream:
         assert_equal(flags.n_baselines, self.vis.n_baselines)
         assert_equal(flags.n_vis, self.vis.n_vis)
         assert_equal(flags.size, self.vis.flag_size)
-        assert_equal(flags.net_bandwidth(), self.vis.flag_bandwidth() * 10.0)
+        assert_equal(flags.data_rate(), self.vis.flag_data_rate() * 10.0)
         assert_equal(flags.int_time, self.vis.int_time)
 
     def test_defaults(self) -> None:

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -1317,7 +1317,7 @@ class TestConfiguration(Fixture):
 
     async def test_bad_stream(self) -> None:
         self.config['outputs']['l0']['continuum_factor'] = 3
-        with assert_raises_regex(ValueError, 'Configuration error for l0: '):
+        with assert_raises_regex(ValueError, 'Configuration error for stream l0: '):
             await Configuration.from_config(self.config)
 
     async def test_sensors(self) -> None:

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -773,8 +773,13 @@ class TestFlagsStream:
         assert_equal(flags.n_baselines, self.vis.n_baselines)
         assert_equal(flags.n_vis, self.vis.n_vis)
         assert_equal(flags.size, self.vis.flag_size)
-        assert_equal(flags.net_bandwidth(), self.vis.flag_bandwidth())
+        assert_equal(flags.net_bandwidth(), self.vis.flag_bandwidth() * 10.0)
         assert_equal(flags.int_time, self.vis.int_time)
+
+    def test_defaults(self) -> None:
+        del self.config['rate_ratio']
+        flags = FlagsStream.from_config(Options(), 'flags', self.config, [self.vis, self.cal], {})
+        assert_equal(flags.rate_ratio, product_config.DEFAULT_FLAGS_RATE_RATIO)
 
     def test_incompatible_vis(self) -> None:
         vis = make_vis()

--- a/katsdpcontroller/test/utils.py
+++ b/katsdpcontroller/test/utils.py
@@ -15,57 +15,43 @@ from nose.tools import assert_raises, assert_equal, assert_true
 _T = TypeVar('_T')
 
 CONFIG = '''{
-    "version": "2.6",
-    "inputs": {
-        "camdata": {
-            "type": "cam.http",
-            "url": "http://127.0.0.1:8999"
-        },
+    "version": "3.0",
+    "outputs": {
         "i0_antenna_channelised_voltage": {
-            "type": "cbf.antenna_channelised_voltage",
-            "url": "spead://239.102.252.0+15:7148",
-            "antennas": ["m000", "m001", "m063", "m064"],
+            "type": "sim.cbf.antenna_channelised_voltage",
+            "antennas": [
+                "m000, -30:42:39.8, 21:26:38.0, 1035.0, 13.5, -8.258 -207.289 1.2075 5874.184 5875.444, -0:00:39.7 0 -0:04:04.4 -0:04:53.0 0:00:57.8 -0:00:13.9 0:13:45.2 0:00:59.8, 1.14",
+                "m001, -30:42:39.8, 21:26:38.0, 1035.0, 13.5, 1.126 -171.761 1.0605 5868.979 5869.998, -0:42:08.0 0 0:01:44.0 0:01:11.9 -0:00:14.0 -0:00:21.0 -0:36:13.1 0:01:36.2, 1.14",
+                "m062, -30:42:39.8, 21:26:38.0, 1035.0, 13.5, -1440.6235 -2503.7705 14.288 5932.94 5934.732, -0:15:23.0 0 0:00:04.6 -0:03:30.4 0:01:12.2 0:00:37.5 0:00:15.6 0:01:11.8, 1.14",
+                "m063, -30:42:39.8, 21:26:38.0, 1035.0, 13.5, -3419.58 -1840.4655 9.005 5684.815 5685.969, -0:59:43.2 0 0:01:58.6 0:01:49.8 0:01:23.3 0:02:04.6 -0:08:15.7 0:03:47.1, 1.14"
+            ],
             "n_chans": 4096,
-            "n_pols": 2,
             "adc_sample_rate": 1712000000.0,
             "bandwidth": 856000000.0,
-            "n_samples_between_spectra": 8192,
-            "instrument_dev_name": "i0"
+            "centre_frequency": 1284000000.0,
+            "band": "l"
         },
         "i0_baseline_correlation_products": {
-            "type": "cbf.baseline_correlation_products",
-            "url": "spead://239.102.255.0+15:7148",
+            "type": "sim.cbf.baseline_correlation_products",
+            "n_endpoints": 16,
             "src_streams": ["i0_antenna_channelised_voltage"],
             "int_time": 0.499,
-            "n_bls": 40,
-            "xeng_out_bits_per_sample": 32,
-            "n_chans_per_substream": 256,
-            "instrument_dev_name": "i0",
-            "simulate": {
-                "center_freq": 1284000000.0,
-                "sources": ["PKS 1934-638, radec, 19:39:25.03, -63:42:45.63"]
-            }
+            "n_chans_per_substream": 256
         },
         "i0_tied_array_channelised_voltage_0x": {
-            "type": "cbf.tied_array_channelised_voltage",
-            "url": "spead://239.102.254.1+15:7148",
+            "type": "sim.cbf.tied_array_channelised_voltage",
+            "n_endpoints": 16,
             "src_streams": ["i0_antenna_channelised_voltage"],
             "spectra_per_heap": 256,
-            "n_chans_per_substream": 256,
-            "beng_out_bits_per_sample": 8,
-            "instrument_dev_name": "i0"
+            "n_chans_per_substream": 256
         },
         "i0_tied_array_channelised_voltage_0y": {
-            "type": "cbf.tied_array_channelised_voltage",
-            "url": "spead://239.102.253.1+15:7148",
+            "type": "sim.cbf.tied_array_channelised_voltage",
+            "n_endpoints": 16,
             "src_streams": ["i0_antenna_channelised_voltage"],
             "spectra_per_heap": 256,
-            "n_chans_per_substream": 256,
-            "beng_out_bits_per_sample": 8,
-            "instrument_dev_name": "i0"
-        }
-    },
-    "outputs": {
+            "n_chans_per_substream": 256
+        },
         "sdp_l0": {
             "type": "sdp.vis",
             "src_streams": ["i0_baseline_correlation_products"],
@@ -127,14 +113,12 @@ CONFIG = '''{
         },
         "sdp_l1_flags": {
             "type": "sdp.flags",
-            "src_streams": ["sdp_l0"],
-            "calibration": ["cal"],
+            "src_streams": ["sdp_l0", "cal"],
             "archive": true
         },
         "sdp_l1_flags_continuum": {
             "type": "sdp.flags",
-            "src_streams": ["sdp_l0_continuum"],
-            "calibration": ["cal"],
+            "src_streams": ["sdp_l0_continuum", "cal"],
             "archive": true
         },
         "continuum_image": {
@@ -152,7 +136,7 @@ CONFIG = '''{
         }
     },
     "config": {}
-}'''
+}'''     # noqa: E501
 
 S3_CONFIG = '''
 {


### PR DESCRIPTION
The new schema is documented at https://docs.google.com/document/d/15ZIyuBf4Vk4ESIEdKsQxdSBoLEwh85eyKeDJouLRAZY/edit#heading=h.v512w2fvji5f.

The implementation is greatly changed, using Python classes to wrap the various streams. These classes combine the functionality of semantic validation and the \*Info classes that were in generator.py, and avoid a lot of tedious dict lookups. There is also lots of type annotations so that it's harder to get confused about which class you're using and look up the wrong thing.

There are also a number of bugs that I noticed and fixed along the way:
- The code for getting sensor values from katportal to override the values in the config was not getting called (SPR1-594).
- The rate_ratio config value was never used (the default of 8 was always used regardless).
- The calculation of cal output bandwidth was wrong (it assumed exactly one flags stream with no spectral averaging)

To keep things slightly simpler, schema versions 2.0-2.3 have been dropped, which basically just means some validation code could be removed since newer versions are strictly more general.

One regression is that there is now no way to specify a single-pol CBF. However, the internal support is still there, and would just require a way to detect such an instrument from sensors (e.g. from the baseline list), and would not require a schema change.