### PR TITLE
Fix calculation of data_rate for GpucbfAntennaChannelisedVoltageStream

### DIFF
--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -577,7 +577,8 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
         time_between_spectra = (
             self.n_samples_between_spectra * self.n_spectra_per_heap / self.adc_sample_rate
         )
-        return data_rate(heap_size, time_between_spectra, ratio, overhead) * self.n_substreams
+        ant_rate = data_rate(heap_size, time_between_spectra, ratio, overhead) * self.n_substreams
+        return ant_rate * (len(self.src_streams) // 2)
 
     @classmethod
     def from_config(cls,

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -406,7 +406,7 @@ class TestGpucbfAntennaChanneliseVoltageStream:
         assert_equal(acv.n_samples_between_spectra, 2 * self.config['n_chans'])
         assert_equal(acv.sources(0), tuple(self.src_streams[0:2]))
         assert_equal(acv.sources(1), tuple(self.src_streams[2:4]))
-        assert_equal(acv.data_rate(1.0, 0), 27392e6)
+        assert_equal(acv.data_rate(1.0, 0), 27392e6 * 2)
         assert_equal(acv.input_labels, self.config['src_streams'])
         assert_equal(acv.command_line_extra, [])
 


### PR DESCRIPTION
It forgot to multiply by the number of antennas.

Closes NGC-418.