### PR TITLE
Depend on pydot, not pydotplus

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ numpy
 plotly==4.0.0              # via dash
 prometheus_async==18.1.0
 prometheus_client==0.2.0
-pydotplus==2.0.2
+pydot==1.4.2
 pymesos==0.3.6
 retrying==1.3.3            # via plotly
 rfc3987==1.3.7

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'numpy',
         'prometheus_async',
         'prometheus_client<0.4.0',   # 0.4.0 forces _total suffix
-        'pydotplus',
+        'pydot',             # For networkx.drawing.nx_pydot
         'pymesos>=0.3.6',    # 0.3.6 implements reviveOffers with roles
         'rfc3987',           # Used by jsonschema to validate URLs
         'yarl'


### PR DESCRIPTION
At one point networkx used pydotplus for writing graphs to dot format,
but that no longer seems to be the case, and it needs pydot for the
`--write-graphs` command-line option to work.