### PR TITLE
NGC-189: Add input_labels and command_line_extra options to schema

### DIFF
--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -315,12 +315,14 @@ class SimDigRawAntennaVoltageStream(Stream):
                  adc_sample_rate: float,
                  centre_frequency: float,
                  band: str,
-                 antenna: katpoint.Antenna) -> None:
+                 antenna: katpoint.Antenna,
+                 command_line_extra: Iterable[str] = ()) -> None:
         super().__init__(name, [])
         self.adc_sample_rate = adc_sample_rate
         self.centre_frequency = centre_frequency
         self.band = band
         self.antenna = antenna
+        self.command_line_extra = list(command_line_extra)
 
     @classmethod
     def from_config(cls,
@@ -333,7 +335,8 @@ class SimDigRawAntennaVoltageStream(Stream):
                    adc_sample_rate=config['adc_sample_rate'],
                    centre_frequency=config['centre_frequency'],
                    band=config['band'],
-                   antenna=_make_antenna(config['antenna']))
+                   antenna=_make_antenna(config['antenna']),
+                   command_line_extra=config.get('command_line_extra', []))
 
 
 class AntennaChannelisedVoltageStreamBase(Stream):
@@ -423,12 +426,25 @@ class NgcAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase):
     stream_type: ClassVar[str] = 'ngc.antenna_channelised_voltage'
     _valid_src_types: ClassVar[_ValidTypes] = {'sim.dig.raw_antenna_voltage'}
 
-    def __init__(self, name: str, src_streams: Sequence[Stream], *,
-                 n_chans: int) -> None:
+    def __init__(
+            self,
+            name: str,
+            src_streams: Sequence[Stream], *,
+            n_chans: int,
+            input_labels: Optional[Iterable[str]] = None,
+            command_line_extra: Iterable[str] = ()) -> None:
         if n_chans < 1 or (n_chans & (n_chans - 1)) != 0:
             raise ValueError('n_chans is not a power of 2')
         if len(src_streams) % 2 != 0:
             raise ValueError('src_streams does not have an even number of elements')
+        self.input_labels = (
+            [stream.name for stream in src_streams]
+            if input_labels is None else list(input_labels)
+        )
+        if len(self.input_labels) != len(src_streams):
+            raise ValueError('input_labels has the wrong number of elements')
+        if len(set(self.input_labels)) != len(src_streams):
+            raise ValueError('input labels are not unique')
         first = src_streams[0]
         assert isinstance(first, SimDigRawAntennaVoltageStream)
         antenna_names = []
@@ -456,6 +472,7 @@ class NgcAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase):
             centre_frequency=first.centre_frequency,
             n_samples_between_spectra=2 * n_chans
         )
+        self.command_line_extra = list(command_line_extra)
 
     @classmethod
     def from_config(cls,
@@ -466,7 +483,9 @@ class NgcAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase):
                     sensors: Mapping[str, Any]) -> 'NgcAntennaChannelisedVoltageStream':
         return cls(
             name, src_streams,
-            n_chans=config['n_chans']
+            n_chans=config['n_chans'],
+            input_labels=config.get('input_labels'),
+            command_line_extra=config.get('command_line_extra', [])
         )
 
 
@@ -704,8 +723,10 @@ class NgcBaselineCorrelationProductsStream(BaselineCorrelationProductsStreamBase
     stream_type: ClassVar[str] = 'ngc.baseline_correlation_products'
     _valid_src_types: ClassVar[_ValidTypes] = {'ngc.antenna_channelised_voltage'}
 
-    def __init__(self, name: str, src_streams: Sequence[Stream], *,
-                 int_time: float) -> None:
+    def __init__(self, name: str,
+                 src_streams: Sequence[Stream], *,
+                 int_time: float,
+                 command_line_extra: Iterable[str] = ()) -> None:
         acv = src_streams[0]
         assert isinstance(acv, AntennaChannelisedVoltageStreamBase)
         n_ants = len(acv.antennas)
@@ -722,6 +743,7 @@ class NgcBaselineCorrelationProductsStream(BaselineCorrelationProductsStreamBase
             n_baselines=n_ants * (n_ants + 1) * 2,
             bits_per_sample=32
         )
+        self.command_line_extra = list(command_line_extra)
 
     if TYPE_CHECKING:     # pragma: nocover
         # Refine the return type for mypy
@@ -737,7 +759,8 @@ class NgcBaselineCorrelationProductsStream(BaselineCorrelationProductsStreamBase
                     sensors: Mapping[str, Any]) -> 'NgcBaselineCorrelationProductsStream':
         return cls(
             name, src_streams,
-            int_time=config['int_time']
+            int_time=config['int_time'],
+            command_line_extra=config.get('command_line_extra', [])
         )
 
 

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -442,7 +442,9 @@ class NgcAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase):
             if input_labels is None else list(input_labels)
         )
         if len(self.input_labels) != len(src_streams):
