### PR TITLE
Copy old aiokatcp.test.test_utils.timelimit into repo

### DIFF
--- a/katsdpcontroller/test/test_product_controller.py
+++ b/katsdpcontroller/test/test_product_controller.py
@@ -23,7 +23,6 @@ import numpy as np
 from addict import Dict
 import aiokatcp
 from aiokatcp import Message, FailReply, Sensor
-from aiokatcp.test.test_utils import timelimit
 from prometheus_client import CollectorRegistry
 import pymesos
 import networkx
@@ -44,7 +43,7 @@ from ..product_controller import (
     CONSUL_URL)
 from .. import scheduler
 from . import fake_katportalclient
-from .utils import (create_patch, assert_request_fails, assert_sensors, DelayedManager,
+from .utils import (create_patch, assert_request_fails, assert_sensors, timelimit, DelayedManager,
                     CONFIG, S3_CONFIG, EXPECTED_INTERFACE_SENSOR_LIST,
                     EXPECTED_PRODUCT_CONTROLLER_SENSOR_LIST)
 

--- a/katsdpcontroller/test/test_sensor_proxy.py
+++ b/katsdpcontroller/test/test_sensor_proxy.py
@@ -17,13 +17,13 @@ from typing import Dict, Mapping, Any, Optional
 
 import aiokatcp
 from aiokatcp import Sensor, SensorSet, Address
-from aiokatcp.test.test_utils import timelimit
 from prometheus_client import Gauge, Counter, Histogram, CollectorRegistry
 
 import asynctest
 
 from ..sensor_proxy import SensorProxyClient, PrometheusInfo, PrometheusWatcher
 from ..controller import device_server_sockname
+from .utils import timelimit
 
 
 class MyEnum(enum.Enum):

--- a/katsdpcontroller/test/utils.py
+++ b/katsdpcontroller/test/utils.py
@@ -1,6 +1,9 @@
 """Utilities for unit tests"""
 
 import asyncio
+import functools
+import inspect
+import sys
 import unittest
 from unittest import mock
 from typing import (List, Tuple, Iterable, Coroutine, Awaitable, Optional,
@@ -9,6 +12,7 @@ from types import TracebackType
 
 import aiokatcp
 import asynctest
+import async_timeout
 from nose.tools import assert_raises, assert_equal, assert_true
 
 
@@ -369,3 +373,39 @@ def future_return(mock: mock.Mock) -> asyncio.Future:
     future = asyncio.Future()         # type: asyncio.Future[Any]
     mock.side_effect = replacement
     return future
+
+
+def timelimit(limit=5.0):
+    """Decorator to run tests with a time limit. It is designed to be used
+    with :class:`asynctest.TestCase`. It can be used as either a method or
+    a class decorator. It can be used as either ``@timelimit(limit)`` or
+    just ``@timelimit`` to use the default of 5 seconds.
+    """
+    if inspect.isfunction(limit) or inspect.isclass(limit):
+        # Used without parameters
+        return timelimit()(limit)
+
+    def decorator(arg):
+        if inspect.isclass(arg):
+            for key, value in arg.__dict__.items():
+                if (inspect.iscoroutinefunction(value) and key.startswith('test_')
+                        and not hasattr(arg, '_timelimit')):
+                    setattr(arg, key, decorator(value))
+            return arg
+        else:
+            @functools.wraps(arg)
+            async def wrapper(self, *args, **kwargs):
+                try:
+                    async with async_timeout.timeout(limit, loop=self.loop) as cm:
+                        await arg(self, *args, **kwargs)
+                except asyncio.TimeoutError:
+                    if not cm.expired:
+                        raise
+                    for task in asyncio.Task.all_tasks(loop=self.loop):
+                        if task.get_stack(limit=1):
+                            print()
+                            task.print_stack(file=sys.stdout)
+                    raise asyncio.TimeoutError('Test did not complete within {}s'.format(limit))
+            wrapper._timelimit = limit
+            return wrapper
+    return decorator


### PR DESCRIPTION
In aiokatcp 1.0, the aiokatcp.test.test_utils module was removed
(because aiokatcp switched to pytest). We relied on the `timelimit`
decorator, so copy-and-paste it into katsdpcontroller.

Closes SPR1-1317.