### PR TITLE
Switch to katgpucbf image

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -64,7 +64,7 @@ CAPTURE_TRANSITIONS = {
 #: Docker images that may appear in the logical graph (used set to Docker image metadata)
 IMAGES = frozenset([
     'katcbfsim',
-    'katfgpu',
+    'katgpucbf',
     'katsdpbfingest',
     'katsdpcal',
     'katsdpcam2telstate',
@@ -74,8 +74,7 @@ IMAGES = frozenset([
     'katsdpingest_' + normalise_gpu_name(defaults.INGEST_GPU_NAME),
     'katsdpdatawriter',
     'katsdpmetawriter',
-    'katsdptelstate',
-    'katxgpu'
+    'katsdptelstate'
 ])
 #: Number of bytes used by spectral imager per visibility
 BYTES_PER_VFW_SPECTRAL = 14.5       # 58 bytes for 4 polarisation products
@@ -277,7 +276,7 @@ def _make_dsim(
     # (antenna.name, adc_sample_rate), so that is guaranteed to be unique.
     name = f'sim.{streams[0].antenna.name}.{streams[0].adc_sample_rate}'
     dsim = SDPLogicalTask(name)
-    dsim.image = 'katfgpu'
+    dsim.image = 'katgpucbf'
     dsim.cpus = 1   # TODO: scale it according to bandwidth.
     dsim.mem = 128  # TODO: this is a guess. Check what it actually needs.
     dsim.cores = [None]  # Pin to a single core (TODO: maybe don't in develop mode)
@@ -285,7 +284,6 @@ def _make_dsim(
     dsim.interfaces = [scheduler.InterfaceRequest('cbf', infiniband=True)]
     dsim.interfaces[0].bandwidth_out = sum(stream.data_rate() for stream in streams)
     dsim.command = [
-        'capambel', '-c', 'cap_net_raw+p', '--',  # Gives NET_RAW capability to invoked command
         'dsim',
         '--interface', '{interfaces[cbf].ipv4_address}',
         '--adc-rate', str(streams[0].adc_sample_rate),
@@ -324,10 +322,11 @@ def _make_fgpu(
     for i in range(0, n_engines):
         srcs = stream.sources(i)
         fgpu = SDPLogicalTask(f'f.{stream.name}.{i}')
-        fgpu.image = 'katfgpu'
+        fgpu.image = 'katgpucbf'
         fgpu.cpus = 3
         fgpu.mem = 4096  # TODO: this is a guess. Check what it actually needs.
         fgpu.cores = ['src0', 'src1', 'dst']
+        fgpu.ports = ['port']
         # TODO: could specify separate interface requests for input and
         # output. Currently that's not possible because interfaces are looked
         # up by network name.
@@ -344,15 +343,15 @@ def _make_fgpu(
             '--src-affinity', '{cores[src0]},{cores[src1]}',
             '--dst-interface', '{interfaces[cbf].name}',
             '--dst-affinity', '{cores[dst]}',
-            # TODO: reenable once katxgpu can handle it
+            # TODO: reenable once katgpucbf.xbgpu can handle it
             # '--dst-packet-payload', '8192',
             '--adc-rate', str(srcs[0].adc_sample_rate),
             '--feng-id', str(i),
-            '--channels', str(stream.n_chans)
+            '--channels', str(stream.n_chans),
+            '--katcp-port', '{ports[port]}'
         ]
         if ibv:
             # Enable cap_net_raw capability for access to raw QPs
-            fgpu.command = ['capambel', '-c', 'cap_net_raw+p', '--'] + fgpu.command
             fgpu.capabilities.append('NET_RAW')
             # Use the core numbers as completion vectors. This ensures that
             # multiple instances on a machine will use distinct vectors.
@@ -383,47 +382,47 @@ def _make_fgpu(
     return fgpu_group
 
 
-def _make_xgpu(
+def _make_xbgpu(
         g: networkx.MultiDiGraph,
         configuration: Configuration,
         stream: product_config.GpucbfBaselineCorrelationProductsStream) -> scheduler.LogicalNode:
     ibv = not configuration.options.develop
     acv = stream.antenna_channelised_voltage
     n_engines = stream.n_substreams
-    xgpu_group = LogicalGroup(f'xgpu.{stream.name}')
-    g.add_node(xgpu_group)
+    xbgpu_group = LogicalGroup(f'xbgpu.{stream.name}')
+    g.add_node(xbgpu_group)
 
     dst_multicast = LogicalMulticast(f'multicast.{stream.name}', stream.n_substreams)
     g.add_node(dst_multicast)
-    g.add_edge(dst_multicast, xgpu_group, depends_init=True, depends_ready=True)
+    g.add_edge(dst_multicast, xbgpu_group, depends_init=True, depends_ready=True)
 
     for i in range(0, stream.n_substreams):
-        xgpu = SDPLogicalTask(f'x.{stream.name}.{i}')
-        xgpu.image = 'katxgpu'
-        xgpu.cpus = 1    # TODO: could be less in develop mode?
-        xgpu.mem = 4096  # TODO: this is a guess. Check what it actually needs.
-        xgpu.cores = ['core']
-        xgpu.interfaces = [scheduler.InterfaceRequest('cbf', infiniband=ibv)]
-        xgpu.interfaces[0].bandwidth_in = acv.data_rate() / n_engines
-        xgpu.interfaces[0].bandwidth_out = stream.data_rate() / n_engines
-        xgpu.gpus = [scheduler.GPURequest()]
-        xgpu.gpus[0].compute = 0.125  # TODO: scale according to problem size
-        xgpu.gpus[0].mem = 1024       # TODO: check what it really needs
+        xbgpu = SDPLogicalTask(f'xb.{stream.name}.{i}')
+        xbgpu.image = 'katgpucbf'
+        xbgpu.cpus = 1    # TODO: could be less in develop mode?
+        xbgpu.mem = 4096  # TODO: this is a guess. Check what it actually needs.
+        xbgpu.cores = ['core']
+        xbgpu.interfaces = [scheduler.InterfaceRequest('cbf', infiniband=ibv)]
+        xbgpu.interfaces[0].bandwidth_in = acv.data_rate() / n_engines
+        xbgpu.interfaces[0].bandwidth_out = stream.data_rate() / n_engines
+        xbgpu.gpus = [scheduler.GPURequest()]
+        xbgpu.gpus[0].compute = 0.125  # TODO: scale according to problem size
+        xbgpu.gpus[0].mem = 1024       # TODO: check what it really needs
         # Minimum capability as a function of bits-per-sample, based on
-        # tensor_core_correlation_kernel.mako from katxgpu.
+        # tensor_core_correlation_kernel.mako from katxbgpu.
         min_compute_capability = {
             4: (7, 3),
             8: (7, 2),
             16: (7, 0)
         }
-        xgpu.gpus[0].min_compute_capability = min_compute_capability[acv.bits_per_sample]
+        xbgpu.gpus[0].min_compute_capability = min_compute_capability[acv.bits_per_sample]
         first_dig = acv.sources(0)[0]
         # TODO: It's not necessary to set core affinity by command-line option
         # because there is only one core reserved and the scheduler will bind
         # it, but they're currently required arguments.
         heap_time = acv.n_samples_between_spectra / acv.adc_sample_rate * acv.n_spectra_per_heap
-        xgpu.command = [
-            'xgpu',
+        xbgpu.command = [
+            'xbgpu',
             '--adc-sample-rate', str(first_dig.adc_sample_rate),
             '--array-size', str(len(acv.src_streams) // 2),  # 2 pols per antenna
             '--channels-total', str(stream.n_chans),
@@ -440,25 +439,25 @@ def _make_xgpu(
         ]
         if ibv:
             # Enable cap_net_raw capability for access to raw QPs
-            xgpu.capabilities.append('NET_RAW')
+            xbgpu.capabilities.append('NET_RAW')
             # Use the core number as completion vector. This ensures that
             # multiple instances on a machine will use distinct vectors.
-            xgpu.command += [
+            xbgpu.command += [
                 '--receiver-comp-vector-affinity', '{cores[core]}'
             ]
-        xgpu.command += stream.command_line_extra
-        # xgpu doesn't use katsdpservices or telstate
-        xgpu.katsdpservices_logging = False
-        xgpu.katsdpservices_config = False
-        xgpu.pass_telstate = False
-        g.add_node(xgpu)
+        xbgpu.command += stream.command_line_extra
+        # xbgpu doesn't use katsdpservices or telstate
+        xbgpu.katsdpservices_logging = False
+        xbgpu.katsdpservices_config = False
+        xbgpu.pass_telstate = False
+        g.add_node(xbgpu)
 
         # Wire it up to the multicast streams
         src_multicast = find_node(g, f'multicast.{acv.name}')
-        g.add_edge(xgpu, src_multicast, port='spead',
+        g.add_edge(xbgpu, src_multicast, port='spead',
                    depends_resolve=True, depends_init=True, depends_ready=True)
-        g.add_edge(xgpu, dst_multicast, port='spead', depends_resolve=True)
-        xgpu.command += [
+        g.add_edge(xbgpu, dst_multicast, port='spead', depends_resolve=True)
+        xbgpu.command += [
             f'{{endpoints_vector[multicast.{acv.name}_spead][{i}].host}}',
             f'{{endpoints_vector[multicast.{acv.name}_spead][{i}].port}}',
             f'{{endpoints_vector[multicast.{stream.name}_spead][{i}].host}}',
@@ -466,9 +465,9 @@ def _make_xgpu(
         ]
 
         # Link it to the group, so that downstream tasks need only depend on the group.
-        g.add_edge(xgpu_group, xgpu, depends_ready=True, depends_init=True)
+        g.add_edge(xbgpu_group, xbgpu, depends_ready=True, depends_init=True)
 
-    return xgpu_group
+    return xbgpu_group
 
 
 def _make_cbf_simulator(g: networkx.MultiDiGraph,
@@ -1512,7 +1511,7 @@ def build_logical_graph(configuration: Configuration,
     for stream in configuration.by_class(product_config.GpucbfAntennaChannelisedVoltageStream):
         _make_fgpu(g, configuration, stream)
     for stream in configuration.by_class(product_config.GpucbfBaselineCorrelationProductsStream):
-        _make_xgpu(g, configuration, stream)
+        _make_xbgpu(g, configuration, stream)
 
     # Pair up spectral and continuum L0 outputs
     l0_done = set()

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -409,7 +409,7 @@ def _make_xbgpu(
         xbgpu.gpus[0].compute = 0.125  # TODO: scale according to problem size
         xbgpu.gpus[0].mem = 1024       # TODO: check what it really needs
         # Minimum capability as a function of bits-per-sample, based on
-        # tensor_core_correlation_kernel.mako from katxbgpu.
+        # tensor_core_correlation_kernel.mako from katgpucbf.xbgpu.
         min_compute_capability = {
             4: (7, 3),
             8: (7, 2),


### PR DESCRIPTION
- Rename xgpu to xbgpu everywhere
- No longer need to use capambel for fgpu, since it runs as root inside
  the container.
- Pass katcp port for fgpu.

Closes NGC-263.