### PR TITLE
Don't start telstate or metawriter without SDP components

### DIFF
--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -1412,6 +1412,7 @@ class SDPSubarrayProduct(SDPSubarrayProductBase):
                     self.add_sensor(ss)
 
                 # launch the telescope state for this graph
+                telstate: Optional[katsdptelstate.aio.TelescopeState]
                 if self.telstate_node is not None:
                     telstate = await self._launch_telstate()
                 else:

--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -168,6 +168,11 @@ class SDPConfigMixin:
                 logger.warning('Graph node %s has explicit config but katsdpservices_config=False',
                                self.name)
             return
+        if not resolver.telstate:
+            logger.warning(
+                "Graph node %s expected to be configured via telstate but there isn't one",
+                self.name)
+            return
 
         # Not every task will take a --external-hostname option, but the
         # katsdpservices argument parser doesn't mind unused arguments.


### PR DESCRIPTION
This will make correlators a bit leaner. To support this change,
`?capture-init` will now fail if there are no SDP components to start.

Closes NGC-414.
