### PR TITLE
Fix postprocessing failing if the queue is blocked by an earlier one

### DIFF
--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -1014,8 +1014,11 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
             # This doesn't actually run anything, just marks the fake telstate node
             # as READY. It could block for a while behind real tasks in the batch
             # queue, but that doesn't matter because our real tasks will block too.
+            # However, because of this blocking it needs a large resources_timeout,
+            # even though it uses no resources.
             await self.sched.launch(physical_graph, self.resolver, [telstate_node],
-                                    queue=self.batch_queue)
+                                    queue=self.batch_queue,
+                                    resources_timeout=BATCH_RESOURCES_TIMEOUT)
             nodelist = [node for node in physical_graph if isinstance(node, scheduler.PhysicalTask)]
             await self.sched.batch_run(physical_graph, self.resolver, nodelist,
                                        queue=self.batch_queue,

--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -1221,9 +1221,10 @@ class GroupInsufficientInterfaceResourcesError(InsufficientResourcesError):
 
 class QueueBusyError(InsufficientResourcesError):
     """The launch group did not reach the front of the queue before its timeout expired."""
-    def __init__(self):
+    def __init__(self, timeout):
+        self.timeout = timeout
         super().__init__(
-            "The launch group did not reach the front of the queue before its timeout expired"
+            f"The launch group timeout ({timeout}s) fired before reaching the front of the queue"
         )
 
 
@@ -3150,7 +3151,7 @@ class Scheduler(pymesos.Scheduler):
             self._wakeup_launcher.set()
             if isinstance(error, asyncio.TimeoutError) and pending.last_insufficient is not None:
                 if not at_front:
-                    raise QueueBusyError()
+                    raise QueueBusyError(resources_timeout)
                 else:
                     raise pending.last_insufficient from None
             else:

--- a/katsdpcontroller/test/test_scheduler.py
+++ b/katsdpcontroller/test/test_scheduler.py
@@ -1663,8 +1663,10 @@ class TestScheduler(asynctest.ClockedTestCase):
             self.sched.launch(self.physical_graph, self.resolver, [self.nodes[2]],
                               resources_timeout=2))
         await self.advance(3)
-        with assert_raises(scheduler.QueueBusyError):
+        with assert_raises(scheduler.QueueBusyError) as cm:
             await launch1
+        assert cm.exception.timeout == 2
+        assert '(2s)' in str(cm.exception)
         assert_false(launch.done())
         await self.advance(30)
         with assert_raises(scheduler.InsufficientResourcesError):


### PR DESCRIPTION
If a second postprocessing task is started and there are tasks from the
first that haven't cleared the batch queue, then it would fail because
it would only wait the default resources_timeout (11s) to launch the
pseudo-task that wraps telstate.

Fixes SPR1-628.