### PR TITLE
Double product controller memory again

### DIFF
--- a/katsdpcontroller/master_controller.py
+++ b/katsdpcontroller/master_controller.py
@@ -653,7 +653,7 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
             },
             "resources": {
                 "cpus": 0.2,
-                "memoryMb": 1024,
+                "memoryMb": 2048,
                 "numPorts": 5         # katcp, http, aiomonitor, aioconsole, dashboard
             }
         }


### PR DESCRIPTION
To fix SPR1-614. It's probably not necessary, but it's still not a huge
amount of memory and when the product controller OOMs it is not pretty.

It would have been nicer to scale this according to the number of
channels, but we don't have that information at the time the product
controller is spun up.