### PR TITLE
Fix service overrides

### DIFF
--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -175,7 +175,8 @@ class SDPConfigMixin:
             config.update(attr.get('config', lambda task_, resolver_, endpoint_: {})(
                 self, resolver, endpoint))
         config.update(self._graph_config(resolver, graph))
-        overrides = resolver.service_overrides.get(self.logical_node.name, {}).get('config')
+        overrides = resolver.service_overrides.get(
+            self.logical_node.name, product_config.ServiceOverride()).config
         if overrides:
             logger.warning('Overriding config for %s', self.name)
             config = product_config.override(config, overrides)

--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -514,7 +514,8 @@ class SDPPhysicalTask(SDPConfigMixin, scheduler.PhysicalTask):
             ])
 
         # Apply overrides to taskinfo given by the user
-        overrides = resolver.service_overrides.get(self.logical_node.name, {}).get('taskinfo')
+        overrides = resolver.service_overrides.get(
+            self.logical_node.name, product_config.ServiceOverride()).taskinfo
         if overrides:
             self.logger.warning('Applying overrides to taskinfo of %s', self.name)
             self.taskinfo = Dict(product_config.override(self.taskinfo.to_dict(), overrides))


### PR DESCRIPTION
They were broken by the product_config refactoring for API v3, which introduced ServiceOverride in place of a dictionary.