### PR TITLE
Use katsdptelstate.aio.redis.RedisBackend.from_url

### DIFF
--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -19,7 +19,6 @@ import aiokatcp
 from aiokatcp import FailReply, Sensor, Address
 from prometheus_client import Gauge, Counter, Histogram, CollectorRegistry, REGISTRY
 import yarl
-import aioredis
 import katsdptelstate.aio.redis
 import katsdpmodels.fetch.aiohttp
 
@@ -1172,8 +1171,9 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
         # connect to telstate store
         self.telstate_endpoint = '{}:{}'.format(self.telstate_node.host,
                                                 self.telstate_node.ports['telstate'])
-        redis_client = await aioredis.create_redis_pool(f'redis://{self.telstate_endpoint}')
-        telstate_backend = katsdptelstate.aio.redis.RedisBackend(redis_client)
+        telstate_backend = await katsdptelstate.aio.redis.RedisBackend.from_url(
+            f'redis://{self.telstate_endpoint}'
+        )
         telstate = katsdptelstate.aio.TelescopeState(telstate_backend)
         self.telstate = telstate
         self.resolver.telstate = telstate

--- a/katsdpcontroller/test/test_product_controller.py
+++ b/katsdpcontroller/test/test_product_controller.py
@@ -26,7 +26,6 @@ from prometheus_client import CollectorRegistry
 import pymesos
 import networkx
 import netifaces
-import aioredis
 import katsdptelstate.aio.memory
 from katsdptelstate.endpoint import Endpoint
 import katpoint
@@ -567,9 +566,8 @@ class TestSDPController(BaseTestSDPController):
 
         # Mock RedisBackend to create an in-memory telstate instead
         self.telstate = katsdptelstate.aio.TelescopeState()
-        create_patch(self, 'katsdptelstate.aio.redis.RedisBackend',
-                     return_value=self.telstate.backend)
-        create_patch(self, 'aioredis.create_redis_pool', autospec=True)
+        create_patch(self, 'katsdptelstate.aio.redis.RedisBackend.from_url',
+                     return_value=self.telstate.backend, autospec=True)
 
         self.sensor_proxy_client_class = create_patch(
             self, 'katsdpcontroller.sensor_proxy.SensorProxyClient', autospec=True)
@@ -757,7 +755,9 @@ class TestSDPController(BaseTestSDPController):
         then indicate success.
         """
         await self._configure_subarray(SUBARRAY_PRODUCT)
-        aioredis.create_redis_pool.assert_called_once_with('redis://host.telstate:20000')
+        katsdptelstate.aio.redis.RedisBackend.from_url.assert_called_once_with(
+            'redis://host.telstate:20000'
+        )
 
         # Verify the telescope state.
         # This is not a complete list of calls. It checks that each category of stuff
@@ -953,7 +953,7 @@ class TestSDPController(BaseTestSDPController):
     async def test_product_configure_telstate_fail(self) -> None:
         """If the telstate task fails, product-configure must fail"""
         self.fail_launches['telstate'] = 'TASK_FAILED'
-        aioredis.create_redis_pool.side_effect = ConnectionRefusedError
+        katsdptelstate.aio.redis.RedisBackend.from_url.side_effect = ConnectionError
         await assert_request_fails(self.client, *self._configure_args(SUBARRAY_PRODUCT))
         self.sched.launch.assert_called_with(mock.ANY, mock.ANY, mock.ANY)
         self.sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
@@ -964,7 +964,9 @@ class TestSDPController(BaseTestSDPController):
         """If a task other than telstate fails, product-configure must fail"""
         self.fail_launches['ingest.sdp_l0.1'] = 'TASK_FAILED'
         await assert_request_fails(self.client, *self._configure_args(SUBARRAY_PRODUCT))
-        aioredis.create_redis_pool.assert_called_once_with('redis://host.telstate:20000')
+        katsdptelstate.aio.redis.RedisBackend.from_url.assert_called_once_with(
+            'redis://host.telstate:20000'
+        )
         self.sched.launch.assert_called_with(mock.ANY, mock.ANY)
         self.sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
         # Must not have created the subarray product internally

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ addict==2.1.1
 aiohttp
 aiohttp-jinja2==1.4.2
 aiokatcp
-aioredis
 aiozk==0.14.0
 async-timeout
 click==7.0                 # via Flask

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         'aiohttp~=3.5',
         'aiohttp-jinja2',
         'aiokatcp>=0.6.1',
-        'aioredis',
         'aiozk',
         'async_timeout',
         'dash>=1.18.*',


### PR DESCRIPTION
This removes the direct dependency on aioredis, and will ease the
transition to aioredis2.

Depends on https://github.com/ska-sa/katsdptelstate/pull/125
