### PR TITLE
Update ADC rate command-line argument

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -296,7 +296,7 @@ def _make_dsim(
     dsim.command = [
         'dsim',
         '--interface', '{interfaces[cbf].ipv4_address}',
-        '--adc-rate', str(streams[0].adc_sample_rate),
+        '--adc-sample-rate', str(streams[0].adc_sample_rate),
         '--ttl', '4',
         '--sync-time', str(sync_time)
     ]
@@ -361,7 +361,7 @@ def _make_fgpu(
             '--dst-affinity', '{cores[dst]}',
             # TODO: reenable once katgpucbf.xbgpu can handle it
             # '--dst-packet-payload', '8192',
-            '--adc-rate', str(srcs[0].adc_sample_rate),
+            '--adc-sample-rate', str(srcs[0].adc_sample_rate),
             '--feng-id', str(i),
             '--array-size', str(n_engines),
             '--channels', str(stream.n_chans),


### PR DESCRIPTION
This is done to match the update to katgpucbf, baselining the variable
as adc-sample-rate (rather than adc-rate).

Contributes to: NGC-269.