### PR TITLE
Support image_overrides in product-config schema

### DIFF
--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -208,10 +208,12 @@ class Options:
     def __init__(self, *, develop: bool = False,
                  wrapper: Optional[str] = None,
                  image_tag: Optional[str] = None,
+                 image_overrides: Mapping[str, str] = {},
                  service_overrides: Mapping[str, ServiceOverride] = {}) -> None:
         self.develop = develop
         self.wrapper = wrapper
         self.image_tag = image_tag
+        self.image_overrides = dict(image_overrides)
         self.service_overrides = dict(service_overrides)
 
     @classmethod
@@ -224,6 +226,7 @@ class Options:
             develop=config.get('develop', False),
             wrapper=config.get('wrapper'),
             image_tag=config.get('image_tag'),
+            image_overrides=config.get('image_overrides', {}),
             service_overrides=service_overrides
         )
 

--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -1491,8 +1491,11 @@ class DeviceServer(aiokatcp.DeviceServer):
             resolver_factory_args = dict(tag=image_tag)
         else:
             resolver_factory_args = {}
+        image_resolver = self.image_resolver_factory(**resolver_factory_args)
+        for image_name, image_path in configuration.options.image_overrides.items():
+            image_resolver.override(image_name, image_path)
         resolver = Resolver(
-            self.image_resolver_factory(**resolver_factory_args),
+            image_resolver,
             scheduler.TaskIDAllocator(name + '-'),
             self.sched.http_url if self.sched else '',
             configuration.options.service_overrides,

--- a/katsdpcontroller/schemas/product_config.json.j2
+++ b/katsdpcontroller/schemas/product_config.json.j2
@@ -592,6 +592,12 @@
                 "develop": {"type": "boolean", "default": false},
                 "wrapper": {"type": "string", "format": "uri"},
                 "image_tag": {"type": "string" },
+{% if version >= "3.1" %}
+                "image_overrides": {
+                    "type": "object",
+                    "additionalProperties": {"type": "string"}
+                },
+{% endif %}
                 "service_overrides": {
                     "type": "object",
                     "additionalProperties": {


### PR DESCRIPTION
This provides an equivalent to the `--image-override` command-line
option, but on a per-product basis.

Closes NGC-273.