### PR TITLE
Remove last vestiges of nvidia-docker 1 support

### DIFF
--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -122,8 +122,8 @@ from 0), there must be corresponding resources
 :samp:`katsdpcontroller.gpu.{i}.compute` (generally with capacity 1.0) and
 :samp:`katsdpcontroller.gpu.{i}.mem` (in MiB).
 
-The node must also provide nvidia-docker-plugin so that driver volumes can be
-loaded.
+The node must also provide nvidia-container-runtime for access to the
+devices.
 
 Agent prioritisation
 --------------------

--- a/katsdpcontroller/schemas/gpus.json
+++ b/katsdpcontroller/schemas/gpus.json
@@ -4,13 +4,6 @@
     "items": {
         "type": "object",
         "properties": {
-            "devices": {
-                "type": "array",
-                "items": {
-                    "type": "string",
-                    "minLength": 1
-                }
-            },
             "uuid": {
                 "type": "string",
                 "minLength": 1


### PR DESCRIPTION
The schema for the GPUs custom Mesos attribute was still allowing a
"devices" section for backwards compatibility.

Closes SPR-162.