### PR TITLE
SPR1-868 - Remove flickering update titlebar

### DIFF
--- a/scripts/sdp_product_controller.py
+++ b/scripts/sdp_product_controller.py
@@ -24,6 +24,7 @@ import aiokatcp
 import aiomonitor
 import katsdpservices
 from katsdptelstate.endpoint import endpoint_parser
+from katsdpcontroller.dashboard import Dashboard
 
 from katsdpcontroller import scheduler, schemas, product_controller, web_utils
 from katsdpcontroller.controller import (
@@ -48,8 +49,6 @@ async def run(sched, server):
 
 
 def init_dashboard(controller, opts, dashboard_path):
-    from katsdpcontroller.dashboard import Dashboard
-
     dashboard = Dashboard(controller, routes_pathname_prefix=dashboard_path, update_title=None)
     dashboard.start(opts.host, opts.dashboard_port)
 

--- a/scripts/sdp_product_controller.py
+++ b/scripts/sdp_product_controller.py
@@ -50,7 +50,7 @@ async def run(sched, server):
 def init_dashboard(controller, opts, dashboard_path):
     from katsdpcontroller.dashboard import Dashboard
 
-    dashboard = Dashboard(controller, routes_pathname_prefix=dashboard_path)
+    dashboard = Dashboard(controller, routes_pathname_prefix=dashboard_path, update_title=None)
     dashboard.start(opts.host, opts.dashboard_port)
 
 


### PR DESCRIPTION
Dash causes the title of the product controller page to brief change to Updating... once a second (on certain browsers). This behaviour has been changed.