### PR TITLE
Use realtime scheduling for CBF tasks

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -307,6 +307,7 @@ def _make_dsim(
         '--katcp-port', '{ports[port]}',
         '--prometheus-port', '{ports[prometheus]}'
     ]
+    dsim.capabilities.append('SYS_NICE')  # For schedrr
     if configuration.options.develop:
         # In develop mode, scale down reservation for low bandwidths to allow
         # testing low-bandwidth arrays on a single machine. Use a full core
@@ -440,6 +441,7 @@ def _make_fgpu(
             '--katcp-port', '{ports[port]}',
             '--prometheus-port', '{ports[prometheus]}'
         ]
+        fgpu.capabilities.append('SYS_NICE')  # For schedrr
         if ibv:
             # Enable cap_net_raw capability for access to raw QPs
             fgpu.capabilities.append('NET_RAW')
@@ -607,6 +609,7 @@ def _make_xbgpu(
             '--katcp-port', '{ports[port]}',
             '--prometheus-port', '{ports[prometheus]}'
         ]
+        xbgpu.capabilities.append('SYS_NICE')  # For schedrr
         if ibv:
             # Enable cap_net_raw capability for access to raw QPs
             xbgpu.capabilities.append('NET_RAW')

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -299,7 +299,7 @@ def _make_dsim(
     )]
     dsim.interfaces[0].bandwidth_out = sum(stream.data_rate() for stream in streams)
     dsim.command = [
-        'dsim',
+        'schedrr', 'dsim',
         '--interface', '{interfaces[cbf].name}',
         '--adc-sample-rate', str(streams[0].adc_sample_rate),
         '--ttl', '4',
@@ -426,7 +426,7 @@ def _make_fgpu(
         fgpu.gpus[0].compute = 0.5 * stream.adc_sample_rate / _MAX_ADC_SAMPLE_RATE
         fgpu.gpus[0].mem = 3072     # Actual use is about 2.5GB, independent of channel count
         fgpu.command = [
-            'fgpu',
+            'schedrr', 'fgpu',
             '--src-interface', '{interfaces[cbf].name}',
             '--src-affinity', '{cores[src0]},{cores[src1]}',
             '--dst-interface', '{interfaces[cbf].name}',
@@ -590,7 +590,7 @@ def _make_xbgpu(
         # TODO: ensure that the main thread runs on cores[dst]
         heap_time = acv.n_samples_between_spectra / acv.adc_sample_rate * acv.n_spectra_per_heap
         xbgpu.command = [
-            'xbgpu',
+            'schedrr', 'xbgpu',
             '--adc-sample-rate', str(first_dig.adc_sample_rate),
             '--array-size', str(len(acv.src_streams) // 2),  # 2 pols per antenna
             '--channels', str(stream.n_chans),


### PR DESCRIPTION
Run CBF tasks with schedrr wrapper for realtime priority.

The wrapper was originally developer for SDP and lives in katsdpdockerbase. The
Dockerfile here just wgets it from the Github repo. It was originally written
to be run setuid root, but it works just fine with the `CAP_SYS_NICE`
capability instead, and that gives it fewer privileges.

Closes NGC-504.
