### PR TITLE
Bump aioresponses to the latest version

### DIFF
--- a/katsdpcontroller/web.py
+++ b/katsdpcontroller/web.py
@@ -21,7 +21,7 @@ import os
 import weakref
 import functools
 import shutil
-from typing import Dict, List, Set, Tuple, Optional
+from typing import Dict, List, Set, Tuple, Optional, Any
 
 import pkg_resources
 from aiokatcp import Sensor, Reading
@@ -76,8 +76,8 @@ def _get_guis(server: master_controller.DeviceServer) -> dict:
 
 
 @aiohttp_jinja2.template('rotate_sd.html.j2')
-def _rotate_handler(request: web.Request) -> dict:
-    defaults = {'rotate_interval': 5000, 'width': 500, 'height': 500}
+async def _rotate_handler(request: web.Request) -> dict:
+    defaults: Dict[str, Any] = {'rotate_interval': 5000, 'width': 500, 'height': 500}
     defaults.update(request.query)
     return defaults
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 addict==2.1.1
 aioconsole                 # via aiomonitor
 aiohttp
-aiohttp-jinja2==1.1.0
+aiohttp-jinja2==1.4.2
 aiohttp-retry              # via katsdpmodels
 aiokatcp
 aiomonitor

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-aioresponses==0.6.4
+aioresponses==0.7.1
 asynctest==0.12.2
 coverage
 nose


### PR DESCRIPTION
The previously used version doesn't work on Python 3.8.