### PR TITLE
Support token authentication with a registry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ traitlets==4.3.2           # via nbformat
 websocket-client==0.45.0   # via docker
 werkzeug==0.15.5           # via flask
 wrapt==1.10.11             # via prometheus_async
+www-authenticate==0.9.2
 yarl
 
 katpoint @ git+https://github.com/ska-sa/katpoint

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(
         'pydot',             # For networkx.drawing.nx_pydot
         'pymesos>=0.3.6',    # 0.3.6 implements reviveOffers with roles
         'rfc3987',           # Used by jsonschema to validate URLs
-        'yarl'
+        'yarl',
+        'www-authenticate'
     ],
     tests_require=tests_require,
     extras_require={


### PR DESCRIPTION
This will allow katsdpcontroller to work with harbor as the registry (or
any registry implementing
https://docs.docker.com/registry/spec/auth/token/). When an HTTP 401
response is receive with a suitable WWW-Authenticate, send another
request to that token server to get a token and then retry the original
request with that token.

This also contains a bug fix: if an explicit registry is provided for a
request, look up the appropriate username and password for that
registry, rather than using the credentials for the default registry.

The unit test has also been significantly beefed up, to test a number of
failure cases, and to actually check that credentials are being looked
up and passed correctly (which also required fixing the test to store
them in the right format).

Closes NGC-389.