### PR TITLE
Optimise getting sensors from katportal

### DIFF
--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -1227,7 +1227,8 @@ class Configuration:
 
         # Extract sensor values. This is pulled into a separate block that
         # queries all sensors at once rather than done as we construct each
-        # stream because katportal has a very high overhead per query.
+        # stream because katportal has a very high overhead per query
+        # (https://skaafrica.atlassian.net/browse/MT-1078).
         sensors: Dict[str, Dict[str, Any]] = {name: {} for name in stream_configs}
         if cam_http:
             client = katportalclient.KATPortalClient(str(cam_http.url), None)

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -1226,7 +1226,7 @@ class Configuration:
                 break
 
         # Extract sensor values. This is pulled into a separate block that
-        # queries all sensors at once rather than done as we construct each
+        # queries all sensors at once, rather than done as we construct each
         # stream because katportal has a very high overhead per query
         # (https://skaafrica.atlassian.net/browse/MT-1078).
         sensors: Dict[str, Dict[str, Any]] = {name: {} for name in stream_configs}

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -1343,7 +1343,7 @@ class TestConfiguration(Fixture):
             with assert_raises(product_config.SensorFailure):
                 await Configuration.from_config(self.config)
 
-        with mock.patch.object(self.client, 'sensor_value',
+        with mock.patch.object(self.client, 'sensor_values',
                                side_effect=ConnectionRefusedError):
             with assert_raises(product_config.SensorFailure):
                 await Configuration.from_config(self.config)


### PR DESCRIPTION
katportal on MeerKAT is very slow (takes 1.5s+ to get each sensor). I'm
guessng it lacks a dictionary lookup and iterates over every single
sensor. Speed it up by munging all the sensors to query into a regex and
querying with that, which at least only makes one pass over the sensor
list on the backend.

This should fix SPR1-621.