### PR TITLE
Customise sensor name mangling for fgpu

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -461,6 +461,11 @@ def _make_fgpu(
         # Link it to the group, so that downstream tasks need only depend on the group.
         g.add_edge(fgpu_group, fgpu, depends_ready=True, depends_init=True)
 
+        # Rename sensors that are relevant to the stream rather than the process
+        for j, src in enumerate(srcs):
+            fgpu.sensor_renames[f"input{j}-eq"] = f"{stream.name}-{src.name}-eq"
+            fgpu.sensor_renames[f"input{j}-delay"] = f"{stream.name}-{src.name}-delay"
+
     return fgpu_group
 
 

--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -133,6 +133,8 @@ class SDPLogicalTask(scheduler.LogicalTask):
         # List of dictionaries for a .gui-urls sensor. The fields are expanded
         # using str.format(self).
         self.gui_urls = []
+        # Overrides for sensor name remapping
+        self.sensor_renames = {}
         # Whether we should abort the capture block if the task fails
         self.critical = True
         # Whether to set config keys in telstate (only useful for processes that use katsdpservices)
@@ -435,7 +437,9 @@ class SDPPhysicalTask(SDPConfigMixin, scheduler.PhysicalTask):
                                  self.host, self.ports['port'], self.name)
                 prefix = self.name + '.'
                 self.katcp_connection = sensor_proxy.SensorProxyClient(
-                    self.sdp_controller, prefix, host=self.host, port=self.ports['port'])
+                    self.sdp_controller, prefix,
+                    renames=self.logical_node.sensor_renames,
+                    host=self.host, port=self.ports['port'])
                 try:
                     await self.katcp_connection.wait_synced()
                     self.logger.info("Connected to %s:%s for node %s",


### PR DESCRIPTION
- Add generic mechanism to SensorProxyClient to allow sensor renaming to
  be overridden for specific sensors.
- Add hook in SDPPhysicalTask to allow the logical task to specify the
  renaming.
- Add renaming rules for `gains` and `delay` for fgpu.

Closes NGC-451.
