### PR TITLE
Shorten minimum imaging times

### DIFF
--- a/katsdpcontroller/defaults.py
+++ b/katsdpcontroller/defaults.py
@@ -9,6 +9,9 @@ WRITER_OBJECT_SIZE = 20e6    # 20 MB
 #: Maximum channels per chunk for spectral imager
 SPECTRAL_OBJECT_CHANNELS = 128
 #: Minimum observation time for continuum imager (seconds)
+#: This, and SPECTRAL_MIN_TIME, are set to one minute
+#: less than some typical observations lengths to avoid
+#: off by one dump triggering issues. 
 CONTINUUM_MIN_TIME = 14 * 60.0     # 14 minutes
 #: Minimum observation time for spectral imager (seconds)
 SPECTRAL_MIN_TIME = 44 * 60.0      # 44 minutes

--- a/katsdpcontroller/defaults.py
+++ b/katsdpcontroller/defaults.py
@@ -11,7 +11,7 @@ SPECTRAL_OBJECT_CHANNELS = 128
 #: Minimum observation time for continuum imager (seconds)
 #: This, and SPECTRAL_MIN_TIME, are set to one minute
 #: less than some typical observations lengths to avoid
-#: off by one dump triggering issues. 
+#: off by one dump triggering issues.
 CONTINUUM_MIN_TIME = 14 * 60.0     # 14 minutes
 #: Minimum observation time for spectral imager (seconds)
 SPECTRAL_MIN_TIME = 44 * 60.0      # 44 minutes

--- a/katsdpcontroller/defaults.py
+++ b/katsdpcontroller/defaults.py
@@ -9,9 +9,9 @@ WRITER_OBJECT_SIZE = 20e6    # 20 MB
 #: Maximum channels per chunk for spectral imager
 SPECTRAL_OBJECT_CHANNELS = 128
 #: Minimum observation time for continuum imager (seconds)
-CONTINUUM_MIN_TIME = 15 * 60.0     # 15 minutes
+CONTINUUM_MIN_TIME = 14 * 60.0     # 14 minutes
 #: Minimum observation time for spectral imager (seconds)
-SPECTRAL_MIN_TIME = 3600.0         # 1 hour
+SPECTRAL_MIN_TIME = 44 * 60.0      # 44 minutes
 #: Size of cal buffer in seconds
 CAL_BUFFER_TIME = 25 * 60.0        # 25 minutes (allows a single batch of 15 minutes)
 #: Maximum number of scans to include in report


### PR DESCRIPTION
Decrease the minimum imaging times, and move them away from "convenient" multiples. We have a bunch of upcoming spectral observations that will be about 1 hour on source, and given we have a fair headroom on the spectral side, reducing to 45 minutes seems fine.

Further to this, shorten the cont and spectral times by 1 minute to 14 and 44 respectively, to avoid off by one dump issues when doing testing.