### PR TITLE
Double memory for the product controller

### DIFF
--- a/katsdpcontroller/master_controller.py
+++ b/katsdpcontroller/master_controller.py
@@ -653,7 +653,7 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
             },
             "resources": {
                 "cpus": 0.2,
-                "memoryMb": 512,
+                "memoryMb": 1024,
                 "numPorts": 5         # katcp, http, aiomonitor, aioconsole, dashboard
             }
         }


### PR DESCRIPTION
We've had some OOM issues (SPR1-614). It shouldn't be using anywhere
near this much memory, but this is a short-term mitigation.