### PR TITLE
Fix calculation of band mask for spectral imaging

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -1579,8 +1579,7 @@ async def _make_spectral_imager(g: networkx.MultiDiGraph,
     dump_bytes = stream.vis.n_baselines * defaults.SPECTRAL_OBJECT_CHANNELS * BYTES_PER_VFW_SPECTRAL
     data_url = _stream_url(capture_block_id, stream.name + '.' + stream.vis.name)
     targets, data_set = _get_targets(configuration, capture_block_id, stream, telstate_endpoint)
-    spw = data_set.spectral_windows[data_set.spw]
-    band = spw.band
+    band = data_set.spectral_windows[data_set.spw].band
     channel_freqs = data_set.channel_freqs * u.Hz
     del data_set    # Allow Python to recover the memory
 
@@ -1592,7 +1591,7 @@ async def _make_spectral_imager(g: networkx.MultiDiGraph,
         telstate_acv = telstate.view(acv.name)
         band_mask = await fetcher.get('model_band_mask_fixed', BandMask, telstate=telstate_acv)
         channel_mask |= band_mask.is_masked(
-            SpectralWindow(spw.bandwidth * u.Hz, spw.centre_freq * u.Hz),
+            SpectralWindow(acv.bandwidth * u.Hz, acv.centre_frequency * u.Hz),
             channel_freqs
         )
 

--- a/katsdpcontroller/test/test_product_controller.py
+++ b/katsdpcontroller/test/test_product_controller.py
@@ -387,7 +387,6 @@ class BaseTestSDPController(asynctest.TestCase):
                 'cbf_1_i0_antenna_channelised_voltage_n_chans': 4096,
                 'cbf_1_i0_adc_sample_rate': 1712e6,
                 'cbf_1_i0_antenna_channelised_voltage_n_samples_between_spectra': 8192,
-                'subarray_1_streams_i0_antenna_channelised_voltage_bandwidth': 856e6,
                 'cbf_1_i0_baseline_correlation_products_int_time': 0.499,
                 'cbf_1_i0_baseline_correlation_products_n_bls': 40,
                 'cbf_1_i0_baseline_correlation_products_xeng_out_bits_per_sample': 32,


### PR DESCRIPTION
It was using the spectral window reported by katdal, but if ingest is
configured to consume only part of the band that will be incorrect. It
must use the full band (from the AntennaChannelisedVoltage stream).