### PR TITLE
Fixes for Python 3.8 and aioresponses 0.6.4

### DIFF
--- a/katsdpcontroller/master_controller.py
+++ b/katsdpcontroller/master_controller.py
@@ -811,6 +811,8 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
             await asyncio.sleep(self.reconciliation_interval)
             try:
                 await self._reconcile_once()
+            except asyncio.CancelledError:
+                raise
             except Exception:
                 logger.exception('Exception in reconciliation')
 

--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -1175,7 +1175,7 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
                 telstate.add('sdp_image_tag', resolver.image_resolver.tag, immutable=True)
                 telstate.add('sdp_image_overrides', resolver.image_resolver.overrides,
                              immutable=True)
-            except Exception as exc:
+            except BaseException as exc:
                 # If there was a problem the graph might be semi-running. Shut it all down.
                 await self._shutdown(force=True)
                 raise exc
@@ -1387,7 +1387,7 @@ class DeviceServer(aiokatcp.DeviceServer):
         self.product.dead_callbacks.append(dead_callback)
         try:
             await product.configure()
-        except Exception:
+        except BaseException:
             self.product = None
             raise
 

--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -2940,7 +2940,7 @@ class Scheduler(pymesos.Scheduler):
                     group.future.set_result(None)
                     queue.remove(group)
                     self._wakeup_launcher.set()
-                except Exception as error:
+                except BaseException as error:
                     if not group.future.done():
                         group.future.set_exception(error)
                     # Don't remove from the queue: launch() handles that
@@ -3113,7 +3113,7 @@ class Scheduler(pymesos.Scheduler):
         try:
             await asyncio.wait_for(pending.resources_future, timeout=resources_timeout)
             await pending.future
-        except Exception as error:
+        except BaseException as error:
             logger.debug('Exception in launching group', exc_info=True)
             # Could be
             # - a timeout

--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -3406,6 +3406,8 @@ class Scheduler(pymesos.Scheduler):
                     tasks = []
                     logger.debug('Requesting implicit reconciliation')
                 self._driver.reconcileTasks(tasks)
+            except asyncio.CancelledError:
+                raise
             except Exception:
                 logger.warning('Exception during task reconciliation', exc_info=True)
             await asyncio.sleep(self.reconciliation_interval)

--- a/katsdpcontroller/test/test_master_controller.py
+++ b/katsdpcontroller/test/test_master_controller.py
@@ -884,7 +884,6 @@ class TestDeviceServer(asynctest.ClockedTestCase):
         await self.client.request('capture-init', 'product')
         reply, informs = await self.client.request('sdp-shutdown')
         self.assertEqual(reply[0], b'127.0.0.144,127.0.0.42')
-        print(poweroff_mock.mock_calls)
         poweroff_mock.assert_any_call(
             url1, headers={'X-Poweroff-Server': '1'}, allow_redirects=True, data=None)
         poweroff_mock.assert_any_call(

--- a/katsdpcontroller/test/test_master_controller.py
+++ b/katsdpcontroller/test/test_master_controller.py
@@ -884,8 +884,11 @@ class TestDeviceServer(asynctest.ClockedTestCase):
         await self.client.request('capture-init', 'product')
         reply, informs = await self.client.request('sdp-shutdown')
         self.assertEqual(reply[0], b'127.0.0.144,127.0.0.42')
-        poweroff_mock.assert_any_call(url1, headers={'X-Poweroff-Server': '1'}, data=None)
-        poweroff_mock.assert_any_call(url2, headers={'X-Poweroff-Server': '1'}, data=None)
+        print(poweroff_mock.mock_calls)
+        poweroff_mock.assert_any_call(
+            url1, headers={'X-Poweroff-Server': '1'}, allow_redirects=True, data=None)
+        poweroff_mock.assert_any_call(
+            url2, headers={'X-Poweroff-Server': '1'}, allow_redirects=True, data=None)
         # The product should have been forcibly deconfigured
         self.assertEqual(self.server._manager.products, {})
 
@@ -914,7 +917,8 @@ class TestDeviceServer(asynctest.ClockedTestCase):
                                     r'^Success: 127\.0\.0\.42 Failed: 127.0.0.144$'):
             await self.client.request('sdp-shutdown')
         # Other machine must still have been powered off
-        poweroff_mock.assert_any_call(url1, headers={'X-Poweroff-Server': '1'}, data=None)
+        poweroff_mock.assert_any_call(
+            url1, headers={'X-Poweroff-Server': '1'}, allow_redirects=True, data=None)
         # The product should have been forcibly deconfigured
         self.assertEqual(self.server._manager.products, {})
 

--- a/katsdpcontroller/test/test_scheduler.py
+++ b/katsdpcontroller/test/test_scheduler.py
@@ -1208,6 +1208,10 @@ class TestScheduler(asynctest.ClockedTestCase):
     def _dummy_random():
         return 0.0
 
