### PR TITLE
Skip spectral imaging tasks that are completely band masked

### DIFF
--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -1150,14 +1150,6 @@ class SpectralImageStream(ImageStream):
         return self.output_channels[1] - self.output_channels[0]
 
     @property
-    def flags(self) -> FlagsStream:
-        return cast(FlagsStream, self.src_streams[0])
-
-    @property
-    def vis(self) -> VisStream:
-        return self.flags.vis
-
-    @property
     def continuum(self) -> Optional[ContinuumImageStream]:
         try:
             return cast(ContinuumImageStream, self.src_streams[1])

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -1154,6 +1154,10 @@ class SpectralImageStream(ImageStream):
         return cast(FlagsStream, self.src_streams[0])
 
     @property
+    def vis(self) -> VisStream:
+        return self.flags.vis
+
+    @property
     def continuum(self) -> Optional[ContinuumImageStream]:
         try:
             return cast(ContinuumImageStream, self.src_streams[1])

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -912,6 +912,7 @@ class TestSpectralImageStream:
         assert_equal(spec.parameters, config['parameters'])
         assert_equal(spec.n_chans, 36)
         assert_is(spec.flags, self.flags)
+        assert_is(spec.vis, self.flags.vis)
         assert_is(spec.continuum, self.continuum_image)
 
     def test_no_continuum(self) -> None:

--- a/katsdpcontroller/test/utils.py
+++ b/katsdpcontroller/test/utils.py
@@ -128,7 +128,7 @@ CONFIG = '''{
         "spectral_image": {
             "type": "sdp.spectral_image",
             "src_streams": ["sdp_l1_flags"],
-            "output_channels": [120, 130],
+            "output_channels": [510, 520],
             "parameters": {
                 "major": 6,
                 "major_gain": 0.15


### PR DESCRIPTION
Only the RFI mask was being applied to compute the channel mask; now the
band mask is used as well.

This partially addresses SPR1-649. Support is also needed in the imager
to skip individual channels when the 128-channel batch lies partially
inside and partially outside the masked region.