### PR TITLE
More compact formatting of durations on dashboard

### DIFF
--- a/katsdpcontroller/dashboard.py
+++ b/katsdpcontroller/dashboard.py
@@ -10,7 +10,6 @@ from datetime import datetime
 
 import networkx
 import jinja2
-import humanfriendly
 
 import dash
 from dash.dependencies import Input, Output
@@ -30,7 +29,8 @@ def timestamp_utc(timestamp):
 
 def timespan(delta):
     if delta is not None:
-        return humanfriendly.format_timespan(delta)
+        delta = round(delta)
+        return f"{delta // 3600}:{delta // 60 % 60:02}:{delta % 60:02}"
     else:
         return delta
 
@@ -203,7 +203,7 @@ class Dashboard:
                     'mesos-state': task.status.state if task.status else '-',
                     'host': task.agent.host if task.agent else '-',
                     'runtime':
-                        humanfriendly.format_timespan((task.end_time or now) - task.start_time)
+                        timespan((task.end_time or now) - task.start_time)
                         if task.start_time is not None else '-'
                 } for (capture_block_id, task) in tasks
             ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,6 @@ future                     # via katdal
 h5py                       # via katdal, katsdpmodels
 hiredis
 http-parser==0.8.3         # via pymesos
-humanfriendly==4.17
 idna                       # via requests
 idna-ssl                   # via aiohttp
 importlib-metadata         # via jsonschema

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         'async_timeout',
         'decorator',
         'docker',
-        'humanfriendly',
         'jinja2',
         'jsonschema>=3.0',   # Version 3 implements Draft 7
         'rfc3987',           # Used by jsonschema to validate URLs


### PR DESCRIPTION
Instead the rather clunky "6 hours, 32 minutes and 7.73 seconds", show
6:32:08. This removes the need for the humanfriendly package, and causes
less visual layout disruption when it is ticking because it has a mostly
fixed width (except when the number of digits in the hours increases).