### PR TITLE
Switch multicast to use 239.192.0.0/18 address space

### DIFF
--- a/katsdpcontroller/master_controller.py
+++ b/katsdpcontroller/master_controller.py
@@ -1568,7 +1568,7 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
                         metavar='FILE',
                         help='configuration for connecting services to S3 '
                              '(loaded on each configure)')
-    parser.add_argument('--safe-multicast-cidr', default='225.100.0.0/16',
+    parser.add_argument('--safe-multicast-cidr', default='239.192.0.0/18',
                         metavar='MULTICAST-CIDR',
                         help='block of multicast addresses from which to draw internal allocation. '
                              'Needs to be at least /16. [%(default)s]')

--- a/katsdpcontroller/test/test_product_controller.py
+++ b/katsdpcontroller/test/test_product_controller.py
@@ -86,7 +86,7 @@ class DummyMasterController(aiokatcp.DeviceServer):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self._network = ipaddress.IPv4Network('225.100.0.0/16')
+        self._network = ipaddress.IPv4Network('239.192.0.0/18')
         self._next = self._network.network_address + 1
 
     async def request_get_multicast_groups(self, ctx: aiokatcp.RequestContext,
@@ -1194,5 +1194,5 @@ class TestSDPResources(asynctest.TestCase):
         self.resources = SDPResources(mc_client, SUBARRAY_PRODUCT)
 
     async def test_get_multicast_groups(self):
-        self.assertEqual('225.100.0.1', await self.resources.get_multicast_groups(1))
-        self.assertEqual('225.100.0.2+3', await self.resources.get_multicast_groups(4))
+        self.assertEqual('239.192.0.1', await self.resources.get_multicast_groups(1))
+        self.assertEqual('239.192.0.2+3', await self.resources.get_multicast_groups(4))


### PR DESCRIPTION
This is RFC2365-compliant, and should play nice with the CBF network
which only supports the 239.0.0.0/8 range. I switched from a /16 to a
/18 because we don't need a lot of addresses and the RFC2365
organisation-local scope is not very big (/14).

Relates to SPR1-706.