### PR TITLE
Remove --pols argument from call to xbgpu

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -564,7 +564,6 @@ def _make_xbgpu(
             '--channels-per-substream', str(stream.n_chans_per_substream),
             '--spectra-per-heap', str(acv.n_spectra_per_heap),
             '--channel-offset-value', str(i * stream.n_chans_per_substream),
-            '--pols', '2',
             '--sample-bits', str(acv.bits_per_sample),
             '--src-interface', '{interfaces[cbf].name}',
             '--dst-interface', '{interfaces[cbf].name}',


### PR DESCRIPTION
Going to be needed since https://github.com/ska-sa/katgpucbf/pull/81 removes the argument entirely.