+    @staticmethod
+    def _dummy_randint(a, b):
+        return a
+
     def _driver_calls(self):
         """self.driver.mock_calls, with reconcileTasks filtered out."""
         return [call for call in self.driver.mock_calls if call[0] != 'reconcileTasks']
@@ -1290,6 +1294,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         # Mock out the random generator so that port allocations will be
         # predictable.
         create_patch(self, 'katsdpcontroller.scheduler.Agent._random.random', self._dummy_random)
+        create_patch(self, 'katsdpcontroller.scheduler.Agent._random.randint', self._dummy_randint)
         await self.sched.start()
 
     async def test_initial_offers(self):

--- a/katsdpcontroller/test/test_scheduler.py
+++ b/katsdpcontroller/test/test_scheduler.py
@@ -24,7 +24,7 @@ import aiohttp
 
 from .. import scheduler
 from ..scheduler import TaskState
-from .utils import create_patch
+from .utils import create_patch, future_return
 
 
 class AnyOrderList(list):
@@ -1490,8 +1490,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         # Tell scheduler that node0 is now running. This will start up the
         # the waiter, so we need to mock poll_ports.
         with mock.patch.object(scheduler, 'poll_ports', autospec=True) as poll_ports:
-            poll_future = asyncio.Future()
-            poll_ports.return_value = poll_future
+            poll_future = future_return(poll_ports)
             status = self._status_update(self.task_ids[0], 'TASK_RUNNING')
             await asynctest.exhaust_callbacks(self.loop)
             assert_equal(TaskState.RUNNING, self.nodes[0].state)
@@ -1554,8 +1553,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         await asynctest.exhaust_callbacks(self.loop)
         assert_equal(TaskState.STARTING, self.nodes[0].state)
         with mock.patch.object(scheduler, 'poll_ports', autospec=True) as poll_ports:
-            poll_future = asyncio.Future()
-            poll_ports.return_value = poll_future
+            poll_future = future_return(poll_ports)
             if target_state > TaskState.STARTING:
                 self.sched.resourceOffers(self.driver, offers)
                 await asynctest.exhaust_callbacks(self.loop)
@@ -1618,8 +1616,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         await asynctest.exhaust_callbacks(self.loop)
         assert_equal(TaskState.STARTED, self.nodes[0].state)
         with mock.patch.object(scheduler, 'poll_ports', autospec=True) as poll_ports:
-            poll_future = asyncio.Future()
-            poll_ports.return_value = poll_future
+            poll_future = future_return(poll_ports)
             poll_future.set_result(None)   # Mark ports as ready
             self._status_update(self.nodes[0].taskinfo.task_id.value, 'TASK_RUNNING')
             await asynctest.exhaust_callbacks(self.loop)

--- a/katsdpcontroller/test/utils.py
+++ b/katsdpcontroller/test/utils.py
@@ -260,10 +260,10 @@ class DelayedManager:
         mock.side_effect = self._side_effect
         self._request_task = asyncio.get_event_loop().create_task(coro)
 
-    def _side_effect(self, *args, **kwargs) -> asyncio.Future:
+    async def _side_effect(self, *args, **kwargs) -> Any:
         self._started.set_result(None)
         self.mock.side_effect = self._old_side_effect
-        return self._result
+        return await self._result
 
     async def __aenter__(self) -> 'DelayedManager':
         await self._started

--- a/katsdpcontroller/test/utils.py
+++ b/katsdpcontroller/test/utils.py
@@ -343,3 +343,13 @@ async def run_clocked(test_case: asynctest.ClockedTestCase, time: float,
     with Background(awaitable) as cm:
         await test_case.advance(time)
     return cm.result
+
+
+def future_return(mock: mock.Mock) -> asyncio.Future:
+    """Modify a callable mock so that it blocks on a future then returns it."""
+    async def replacement(*args, **kwargs):
+        return await future
+
+    future = asyncio.Future()         # type: asyncio.Future[Any]
+    mock.side_effect = replacement
+    return future

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from setuptools import setup, find_packages
 
-tests_require = ['nose', 'aioresponses', 'asynctest', 'open-mock-file']
+tests_require = ['nose', 'aioresponses>=0.6.4', 'asynctest', 'open-mock-file']
 
 setup(
     name="katsdpcontroller",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-aioresponses==0.6.0
+aioresponses==0.6.4
 asynctest==0.12.2
 coverage
 nose


### PR DESCRIPTION
I ran into a number of issues when I tried to run the unit tests on a fresh Python 3.8 venv. Mostly they relate to 3.8 having changed the base class for asyncio.CancelledError from Exception to BaseException.

A couple of these fixes (where an explicit catch for CancelledError is added) don't affect 3.8, but rather bring pre-3.8 behaviour into line with the behaviour under 3.8, which is actually the correct, desired behaviour i.e. CancelledError should not be swept up in the Exception catch-all.