### PR TITLE
Suppress some warnings about config without telstate

### DIFF
--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -169,9 +169,10 @@ class SDPConfigMixin:
                                self.name)
             return
         if not resolver.telstate:
-            logger.warning(
-                "Graph node %s expected to be configured via telstate but there isn't one",
-                self.name)
+            if self._graph_config(resolver, graph):
+                logger.warning(
+                    "Graph node %s has explicit config but there is no telstate",
+                    self.name)
             return
 
         # Not every task will take a --external-hostname option, but the


### PR DESCRIPTION
It was warning about some group nodes for which the default of
katsdpservices_config was still in place. I've now made it only warn if
some config was explicitly provided.
