### PR TITLE
Improve user experience with image overrides

### DIFF
--- a/katsdpcontroller/master_controller.py
+++ b/katsdpcontroller/master_controller.py
@@ -856,6 +856,8 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
         # and throw away the cache immediately after this function.
         try:
             image_resolver = self._image_resolver_factory(**image_resolver_kwargs)
+            for image_name, image in config.get('config', {}).get('image_overrides', {}).items():
+                image_resolver.override(image_name, image)
         except Exception as exc:
             raise ProductFailed(f'Could not load image tag file: {exc}')
         port = device_server_sockname(self._server)[1]

--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -3528,6 +3528,7 @@ __all__ = [
     'GroupInsufficientGPUResourcesError',
     'GroupInsufficientInterfaceResourcesError',
     'InterfaceRequest', 'GPURequest',
+    'ImageLookup', 'SimpleImageLookup', 'HTTPImageLookup',
     'ImageResolver', 'TaskIDAllocator', 'Resolver',
     'Agent', 'AgentGPU', 'AgentInterface',
     'Scheduler', 'instantiate']

--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -169,7 +169,7 @@ import decimal
 from decimal import Decimal
 import time
 import io
-from abc import abstractmethod
+from abc import abstractmethod, ABC
 import random
 import typing
 # Note: don't include Dict here, because it conflicts with addict.Dict.
@@ -882,7 +882,7 @@ def _strip_scheme(image: str) -> str:
     return re.sub(r'^https?://', '', image)
 
 
-class ImageLookup:
+class ImageLookup(ABC):
     """Abstract base class to get a full image name from a repo and tag."""
     @abstractmethod
     async def __call__(self, repo: str, tag: str) -> str: pass

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -198,7 +198,7 @@ In an edit-debug cycle, it's not always convenient to rebuild the container
 and the subarray on every edit. If the service uses `setup_restart` from
 [katsdpservices](https://github.com/ska-sa/katsdpservices), then you can send
 the process SIGHUP to have it restart itself. Use `docker exec` to enter the
-container and modify the code in `/home/kat/ve3/lib/python3.6/site-packages`,
+container and modify the code in `/home/kat/ve3/lib/python3.8/site-packages`,
 use `ps` to find the PID, and then `kill -HUP <PID>`.
 
 Note that `docker restart` is *not* your friend any more: Mesos thinks the
@@ -215,5 +215,5 @@ local copy of the image if it exists. Note that this can easily lead to using
 very old copies of images.
 
 For overriding individual images, one can use `--image-override NAME:IMAGE` to
-specify the specific image to use for NAME. This will not be force-pulled, so a
-locally-built image will be used.
+specify the specific image to use for NAME. The IMAGE can specify an
+alternative registry, or can omit it to the default one.


### PR DESCRIPTION
This has three parts:
1. Put image overrides through the lookup machinery
2. Allow config image_overrides to override the product controller
3. Some small code cleanups.

See the individual commits for more details.

Closes SPR1-1466.