### PR TITLE
Be more aggressive with xbgpu resources

### DIFF
--- a/katsdpcontroller/defaults.py
+++ b/katsdpcontroller/defaults.py
@@ -28,7 +28,7 @@ KATCBFSIM_SPECTRA_PER_HEAP = 256
 #: Alignment constraint for `int_time` in katxgpu
 GPUCBF_SPECTRA_PER_HEAP = 256
 #: Maximum input data rate for an xbgpu instance (bytes per second).
-#: This is sufficient for S-band with 80 antennas to be handled by 64 engines.
-XBGPU_MAX_SRC_DATA_RATE = 4.375e9
+#: This is sufficient for UHF with 80 antennas to be handled by 32 engines.
+XBGPU_MAX_SRC_DATA_RATE = 5.45e9
 #: Number of polyphase filter-bank taps for gpucbf F-engines
 PFB_TAPS = 16

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -7,7 +7,7 @@ import copy
 import urllib.parse
 import os.path
 from typing import (
-    List, Dict, Tuple, Set, Sequence, Iterable, Type, Union, Optional, Any, TYPE_CHECKING
+    List, Dict, Tuple, Set, Sequence, Iterable, Type, Union, Optional, Any, TYPE_CHECKING, cast
 )
 
 import addict
@@ -615,7 +615,11 @@ def _make_xbgpu(
     for key, value in telstate_data.items():
         init_telstate[(stream.name, key)] = value
 
-    bw_scale = stream.adc_sample_rate / _MAX_ADC_SAMPLE_RATE
+    input_rate = sum(
+        cast(product_config.DigRawAntennaVoltageStreamBase, dig).adc_sample_rate
+        for dig in acv.src_streams
+    ) * acv.bits_per_sample // 8
+    bw_scale = input_rate / (acv.n_substreams * defaults.XBGPU_MAX_SRC_DATA_RATE)
 
     # Compute how much memory to provide for input
 

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -653,7 +653,7 @@ def _make_xbgpu(
         xbgpu.mem = 512 + _mb(recv_buffer + send_buffer)
         if not configuration.options.develop:
             xbgpu.cores = ['src', 'dst']
-            xbgpu.numa_nodes = 1.0  # It's easily starved of bandwidth
+            xbgpu.numa_nodes = 0.5 * bw_scale  # It's easily starved of bandwidth
             taskset = ['taskset', '-c', '{cores[dst]}']
         else:
             taskset = []
@@ -671,7 +671,7 @@ def _make_xbgpu(
         xbgpu.interfaces[0].bandwidth_in = acv.data_rate() / n_engines
         xbgpu.interfaces[0].bandwidth_out = stream.data_rate() / n_engines
         xbgpu.gpus = [scheduler.GPURequest()]
-        xbgpu.gpus[0].compute = 0.2 * bw_scale
+        xbgpu.gpus[0].compute = 0.15 * bw_scale
         xbgpu.gpus[0].mem = 300 + _mb(3 * chunk_size + 2 * vis_size + mid_vis_size)
         # Minimum capability as a function of bits-per-sample, based on
         # tensor_core_correlation_kernel.mako from katgpucbf.xbgpu.


### PR DESCRIPTION
- Fix calculation of `bw_scale` in `_make_xbgpu`. This variable is intended to capture how heavily loaded an instance of
the engine is. However, the calculation considered only the ADC sample rate, without considering how many engines there are.
- Increase XBGPU_MAX_SRC_DATA_RATE so that UHF will need only 32 engines
  rather than 64 for the full system (and will also allow only 32
  engines for <50 antennas in L/S-band).
- Decrease NUMA allocation to 50% of a node, allowing two xbgpus to run
  on one CCD. This in theory would allow more than 4 per server, but in
  practice most configurations don't have enough bandwidth to run 3 on
  one NIC (there is a small window where the bandwidth is low enough to
  fit a 3rd but not so low that the number of engines gets halved). It
  does allow other processes (such as dsims) more room to run.
- Decrease GPU allocation to 0.15. The model suggests 0.1 is sufficient
  (on RTX 3080), but since this has never been the limiting factor
  anyway there is no harm in being a little conservative.

Closes NGC-475.