-            raise ValueError('input_labels has the wrong number of elements')
+            raise ValueError(
+                f'input_labels has {len(self.input_labels)} elements, expected {len(src_streams)}'
+            )
         if len(set(self.input_labels)) != len(src_streams):
             raise ValueError('input labels are not unique')
         first = src_streams[0]

--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -527,7 +527,11 @@
                                     "adc_sample_rate": {"$ref": "#/definitions/positive_number"},
                                     "centre_frequency": {"$ref": "#/definitions/positive_number"},
                                     "band": {"type": "string"},
-                                    "antenna": {"type": "string"}
+                                    "antenna": {"type": "string"},
+                                    "command_line_extra": {
+                                        "type": "array",
+                                        "items": {"type": "string"}
+                                    }
                                 },
                                 "additionalProperties": false,
                                 "required": ["adc_sample_rate", "centre_frequency", "band", "antenna"]
@@ -539,10 +543,26 @@
                                 "properties": {
                                     "type": {},
                                     "src_streams": {"minItems": 2},
-                                    "n_chans": {"$ref": "#/definitions/positive_integer"}
+                                    "n_chans": {"$ref": "#/definitions/positive_integer"},
+                                    "input_labels": {
+                                        "type": "array",
+                                        "items": {"$ref": "#/definitions/stream_name"},
+                                        "uniqueItems": true
+                                    },
+                                    "command_line_extra": {
+                                        "type": "array",
+                                        "items": {"type": "string"}
+                                    }
                                 },
                                 "additionalProperties": false,
