### PR TITLE
Bump kazoo and http-parser to the newest versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ flask-compress==1.4.0      # via dash
 future                     # via katdal
 h5py                       # via katdal, katsdpmodels
 hiredis
-http-parser==0.8.3         # via pymesos
+http-parser==0.9.0         # via pymesos
 idna                       # via requests
 idna-ssl                   # via aiohttp
 importlib-metadata         # via jsonschema
@@ -41,7 +41,7 @@ jsonschema
 jupyter-core==4.4.0        # via nbformat
 katportalclient
 katversion
-kazoo==2.4.0
+kazoo==2.8.0
 llvmlite                   # via numba
 markupsafe                 # via jinja2
 monotonic==1.5             # via prometheus_async


### PR DESCRIPTION
The old versions didn't play nice with Python 3.8.