### PR TITLE
Generate Prometheus gauges for expected heap rates

### DIFF
--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -527,6 +527,10 @@ def _make_fgpu(
         for j, src in enumerate(srcs):
             fgpu.sensor_renames[f"input{j}-eq"] = f"{stream.name}-{src.name}-eq"
             fgpu.sensor_renames[f"input{j}-delay"] = f"{stream.name}-{src.name}-delay"
+        # Prepare expected data rate
+        fgpu.static_gauges['fgpu_expected_input_heaps_per_second'] = sum(
+            src.adc_sample_rate / src.samples_per_heap for src in srcs
+        )
 
     return fgpu_group
 

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -735,6 +735,11 @@ def _make_xbgpu(
         # Link it to the group, so that downstream tasks need only depend on the group.
         g.add_edge(xbgpu_group, xbgpu, depends_ready=True, depends_init=True)
 
+        xbgpu.static_gauges['xbgpu_expected_input_heaps_per_second'] = (
+            acv.adc_sample_rate / (acv.n_samples_between_spectra * acv.n_spectra_per_heap)
+            * len(acv.src_streams) / 2   # / 2 because each heap contains two pols
+        )
+
     return xbgpu_group
 
 

--- a/katsdpcontroller/product_config.py
+++ b/katsdpcontroller/product_config.py
@@ -329,12 +329,12 @@ class DigRawAntennaVoltageStreamBase(Stream):
         self.band = band
         self.antenna_name = antenna_name
         self.bits_per_sample = 10
+        self.samples_per_heap = 4096
 
     def data_rate(self, ratio: float = 1.05, overhead: int = 128) -> float:
         """Network bandwidth in bits per second."""
-        samples_per_heap = 4096
-        heap_size = samples_per_heap * self.bits_per_sample // 8
-        heap_time = samples_per_heap / self.adc_sample_rate
+        heap_size = self.samples_per_heap * self.bits_per_sample // 8
+        heap_time = self.samples_per_heap / self.adc_sample_rate
         return data_rate(heap_size, heap_time, ratio, overhead)
 
 

--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -51,6 +51,9 @@ POSTPROCESSING_TIME_REL = Histogram(
 STATIC_GAUGES = [
     Gauge(
         'fgpu_expected_input_heaps_per_second',
+        'Number of heaps that should be received per second'),
+    Gauge(
+        'xbgpu_expected_input_heaps_per_second',
         'Number of heaps that should be received per second')
 ]
 logger = logging.getLogger(__name__)

--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -48,6 +48,11 @@ POSTPROCESSING_TIME_REL = Histogram(
     'Wall-clock time for postprocessing each capture block (including burndown phase)'
     ', relative to observation time',
     buckets=POSTPROCESSING_REL_BUCKETS)
+STATIC_GAUGES = [
+    Gauge(
+        'fgpu_expected_input_heaps_per_second',
+        'Number of heaps that should be received per second')
+]
 logger = logging.getLogger(__name__)
 
 
@@ -421,6 +426,15 @@ class SDPSubarrayProductBase:
             "State of the subarray product state machine (prometheus: gauge)",
             status_func=_error_on_error)
         self._device_status_sensor = sdp_controller.sensors['device-status']
+
+        # Set gauges for expected data rates
+        for gauge in STATIC_GAUGES:
+            value = 0.0
+            gauge_name = gauge.collect()[0].name
+            for node in self.logical_graph:
+                if isinstance(node, tasks.SDPLogicalTask):
+                    value += node.static_gauges.get(gauge_name, 0.0)
+            gauge.set(value)
 
         self.state = ProductState.CONFIGURING   # This sets the sensor
         self.add_sensor(self._capture_block_sensor)

--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -5,8 +5,9 @@ import socket
 import ipaddress
 import os
 import typing
+from collections import defaultdict
 from contextlib import asynccontextmanager
-from typing import AsyncContextManager, AsyncGenerator, List, Set, Type, Union
+from typing import AsyncContextManager, AsyncGenerator, List, MutableMapping, Set, Type, Union
 
 import async_timeout
 import aiokatcp
@@ -140,6 +141,8 @@ class SDPLogicalTask(scheduler.LogicalTask):
         self.gui_urls = []
         # Overrides for sensor name remapping
         self.sensor_renames = {}
+        # Passes values to SDPSubarrayProduct to set as gauges
+        self.static_gauges: MutableMapping[str, float] = defaultdict(float)
         # Whether we should abort the capture block if the task fails
         self.critical = True
         # Whether to set config keys in telstate (only useful for processes that use katsdpservices)

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ networkx==2.0
 numpy
 plotly==4.0.0              # via dash
 prometheus_async==18.1.0
-prometheus_client==0.2.0
+prometheus_client==0.3.1
 pydot==1.4.2
 pymesos==0.3.6
 retrying==1.3.3            # via plotly

--- a/sandbox/etc/prometheus/prometheus.yml
+++ b/sandbox/etc/prometheus/prometheus.yml
@@ -9,6 +9,17 @@ scrape_configs:
     static_configs:
       - targets:
         - "127.0.0.1:5004"
+  - job_name: 'product-controller'
+    consul_sd_configs:
+      - refresh_interval: 5s
+    relabel_configs:
+      - source_labels: [__meta_consul_service]
+        regex: product-controller
+        action: keep
+      - source_labels: [__meta_consul_service_metadata_subarray_product_id]
+        target_label: subarray_product_id
+      - source_labels: [__meta_consul_service_metadata_subarray_product_id]
+        target_label: instance
   - job_name: 'subarray-metrics'
     consul_sd_configs:
       - refresh_interval: 5s

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'networkx>=2.0',
         'numpy',
         'prometheus_async',
-        'prometheus_client<0.4.0',   # 0.4.0 forces _total suffix
+        'prometheus_client>=0.3.0,<0.4.0',   # 0.4.0 forces _total suffix
         'pydot',             # For networkx.drawing.nx_pydot
         'pymesos>=0.3.6',    # 0.3.6 implements reviveOffers with roles
         'rfc3987',           # Used by jsonschema to validate URLs


### PR DESCRIPTION
Create fgpu_expected_input_heaps_per_second and xbgpu_expected_input_heaps_per_second metrics, which can be added to the Grafana dashboards to show what the rate should be.

This is done in the product controller rather than in the individual engines because the latter suffers the issue that if an engine vanishes completely (so that Prometheus no longer scrapes it), it will no longer contribute to the sum, and so the "expected" rate will be too low. Doing it in the product controller does unfortunately require some duplication of logic.

I'm not totally happy with these gauges being unitary (no labels). It would be nice if they were labelled with the stream, but that gets complicated when a single engine is processing multiple streams (i.e., wide+narrow). For now I've just made it a grand total.