### PR TITLE
Allow tasks to directly expose Prometheus metrics

### DIFF
--- a/katsdpcontroller/consul.py
+++ b/katsdpcontroller/consul.py
@@ -17,12 +17,12 @@ class ConsulService:
         self.service_id = service_id
 
     async def deregister(self) -> bool:
-        """Deregister the service from Consul.
+        """Deregister the service from Consul, if currently registered.
 
-        If it fails, no exception is thrown, but a warning message is logged.
-        Returns true if the service is not registered, whether because it was
-        never registered or was previously deregistered. If it returns false,
-        it is safe to try again.
+        If it fails, no exception is thrown, but a warning message is logged
+        (and it is safe to try again). Returns true if the service is no
+        longer registered, whether because it was already unregistered or
+        because it was successfully deregistered.
         """
         if self.service_id is None:
             return True

--- a/katsdpcontroller/consul.py
+++ b/katsdpcontroller/consul.py
@@ -49,8 +49,8 @@ class ConsulService:
         Parameters
         ----------
         service
-            A JSON dictionary to pass to Consul. It should exclude the
-            ``ID`` member, which will be generated automatically.
+            A JSON-serializable dictionary to pass to Consul. It should exclude
+            the ``ID`` member, which will be generated automatically.
         """
         service_id = str(uuid.uuid4())
         # We're talking to localhost, so use a low timeout. This will avoid

--- a/katsdpcontroller/consul.py
+++ b/katsdpcontroller/consul.py
@@ -1,0 +1,70 @@
+"""Dynamically register and deregister services with consul."""
+
+import logging
+import uuid
+from typing import Optional
+
+import aiohttp
+
+from .defaults import LOCALHOST
+
+CONSUL_URL = f'http://{LOCALHOST}:8500'
+logger = logging.getLogger(__name__)
+
+
+class ConsulService:
+    def __init__(self, service_id: Optional[str] = None) -> None:
+        self.service_id = service_id
+
+    async def deregister(self) -> bool:
+        """Deregister the service from Consul.
+
+        If it fails, no exception is thrown, but a warning message is logged.
+        Returns true if the service is not registered, whether because it was
+        never registered or was previously deregistered. If it returns false,
+        it is safe to try again.
+        """
+        if self.service_id is None:
+            return True
+        timeout = aiohttp.ClientTimeout(total=5)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.put(
+                        f'{CONSUL_URL}/v1/agent/service/deregister/{self.service_id}') as resp:
+                    resp.raise_for_status()
+                    self.service_id = None
+                    logging.info('Deregistered from consul (ID %s)', self.service_id)
+                    return True
+        except aiohttp.ClientError as exc:
+            logger.warning('Could not deregister from consul: %s', exc)
+            return False
+
+    @classmethod
+    async def register(cls, service: dict) -> 'ConsulService':
+        """Register a service with Consul.
+
+        If registration fails, an instance of the class is still returned,
+        but its deregistration will be a no-op.
+
+        Parameters
+        ----------
+        service
+            A JSON dictionary to pass to Consul. It should exclude the
+            ``ID`` member, which will be generated automatically.
+        """
+        service_id = str(uuid.uuid4())
+        # We're talking to localhost, so use a low timeout. This will avoid
+        # stalling if consul isn't running on the host.
+        timeout = aiohttp.ClientTimeout(total=5)
+        service = {**service, 'ID': service_id}
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.put(f'{CONSUL_URL}/v1/agent/service/register',
+                                       params={'replace-existing-checks': '1'},
+                                       json=service) as resp:
+                    resp.raise_for_status()
+                    logging.info("Registered with consul as ID %s", service_id)
+                    return ConsulService(service_id)
+        except aiohttp.ClientError as exc:
+            logger.warning('Could not register with consul: %s', exc)
+            return ConsulService()

--- a/katsdpcontroller/defaults.py
+++ b/katsdpcontroller/defaults.py
@@ -1,5 +1,7 @@
 """Constants controlling tunable policies."""
 
+#: Unlike "localhost", guaranteed to be IPv4, which is more compatible with Docker
+LOCALHOST = '127.0.0.1'
 #: GPU to target when not running develop mode
 INGEST_GPU_NAME = 'GeForce GTX TITAN X'
 #: Maximum number of custom signals requested by (correlator) timeplot

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -26,6 +26,7 @@ from katsdpmodels.rfi_mask import RFIMask
 from katsdpmodels.band_mask import BandMask, SpectralWindow
 
 from . import scheduler, product_config, defaults
+from .defaults import LOCALHOST
 from .tasks import (
     SDPLogicalTask, SDPPhysicalTask, LogicalGroup,
     CaptureBlockState, KatcpTransition)
@@ -51,9 +52,6 @@ def escape_format(s: str) -> str:
     return s.replace('{', '{{').replace('}', '}}')
 
 
