### PR TITLE
Some requirements cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH="$PATH_PYTHON3" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON3"
 
 # Install Python dependencies
 COPY requirements.txt /tmp/install/requirements.txt
-RUN install-requirements.py --default-versions ~/docker-base/base-requirements.txt -r /tmp/install/requirements.txt
+RUN install_pinned.py -r /tmp/install/requirements.txt
 
 # Install the current package
 COPY --chown=kat:kat . /tmp/install/katsdpcontroller

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "katversion"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ nbformat==4.4.0            # via plotly
 netifaces
 networkx==2.0
 numpy
-plotly==4.0.0              # via plotly
+plotly==4.0.0              # via dash
 prometheus_async==18.1.0
 prometheus_client==0.2.0
 pydotplus==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,12 @@
+-c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+
 addict==2.1.1
-aioconsole                 # via aiomonitor
 aiohttp
 aiohttp-jinja2==1.4.2
-aiohttp-retry              # via katsdpmodels
 aiokatcp
-aiomonitor
 aioredis
 aiozk==0.14.0
-astropy                    # via katsdpmodels
 async-timeout
-attrs                      # via aiohttp, prometheus_async
-certifi                    # via requests
-chardet                    # via aiohttp, requests
-cityhash                   # via katdal
 click==7.0                 # via Flask
 dash==1.0.2
 dash-core-components==1.0.0
@@ -20,72 +14,40 @@ dash-html-components==1.0.0
 dash-table==4.0.2
 dash-dangerously-set-inner-html==0.0.2
 dash-renderer==1.0.0       # via dash
-dask                       # via katdal
 decorator
 docker-pycreds==0.3.0      # via docker
 docker==3.4.1
-ephem                      # via pyephem
 flask==1.1.1               # via dash
 flask-compress==1.4.0      # via dash
-future                     # via katdal
-h5py                       # via katdal, katsdpmodels
-hiredis
+hiredis                    # speeds up katsdptelstate
 http-parser==0.9.0         # via pymesos
-idna                       # via requests
-idna-ssl                   # via aiohttp
-importlib-metadata         # via jsonschema
 ipython-genutils==0.2.0    # via nbformat
 itsdangerous==1.1.0        # via flask
-jinja2                     # via aiohttp-jinja2
+jinja2
 jsonschema
 jupyter-core==4.4.0        # via nbformat
 katportalclient
-katversion
 kazoo==2.8.0
-llvmlite                   # via numba
-markupsafe                 # via jinja2
 monotonic==1.5             # via prometheus_async
-msgpack                    # via katsdptelstate
-multidict                  # via aiohttp, yarl
 nbformat==4.4.0            # via plotly
-numba                      # via katdal
 netifaces
 networkx==2.0
 numpy
-omnijson                   # via katportalclient
 plotly==4.0.0              # via plotly
 prometheus_async==18.1.0
 prometheus_client==0.2.0
 pydotplus==2.0.2
-pyephem                    # via katpoint
-pygelf                     # via katsdpservices
-pyjwt                      # via katdal
-pyparsing                  # via pydotplus
-pyrsistent                 # via jsonschema
 pymesos==0.3.6
-pytz                       # via plotly
-pyyaml                     # via dash
-redis                      # via katsdptelstate
-requests                   # via docker
 retrying==1.3.3            # via plotly
 rfc3987==1.3.7
-six                        # via docker, plotly and others
-strict-rfc3339             # via katsdpmodels
-terminaltables             # via aiomonitor
-toolz                      # via katdal
-tornado                    # via katportalclient
 traitlets==4.3.2           # via nbformat
-typing-extensions          # via aiohttp, katsdpmodels
-ujson                      # via katportalclient
-urllib3                    # via requests
 websocket-client==0.45.0   # via docker
 werkzeug==0.15.5           # via flask
 wrapt==1.10.11             # via prometheus_async
-yarl                       # via aiohttp
-zipp                       # via importlib-metadata
+yarl
 
 katpoint @ git+https://github.com/ska-sa/katpoint
 katdal @ git+https://github.com/ska-sa/katdal
-katsdpmodels @ git+https://github.com/ska-sa/katsdpmodels
-katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate
-katsdpservices @ git+https://github.com/ska-sa/katsdpservices
+katsdpmodels[aiohttp] @ git+https://github.com/ska-sa/katsdpmodels
+katsdptelstate[aio] @ git+https://github.com/ska-sa/katsdptelstate
+katsdpservices[argparse,aiomonitor] @ git+https://github.com/ska-sa/katsdpservices

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
 from setuptools import setup, find_packages
 
-tests_require = ['nose', 'aioresponses>=0.6.4', 'asynctest', 'open-mock-file']
+tests_require = [
+    'aioresponses>=0.6.4',
+    'asynctest',
+    'nose',
+    'open-mock-file'
+]
 
 setup(
     name="katsdpcontroller",
@@ -18,37 +23,37 @@ setup(
         ],
     setup_requires=['katversion'],
     install_requires=[
-        'pymesos>=0.3.6',    # 0.3.6 implements reviveOffers with roles
         'addict!=2.0.*,!=2.4.0',
         'aiohttp~=3.5',
         'aiohttp-jinja2',
-        'aiomonitor',
-        'aioredis',
-        'async_timeout',
-        'decorator',
-        'docker',
-        'jinja2',
-        'jsonschema>=3.0',   # Version 3 implements Draft 7
-        'rfc3987',           # Used by jsonschema to validate URLs
-        'networkx>=2.0',
-        'pydotplus',
-        'netifaces',
         'aiokatcp>=0.6.1',
-        'katdal',
-        'katsdpmodels[aiohttp]',
-        'katsdptelstate[aio]',
-        'katsdpservices',
-        'katportalclient',
-        'kazoo',
+        'aioredis',
         'aiozk',
-        'yarl',
-        'prometheus_client<0.4.0',   # 0.4.0 forces _total suffix
-        'prometheus_async',
+        'async_timeout',
         'dash',
         'dash-core-components',
         'dash-html-components',
         'dash-table',
-        'dash-dangerously-set-inner-html'
+        'dash-dangerously-set-inner-html',
+        'decorator',
+        'docker',
+        'jinja2',
+        'jsonschema>=3.0',   # Version 3 implements Draft 7
+        'katdal',
+        'katsdpmodels[aiohttp]',
+        'katsdptelstate[aio]',
+        'katsdpservices[argparse,aiomonitor]',
+        'katportalclient',
+        'kazoo',
+        'netifaces',
+        'networkx>=2.0',
+        'numpy',
+        'prometheus_async',
+        'prometheus_client<0.4.0',   # 0.4.0 forces _total suffix
+        'pydotplus',
+        'pymesos>=0.3.6',    # 0.3.6 implements reviveOffers with roles
+        'rfc3987',           # Used by jsonschema to validate URLs
+        'yarl'
     ],
     tests_require=tests_require,
     extras_require={

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,7 @@
+-c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+
 aioresponses==0.7.1
-asynctest==0.12.2
+asynctest
 coverage
 nose
 open-mock-file==1.0.2


### PR DESCRIPTION
- Explicitly list numpy in setup.py (it's used directly)
- Add a pyproject.toml intead of listing katversion in requirements.txt
- Sort requirements in setup.py alphabetically
- List extras on git dependencies in requirements.txt
- Add -c option to requirements.txt to set defaults
- Remove recursive requirements that have default versions
- Unpin asynctest, since it is pinned in the base requirements

See SPR1-833.