### PR TITLE
Preparations for moving to Ubuntu 20.04 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG KATSDPDOCKERBASE_REGISTRY=quay.io/ska-sa
 
-FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-build:ubuntu20.04 as build
+FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-build as build
 
 # Switch to Python 3 environment
 ENV PATH="$PATH_PYTHON3" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON3"
@@ -18,7 +18,7 @@ RUN pip check
 
 #######################################################################
 
-FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-runtime:ubuntu20.04
+FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-runtime
 LABEL maintainer="sdpdev+katsdpcontroller@ska.ac.za"
 
 # Label the image with a list of images it uses

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,6 @@
 ARG KATSDPDOCKERBASE_REGISTRY=quay.io/ska-sa
 
-FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-build as build
-
-USER root
-RUN apt-get update && \
-    apt-get -y --no-install-recommends install liblua5.3-dev libssl-dev
-USER kat
-
-# We need to build haproxy from source because the version in Ubuntu 18.04 has
-# a bug that causes it to run out of file handles and the PPA at
-# https://launchpad.net/~vbernat/+archive/ubuntu/haproxy-1.8 deletes non-latest
-# versions.
-#
-# The make flags are based on debian/rules from the Ubuntu 18.04 package.
-RUN VERSION=1.8.22 && \
-    wget http://www.haproxy.org/download/1.8/src/haproxy-$VERSION.tar.gz -O /tmp/haproxy-$VERSION.tar.gz && \
-    tar -C /tmp -zxf /tmp/haproxy-$VERSION.tar.gz && \
-    cd /tmp/haproxy-$VERSION && \
-    make -j PREFIX=/usr \
-        USE_PCRE=1 PCREDIR= USE_PCRE_JIT=1 \
-        USE_OPENSSL=1 USE_ZLIB=1 USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
-        USE_GETADDRINFO=1 \
-        USE_NS=1 TARGET=linux2628 USE_REGPARM=1 DEBUG=-s && \
-    make install PREFIX=/usr DESTDIR=/tmp/haproxy-install
+FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-build:ubuntu20.04 as build
 
 # Switch to Python 3 environment
 ENV PATH="$PATH_PYTHON3" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON3"
@@ -40,7 +18,7 @@ RUN pip check
 
 #######################################################################
 
-FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-runtime
+FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-runtime:ubuntu20.04
 LABEL maintainer="sdpdev+katsdpcontroller@ska.ac.za"
 
 # Label the image with a list of images it uses
@@ -50,9 +28,8 @@ LABEL za.ac.kat.sdp.image-depends $dependencies
 
 # Install haproxy for --haproxy support and graphviz for --write-graphs
 USER root
-COPY --from=build /tmp/haproxy-install/usr/sbin/haproxy /usr/sbin/haproxy
 RUN apt-get update && \
-    apt-get -y --no-install-recommends install liblua5.3 graphviz && \
+    apt-get -y --no-install-recommends install haproxy graphviz && \
     rm -rf /var/lib/apt/lists/*
 USER kat
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ flask-compress==1.4.0      # via dash
 future                     # via katdal
 h5py                       # via katdal, katsdpmodels
 hiredis
-http-parser==0.8.3         # via pymesos
+http-parser==0.9.0         # via pymesos
 idna                       # via requests
 idna-ssl                   # via aiohttp
 importlib-metadata         # via jsonschema
@@ -41,7 +41,7 @@ jsonschema
 jupyter-core==4.4.0        # via nbformat
 katportalclient
 katversion
-kazoo==2.4.0
+kazoo==2.8.0
 llvmlite                   # via numba
 markupsafe                 # via jinja2
 monotonic==1.5             # via prometheus_async


### PR DESCRIPTION
- Install the distro's haproxy instead of building from source.
- Bump http-parser, kazoo to versions that works on Python 3.8.