### PR TITLE
bump dash >=1.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,12 +8,11 @@ aioredis
 aiozk==0.14.0
 async-timeout
 click==7.0                 # via Flask
-dash==1.0.2
-dash-core-components==1.0.0
-dash-html-components==1.0.0
-dash-table==4.0.2
-dash-dangerously-set-inner-html==0.0.2
-dash-renderer==1.0.0       # via dash
+dash==1.20.0
+dash_core_components==1.16.0
+dash_dangerously_set_inner_html==0.0.2
+dash_html_components==1.1.3
+dash_table==4.11.3
 decorator
 docker-pycreds==0.3.0      # via docker
 docker==3.4.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'aioredis',
         'aiozk',
         'async_timeout',
-        'dash',
+        'dash>=1.18.*',
         'dash-core-components',
         'dash-html-components',
         'dash-table',


### PR DESCRIPTION
Neglected to update requirements.txt to update version of dash (>=1.20.0) during https://skaafrica.atlassian.net/browse/SPR1-868