### PR TITLE
Tweaks to linkage with consul

### DIFF
--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -401,11 +401,11 @@ class SDPPhysicalTask(SDPConfigMixin, scheduler.PhysicalTask):
         if 'prometheus' in self.ports:
             prometheus_port = self.ports['prometheus']
             service = {
-                'Name': self.logical_node.name,
+                'Name': self.logical_node.task_type,
                 'Tags': ['prometheus-metrics'],
                 'Meta': {
                     'subarray_product_id': self.subarray_product_id,
-                    'task_type': self.logical_node.task_type
+                    'task_name': self.logical_node.name
                 },
                 'Port': prometheus_port,
                 'Checks': [

--- a/sandbox/etc/prometheus/prometheus.yml
+++ b/sandbox/etc/prometheus/prometheus.yml
@@ -13,12 +13,12 @@ scrape_configs:
     consul_sd_configs:
       - refresh_interval: 5s
     relabel_configs:
-      - source_labels: [__meta_consul_tags, __meta_consul_service_metadata_subarray_product_id]
-        regex: .*,prometheus-metrics,.*;.+
+      - source_labels: [__meta_consul_tags, __meta_consul_service_metadata_subarray_product_id, __meta_consul_service_metadata_task_name]
+        regex: .*,prometheus-metrics,.*;.+;.+
         action: keep
       - source_labels: [__meta_consul_service_metadata_subarray_product_id]
         target_label: subarray_product_id
-      - source_labels: [__meta_consul_service_metadata_task_type]
-        target_label: task_type
-      - source_labels: [__meta_consul_service]
+      - source_labels: [__meta_consul_service_metadata_task_name]
         target_label: instance
+      - source_labels: [__meta_consul_service]
+        target_label: job


### PR DESCRIPTION
The consul `Name` is changed to be the task type: this means that consul
service discovery can be used to find all F-engine tasks for example.
The specific instance e.g. `f.antenna_channelised_voltage.1` is put into
a `task_name` metadata field.

The sandbox Prometheus config is also adjusted: the task type is now
mapped to `job` (a standard Prometheus label).

Relates to NGC-325.