-# Docker doesn't support IPv6 out of the box, and on some systems 'localhost'
-# resolves to ::1, so force an IPv4 localhost.
-LOCALHOST = '127.0.0.1'
 CAPTURE_TRANSITIONS = {
     CaptureBlockState.CAPTURING: [
         KatcpTransition('capture-init', '{capture_block_id}', timeout=30)

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -399,7 +399,7 @@ def _make_fgpu(
         fgpu.cpus = 3
         fgpu.mem = 3072  # Actual use is currently around 2.2 GB
         fgpu.cores = ['src0', 'src1', 'dst']
-        fgpu.ports = ['port']
+        fgpu.ports = ['port', 'prometheus']
         # TODO: could specify separate interface requests for input and
         # output. Currently that's not possible because interfaces are looked
         # up by network name.
@@ -424,7 +424,8 @@ def _make_fgpu(
             '--array-size', str(n_engines),
             '--channels', str(stream.n_chans),
             '--sync-epoch', str(sync_time),
-            '--katcp-port', '{ports[port]}'
+            '--katcp-port', '{ports[port]}',
+            '--prometheus-port', '{ports[prometheus]}'
         ]
         if ibv:
             # Enable cap_net_raw capability for access to raw QPs

--- a/katsdpcontroller/test/test_consul.py
+++ b/katsdpcontroller/test/test_consul.py
@@ -1,0 +1,52 @@
+"""Tests for :mod:`katsdpcontroller.consul`."""
+
+from urllib.parse import urljoin
+
+import asynctest
+from aioresponses import aioresponses
+
+from ..consul import ConsulService, CONSUL_URL
+
+
+class TestConsulService(asynctest.TestCase):
+    def setUp(self) -> None:
+        self.service_data = {
+            'Name': 'product-controller',
+            'Tags': ['prometheus-metrics'],
+            'Port': 12345
+        }
+
+    @aioresponses()
+    async def test_register_failure(self, m) -> None:
+        m.put(
+            urljoin(CONSUL_URL, '/v1/agent/service/register?replace-existing-checks=1'),
+            status=500
+        )
+        service = await ConsulService.register(self.service_data)
+        self.assertIsNone(service.service_id)
+
+    @aioresponses()
+    async def test_register_success(self, m) -> None:
+        m.put(urljoin(CONSUL_URL, '/v1/agent/service/register?replace-existing-checks=1'))
+        service = await ConsulService.register(self.service_data)
+        self.assertIsNotNone(service.service_id)
+
+    async def test_deregister_none(self) -> None:
+        service = ConsulService()
+        self.assertTrue(await service.deregister())
+
+    @aioresponses()
+    async def test_deregister_success(self, m) -> None:
+        service_id = 'test-id'
+        service = ConsulService(service_id)
+        m.put(urljoin(CONSUL_URL, f'/v1/agent/service/deregister/{service_id}'))
+        self.assertTrue(await service.deregister())
+        self.assertIsNone(service.service_id)
+
+    @aioresponses()
+    async def test_deregister_failure(self, m) -> None:
+        service_id = 'test-id'
+        service = ConsulService(service_id)
+        m.put(urljoin(CONSUL_URL, f'/v1/agent/service/deregister/{service_id}'), status=500)
+        self.assertFalse(await service.deregister())
+        self.assertEqual(service.service_id, service_id)

--- a/katsdpcontroller/test/test_product_controller.py
+++ b/katsdpcontroller/test/test_product_controller.py
@@ -37,11 +37,11 @@ import katsdpmodels.rfi_mask
 import katsdpmodels.primary_beam
 import yarl
 
+from ..consul import CONSUL_URL
 from ..controller import device_server_sockname
 from ..product_controller import (
     DeviceServer, SDPSubarrayProductBase, SDPSubarrayProduct, SDPResources,
-    ProductState, DeviceStatus, _redact_keys, _normalise_s3_config, _relative_url,
-    CONSUL_URL)
+    ProductState, DeviceStatus, _redact_keys, _normalise_s3_config, _relative_url)
 from .. import scheduler
 from . import fake_katportalclient
 from .utils import (create_patch, assert_request_fails, assert_sensor_value,

--- a/katsdpcontroller/test/utils.py
+++ b/katsdpcontroller/test/utils.py
@@ -240,7 +240,7 @@ EXPECTED_INTERFACE_SENSOR_LIST: List[Tuple[bytes, ...]] = [
 
 
 def create_patch(test_case: unittest.TestCase, *args, **kwargs) -> Any:
-    """Wrap mock.patch such that it will be unpatched as part of test case cleanup"""
+    """Wrap asynctest.patch such that it will be unpatched as part of test case cleanup."""
     patcher = asynctest.patch(*args, **kwargs)
     mock_obj = patcher.start()
     test_case.addCleanup(patcher.stop)

--- a/sandbox/etc/prometheus/prometheus.yml
+++ b/sandbox/etc/prometheus/prometheus.yml
@@ -9,14 +9,16 @@ scrape_configs:
     static_configs:
       - targets:
         - "127.0.0.1:5004"
-  - job_name: 'product_controller'
+  - job_name: 'subarray-metrics'
     consul_sd_configs:
       - refresh_interval: 5s
     relabel_configs:
-      - source_labels: [__meta_consul_service]
-        regex: product-controller
+      - source_labels: [__meta_consul_tags, __meta_consul_service_metadata_subarray_product_id]
+        regex: .*,prometheus-metrics,.*;.+
         action: keep
       - source_labels: [__meta_consul_service_metadata_subarray_product_id]
         target_label: subarray_product_id
-      - source_labels: [__meta_consul_service_metadata_subarray_product_id]
+      - source_labels: [__meta_consul_service_metadata_task_type]
+        target_label: task_type
+      - source_labels: [__meta_consul_service]
         target_label: instance


### PR DESCRIPTION
Currently tasks can indirectly provide metrics to Prometheus by exporting katcp sensors with some magic in the sensor description, and the product controller will transform it into a metric. This has a number of shortcomings:
- Every metric has to also be a katcp sensor that CAM will collect and archive. This has been a problem for the large number of sensors exposed by CBF.
- It is not possible to use Prometheus features that don't fit the katcp model, such as labels.
- In some cases sensors are pushed to the product controller on some cadence (to avoid sending every update, when the update rate is high) then scraped at some other cadence by Prometheus, sometimes leading to sampling artefacts.

This allows a task to define a "prometheus" port, and the product controller will register the task with consul. There will probably need to be a few adjustments to katsdpinfrastructure to have the Prometheus in production pick up these tasks, similar to what's done in the sandbox.