### PR TITLE
Adjust memory usage for xbgpu

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -89,7 +89,7 @@ DATA_VOL = scheduler.VolumeRequest('data', '/var/kat/data', 'RW')
 OBJ_DATA_VOL = scheduler.VolumeRequest('obj_data', '/var/kat/data', 'RW')
 #: Volume for persisting user configuration
 CONFIG_VOL = scheduler.VolumeRequest('config', '/var/kat/config', 'RW')
-#: Number of real components in a complex number
+#: Number of components in a complex number
 COMPLEX = 2
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Set `--heaps-per-fengine-per-chunk` to aim for a 16MB chunk size, to
ensure chunks are not so small that per-chunk overheads become
significant, while also limiting the memory needed for the visibility
accumulators (which scale with the number of batches per chunk).

At the same time, try to more accurately model the memory usage of
xbgpu, both on the host and GPU, and update the GPU compute allocation.

Relates to NGC-526.
