### PR TITLE
Decrease number of substreams for gpucbf correlator

### DIFF
--- a/katsdpcontroller/defaults.py
+++ b/katsdpcontroller/defaults.py
@@ -25,3 +25,6 @@ FLAGS_RATE_RATIO = 8.0
 KATCBFSIM_SPECTRA_PER_HEAP = 256
 #: Alignment constraint for `int_time` in katxgpu
 GPUCBF_SPECTRA_PER_HEAP = 256
+#: Maximum input data rate for an xbgpu instance (bytes per second).
+#: This is sufficient for S-band with 80 antennas to be handled by 64 engines.
+XBGPU_MAX_SRC_DATA_RATE = 4.375e9

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -530,7 +530,7 @@ def _make_xbgpu(
     # * 2 is for real+complex
     batch_size = (
         len(acv.src_streams) * acv.n_spectra_per_heap
-        * stream.n_chans_per_endpoint * 4 * acv.bits_per_sample // 8
+        * stream.n_chans_per_endpoint * 2 * acv.bits_per_sample // 8
     )
     rx_reorder_tol = 536870912  # Default of --rx-reorder-tol option
     # Memory allocated for buffering and reordering incoming data

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -531,13 +531,13 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
                     'Inconsistent centre frequencies '
                     f'(both {first.centre_frequency} and {src.centre_frequency})')
         # Determine how fine to divide the stream, i.e., the number of xgpu
-        # processes to run. The constant is the data rate (in bytes per
-        # second) that one engine can handle, and is sufficient for S-band
-        # with 80 antennas to be handled by 64 engines.
+        # processes to run. The constant is the data rate that one engine can
+        # handle, and is sufficient for S-band with 80 antennas to be handled
+        # by 64 engines.
+        max_engine_data_rate = 4.375e9  # in bytes per second
         # The minimum is 4 since SDP expects to run 4 ingest processes.
-        first.adc_sample_rate
         n_substreams = 4
-        while n_substreams * 4.375e9 < first.adc_sample_rate * len(src_streams):
+        while n_substreams * max_engine_data_rate < first.adc_sample_rate * len(src_streams):
             n_substreams *= 2
         if n_chans % n_substreams != 0:
             raise ValueError('Number of channels is too low')

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -531,13 +531,11 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
                     'Inconsistent centre frequencies '
                     f'(both {first.centre_frequency} and {src.centre_frequency})')
         # Determine how fine to divide the stream, i.e., the number of xgpu
-        # processes to run. The constant is the data rate that one engine can
-        # handle, and is sufficient for S-band with 80 antennas to be handled
-        # by 64 engines.
-        max_engine_data_rate = 4.375e9  # in bytes per second
-        # The minimum is 4 since SDP expects to run 4 ingest processes.
+        # processes to run. The minimum is 4 since SDP expects to run 4 ingest
+        # processes.
         n_substreams = 4
-        while n_substreams * max_engine_data_rate < first.adc_sample_rate * len(src_streams):
+        while (n_substreams * defaults.XBGPU_MAX_SRC_DATA_RATE
+               < first.adc_sample_rate * len(src_streams)):
             n_substreams *= 2
         if n_chans % n_substreams != 0:
             raise ValueError('Number of channels is too low')

--- a/katsdpcontroller/test/test_product_config.py
+++ b/katsdpcontroller/test/test_product_config.py
@@ -651,8 +651,8 @@ class TestGpucbfBaselineCorrelationProductsStream:
         )
         # Note: the test values will probably need to be updated as the
         # implementation evolves.
-        assert_equal(bcp.n_chans_per_substream, 512)
-        assert_equal(bcp.n_substreams, 8)
+        assert_equal(bcp.n_chans_per_substream, 1024)
+        assert_equal(bcp.n_substreams, 4)
         assert_equal(bcp.int_time, 104448 * 4096 / 856e6)
         assert_equal(bcp.command_line_extra, [])
 

--- a/katsdpcontroller/test/test_product_controller.py
+++ b/katsdpcontroller/test/test_product_controller.py
@@ -843,7 +843,7 @@ class TestSDPController(BaseTestSDPController):
 
         # Verify katcp sensors.
 
-        n_xengs = 8  # Update if sizing logic changes
+        n_xengs = 4  # Update if sizing logic changes
         # antenna-channelised-voltage sensors
         await assert_sensor_value(
             self.client,


### PR DESCRIPTION
Some updates were needed to the memory usage calculation too - see the second commit. Testing with 4 antennas and either 1024 or 32768 channels shows actual memory usage is 45-60% of that allocated. We can always trim it a bit closer later if necessary, but I'd rather see how things scale with the number of antennas.

See NGC-354.