-                                "required": ["src_streams", "n_chans"]
+                                "required": ["src_streams", "n_chans"],
+{# If input_labels is absent, src_streams must contain unique elements #}
+                                "if": {"not": {"required": ["input_labels"]}},
+                                "then": {
+                                    "properties": {
+                                        "src_streams": {"uniqueItems": true}
+                                    }
+                                }
                             }
                         },
                         {
@@ -551,7 +571,11 @@
                                 "properties": {
                                     "type": {},
                                     "src_streams": {"$ref": "#/definitions/singleton"},
-                                    "int_time": {"$ref": "#/definitions/positive_number"}
+                                    "int_time": {"$ref": "#/definitions/positive_number"},
+                                    "command_line_extra": {
+                                        "type": "array",
+                                        "items": {"type": "string"}
+                                    }
                                 },
                                 "additionalProperties": false,
                                 "required": ["src_streams", "int_time"]

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -405,7 +405,7 @@ class TestNgcAntennaChanneliseVoltageStream:
 
     def test_bad_input_labels(self) -> None:
         self.config['input_labels'] = ['m900h']
-        with assert_raises_regex(ValueError, 'input_labels has the wrong number of elements'):
+        with assert_raises_regex(ValueError, 'input_labels has 1 elements, expected 4'):
             NgcAntennaChannelisedVoltageStream.from_config(
                 Options(), 'wide1_acv', self.config, self.src_streams, {}
             )

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -265,6 +265,7 @@ class TestSimDigRawAntennaVoltageStream:
         assert_equal(dig.centre_frequency, self.config['centre_frequency'])
         assert_equal(dig.band, self.config['band'])
         assert_equal(dig.antenna, _M000)
+        assert_equal(dig.command_line_extra, [])
 
     def test_bad_antenna_description(self) -> None:
         with assert_raises_regex(ValueError, "Invalid antenna description 'bad antenna': "):
@@ -272,6 +273,13 @@ class TestSimDigRawAntennaVoltageStream:
             SimDigRawAntennaVoltageStream.from_config(
                 Options(), 'm000h', self.config, [], {}
             )
+
+    def test_command_line_extra(self) -> None:
+        self.config['command_line_extra'] = ['--extra-arg']
+        dig = SimDigRawAntennaVoltageStream.from_config(
+            Options(), 'm000h', self.config, [], {}
+        )
+        assert_equal(dig.command_line_extra, self.config['command_line_extra'])
 
 
 class TestAntennaChannelisedVoltageStream:
@@ -344,6 +352,8 @@ class TestNgcAntennaChanneliseVoltageStream:
         assert_equal(acv.centre_frequency, self.src_streams[0].centre_frequency)
         assert_equal(acv.adc_sample_rate, self.src_streams[0].adc_sample_rate)
         assert_equal(acv.n_samples_between_spectra, 2 * self.config['n_chans'])
+        assert_equal(acv.input_labels, self.config['src_streams'])
+        assert_equal(acv.command_line_extra, [])
 
     def test_n_chans_not_power_of_two(self) -> None:
         for n_chans in [0, 3, 17]:
@@ -385,6 +395,32 @@ class TestNgcAntennaChanneliseVoltageStream:
             NgcAntennaChannelisedVoltageStream.from_config(
                 Options(), 'wide1_acv', self.config, self.src_streams, {}
             )
+
+    def test_input_labels(self) -> None:
+        self.config['input_labels'] = ['m900h', 'm900v', 'm901h', 'm901v']
+        acv = NgcAntennaChannelisedVoltageStream.from_config(
+            Options(), 'wide1_acv', self.config, self.src_streams, {}
+        )
+        assert_equal(acv.input_labels, self.config['input_labels'])
+
+    def test_bad_input_labels(self) -> None:
+        self.config['input_labels'] = ['m900h']
+        with assert_raises_regex(ValueError, 'input_labels has the wrong number of elements'):
+            NgcAntennaChannelisedVoltageStream.from_config(
+                Options(), 'wide1_acv', self.config, self.src_streams, {}
+            )
+        self.config['input_labels'] = ['m900h'] * 4
+        with assert_raises_regex(ValueError, 'are not unique'):
+            NgcAntennaChannelisedVoltageStream.from_config(
+                Options(), 'wide1_acv', self.config, self.src_streams, {}
+            )
+
+    def test_command_line_extra(self) -> None:
+        self.config['command_line_extra'] = ['--extra-arg']
+        acv = NgcAntennaChannelisedVoltageStream.from_config(
+            Options(), 'wide1_acv', self.config, self.src_streams, {}
+        )
+        assert_equal(acv.command_line_extra, self.config['command_line_extra'])
 
 
 class TestSimAntennaChannelisedVoltageStream:
@@ -556,6 +592,7 @@ class TestNgcBaselineCorrelationProductsStream:
         assert_equal(bcp.n_chans_per_substream, 512)
         assert_equal(bcp.n_substreams, 8)
         assert_equal(bcp.int_time, 104448 * 4096 / 856e6)
+        assert_equal(bcp.command_line_extra, [])
 
     def test_too_few_channels(self) -> None:
         with assert_raises(ValueError):
@@ -563,6 +600,13 @@ class TestNgcBaselineCorrelationProductsStream:
             NgcBaselineCorrelationProductsStream.from_config(
                 Options(), 'wide2_bcp', self.config, [self.acv], {}
             )
+
+    def test_command_line_extra(self) -> None:
+        self.config['command_line_extra'] = ['--extra-arg']
+        bcp = NgcBaselineCorrelationProductsStream.from_config(
+            Options(), 'wide2_bcp', self.config, [self.acv], {}
+        )
+        assert_equal(bcp.command_line_extra, self.config['command_line_extra'])
 
 
 class TestSimBaselineCorrelationProductsStream:


### PR DESCRIPTION
The former is to support assigning unique labels to digitiser outputs
even when repeating digitisers to make up extra antennas. The latter is
an escape hatch to allow for passing extra arguments directly to
processes without rebuilding the container.