### PR TITLE
Updates to reflect that it's not just for SDP

### DIFF
--- a/katsdpcontroller/dashboard.py
+++ b/katsdpcontroller/dashboard.py
@@ -19,7 +19,7 @@ import dash_table
 from dash_dangerously_set_inner_html import DangerouslySetInnerHTML
 
 from . import scheduler
-from .tasks import PhysicalTask
+from .tasks import ProductPhysicalTask
 
 
 def timestamp_utc(timestamp):
@@ -45,7 +45,7 @@ def _get_tasks(product):
     order_graph = scheduler.subgraph(product.physical_graph, scheduler.DEPENDS_READY)
     tasks = networkx.lexicographical_topological_sort(
             order_graph.reverse(), key=lambda node: node.name)
-    tasks = [task for task in tasks if isinstance(task, PhysicalTask)]
+    tasks = [task for task in tasks if isinstance(task, ProductPhysicalTask)]
     return tasks
 
 
@@ -55,7 +55,7 @@ def _get_batch_tasks(product):
         graph = capture_block.postprocess_physical_graph
         if graph is not None:
             for task in graph.nodes:
-                if isinstance(task, PhysicalTask):
+                if isinstance(task, ProductPhysicalTask):
                     tasks.append((name, task))
     return tasks
 

--- a/katsdpcontroller/dashboard.py
+++ b/katsdpcontroller/dashboard.py
@@ -19,7 +19,7 @@ import dash_table
 from dash_dangerously_set_inner_html import DangerouslySetInnerHTML
 
 from . import scheduler
-from .tasks import SDPPhysicalTask
+from .tasks import PhysicalTask
 
 
 def timestamp_utc(timestamp):
@@ -45,7 +45,7 @@ def _get_tasks(product):
     order_graph = scheduler.subgraph(product.physical_graph, scheduler.DEPENDS_READY)
     tasks = networkx.lexicographical_topological_sort(
             order_graph.reverse(), key=lambda node: node.name)
-    tasks = [task for task in tasks if isinstance(task, SDPPhysicalTask)]
+    tasks = [task for task in tasks if isinstance(task, PhysicalTask)]
     return tasks
 
 
@@ -55,7 +55,7 @@ def _get_batch_tasks(product):
         graph = capture_block.postprocess_physical_graph
         if graph is not None:
             for task in graph.nodes:
-                if isinstance(task, SDPPhysicalTask):
+                if isinstance(task, PhysicalTask):
                     tasks.append((name, task))
     return tasks
 

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -29,7 +29,7 @@ from . import scheduler, product_config, defaults
 from .defaults import LOCALHOST
 from .fake_servers import FakeCalDeviceServer, FakeFgpuDeviceServer, FakeIngestDeviceServer
 from .tasks import (
-    SDPLogicalTask, SDPPhysicalTask, SDPFakePhysicalTask,
+    LogicalTask, PhysicalTask, FakePhysicalTask,
     LogicalGroup, CaptureBlockState, KatcpTransition)
 from .product_config import (
     BYTES_PER_VIS, BYTES_PER_FLAG, BYTES_PER_VFW, data_rate,
@@ -130,7 +130,7 @@ class PhysicalMulticast(scheduler.PhysicalExternal):
         self._endpoint_sensor.value = str(Endpoint(self.host, self.ports['spead']))
 
 
-class TelstateTask(SDPPhysicalTask):
+class TelstateTask(PhysicalTask):
     async def resolve(self, resolver, graph):
         await super().resolve(resolver, graph)
         # Add a port mapping
@@ -150,7 +150,7 @@ class TelstateTask(SDPPhysicalTask):
             parameters.append({'key': 'publish', 'value': f'{LOCALHOST}:{host_port}:6379'})
 
 
-class IngestTask(SDPPhysicalTask):
+class IngestTask(PhysicalTask):
     async def resolve(self, resolver, graph, image_path=None):
         # In develop mode, the GPU can be anything, and we need to pick a
         # matching image.
@@ -193,7 +193,7 @@ def _make_telstate(g: networkx.MultiDiGraph,
         if isinstance(stream, product_config.AntennaChannelisedVoltageStreamBase):
             n_antennas += len(stream.antennas)
 
-    telstate = SDPLogicalTask('telstate')
+    telstate = LogicalTask('telstate')
     # redis is nominally single-threaded, but has some helper threads
     # for background tasks so can occasionally exceed 1 CPU.
     telstate.cpus = 1.2 if not configuration.options.develop else 0.2
@@ -206,7 +206,7 @@ def _make_telstate(g: networkx.MultiDiGraph,
         {'key': 'workdir', 'value': '/mnt/mesos/sandbox'})
     telstate.command = ['redis-server', '/usr/local/etc/redis/redis.conf']
     if configuration.options.interface_mode:
-        telstate.physical_factory = SDPFakePhysicalTask
+        telstate.physical_factory = FakePhysicalTask
     else:
         telstate.physical_factory = TelstateTask
     telstate.katsdpservices_logging = False
@@ -220,7 +220,7 @@ def _make_telstate(g: networkx.MultiDiGraph,
 def _make_cam2telstate(g: networkx.MultiDiGraph,
                        configuration: Configuration,
                        stream: product_config.CamHttpStream) -> scheduler.LogicalNode:
-    cam2telstate = SDPLogicalTask('cam2telstate')
+    cam2telstate = LogicalTask('cam2telstate')
     cam2telstate.image = 'katsdpcam2telstate'
     cam2telstate.command = ['cam2telstate.py']
     cam2telstate.cpus = 0.75
@@ -241,7 +241,7 @@ def _make_cam2telstate(g: networkx.MultiDiGraph,
 
 def _make_meta_writer(g: networkx.MultiDiGraph,
                       configuration: Configuration) -> scheduler.LogicalNode:
-    meta_writer = SDPLogicalTask('meta_writer')
+    meta_writer = LogicalTask('meta_writer')
     meta_writer.image = 'katsdpmetawriter'
     meta_writer.command = ['meta_writer.py']
     meta_writer.cpus = 0.2
@@ -303,7 +303,7 @@ def _make_dsim(
     # Generate a unique name. The caller groups streams by
     # (antenna.name, adc_sample_rate), so that is guaranteed to be unique.
     name = f'sim.{streams[0].antenna.name}.{streams[0].adc_sample_rate}'
-    dsim = SDPLogicalTask(name, streams=streams)
+    dsim = LogicalTask(name, streams=streams)
     dsim.image = 'katgpucbf'
     dsim.mem = 2048
     dsim.ports = ['port', 'prometheus']
@@ -442,7 +442,7 @@ def _make_fgpu(
 
     for i in range(0, n_engines):
         srcs = stream.sources(i)
-        fgpu = SDPLogicalTask(f'f.{stream.name}.{i}', streams=[stream])
+        fgpu = LogicalTask(f'f.{stream.name}.{i}', streams=[stream])
         fgpu.image = 'katgpucbf'
         fgpu.fake_katcp_server_cls = FakeFgpuDeviceServer
         fgpu.cpus = 4
@@ -647,7 +647,7 @@ def _make_xbgpu(
     send_buffer = vis_size * 5  # Magic number is default in XSend class
 
     for i in range(0, stream.n_substreams):
-        xbgpu = SDPLogicalTask(f'xb.{stream.name}.{i}', streams=[stream])
+        xbgpu = LogicalTask(f'xb.{stream.name}.{i}', streams=[stream])
         xbgpu.image = 'katgpucbf'
         xbgpu.cpus = 0.5 * bw_scale if configuration.options.develop else 1.5
         xbgpu.mem = 512 + _mb(recv_buffer + send_buffer)
@@ -760,7 +760,7 @@ def _make_cbf_simulator(g: networkx.MultiDiGraph,
             n_sim *= 2
     ibv = not configuration.options.develop
 
-    def make_cbf_simulator_config(task: SDPPhysicalTask,
+    def make_cbf_simulator_config(task: PhysicalTask,
                                   resolver: 'product_controller.Resolver') -> Dict[str, Any]:
         conf = {
             'cbf_channels': stream.n_chans,
@@ -803,7 +803,7 @@ def _make_cbf_simulator(g: networkx.MultiDiGraph,
     init_telstate[('sub', 'band')] = stream.antenna_channelised_voltage.band
 
     for i in range(n_sim):
-        sim = SDPLogicalTask('sim.{}.{}'.format(stream.name, i + 1), streams=[stream])
+        sim = LogicalTask('sim.{}.{}'.format(stream.name, i + 1), streams=[stream])
         sim.image = 'katcbfsim'
         # create-*-stream is passed on the command-line instead of telstate
         # for now due to SR-462.
@@ -872,7 +872,7 @@ def _make_timeplot(g: networkx.MultiDiGraph, name: str, description: str,
                    extra_config: dict) -> scheduler.LogicalNode:
     """Common backend code for creating a single timeplot server."""
     multicast = find_node(g, 'multicast.timeplot.' + name)
-    timeplot = SDPLogicalTask('timeplot.' + name)
+    timeplot = LogicalTask('timeplot.' + name)
     timeplot.image = 'katsdpdisp'
     timeplot.command = ['time_plot.py']
     timeplot.cpus = cpus
@@ -1128,9 +1128,9 @@ def _make_ingest(g: networkx.MultiDiGraph, configuration: Configuration,
                config=lambda task, resolver, endpoint: {'cbf_spead': str(endpoint)})
 
     for i in range(1, n_ingest + 1):
-        ingest = SDPLogicalTask('ingest.{}.{}'.format(name, i), streams=streams)
+        ingest = LogicalTask('ingest.{}.{}'.format(name, i), streams=streams)
         if configuration.options.interface_mode:
-            ingest.physical_factory = SDPFakePhysicalTask
+            ingest.physical_factory = FakePhysicalTask
         else:
             ingest.physical_factory = IngestTask
         ingest.fake_katcp_server_cls = FakeIngestDeviceServer
@@ -1170,7 +1170,7 @@ def _make_ingest(g: networkx.MultiDiGraph, configuration: Configuration,
             data_rate_out += continuum.data_rate()
         ingest.interfaces[1].bandwidth_out = data_rate_out / n_ingest
 
-        def make_ingest_config(task: SDPPhysicalTask,
+        def make_ingest_config(task: PhysicalTask,
                                resolver: 'product_controller.Resolver',
                                server_id: int = i) -> Dict[str, Any]:
             conf = {
@@ -1299,8 +1299,8 @@ def _make_cal(g: networkx.MultiDiGraph,
 
     dask_prefix = '/gui/{0.subarray_product.subarray_product_id}/{0.name}/cal-diagnostics'
     for i in range(1, n_cal + 1):
-        cal = SDPLogicalTask('{}.{}'.format(stream.name, i),
-                             streams=(stream,) + tuple(flags_streams))
+        cal = LogicalTask('{}.{}'.format(stream.name, i),
+                          streams=(stream,) + tuple(flags_streams))
         cal.fake_katcp_server_cls = FakeCalDeviceServer
         cal.image = 'katsdpcal'
         cal.command = ['run_cal.py']
@@ -1325,7 +1325,7 @@ def _make_cal(g: networkx.MultiDiGraph,
         cal.transitions = CAPTURE_TRANSITIONS
         cal.final_state = CaptureBlockState.POSTPROCESSING
 
-        def make_cal_config(task: SDPPhysicalTask,
+        def make_cal_config(task: PhysicalTask,
                             resolver: 'product_controller.Resolver',
                             server_id: int = i) -> Dict[str, Any]:
             cal_config = {
@@ -1355,7 +1355,7 @@ def _make_cal(g: networkx.MultiDiGraph,
             # streams. This is used as a config= function, but instead of
             # returning config we just stash information in the task object
             # which is retrieved by make_cal_config.
-            def add_flags_endpoint(task: SDPPhysicalTask,
+            def add_flags_endpoint(task: PhysicalTask,
                                    resolver: 'product_controller.Resolver',
                                    endpoint: Endpoint,
                                    name: str = flags_stream.name) -> Dict[str, Any]:
@@ -1427,7 +1427,7 @@ def _make_vis_writer(g: networkx.MultiDiGraph,
                      max_channels: Optional[int] = None):
     output_name = prefix + '.' + stream.name if prefix is not None else stream.name
     g.graph['archived_streams'].append(output_name)
-    vis_writer = SDPLogicalTask('vis_writer.' + output_name, streams=[stream])
+    vis_writer = LogicalTask('vis_writer.' + output_name, streams=[stream])
     vis_writer.image = 'katsdpdatawriter'
     vis_writer.command = ['vis_writer.py']
     # Don't yet have a good idea of real CPU usage. For now assume that 32
@@ -1464,7 +1464,7 @@ def _make_vis_writer(g: networkx.MultiDiGraph,
         ])
     vis_writer.transitions = CAPTURE_TRANSITIONS
 
-    def make_vis_writer_config(task: SDPPhysicalTask,
+    def make_vis_writer_config(task: PhysicalTask,
                                resolver: 'product_controller.Resolver') -> Dict[str, Any]:
         conf = {
             'l0_name': stream.name,
@@ -1504,7 +1504,7 @@ def _make_flag_writer(g: networkx.MultiDiGraph,
                       max_channels: Optional[int] = None) -> scheduler.LogicalNode:
     output_name = prefix + '.' + stream.name if prefix is not None else stream.name
     g.graph['archived_streams'].append(output_name)
-    flag_writer = SDPLogicalTask('flag_writer.' + output_name, streams=[stream])
+    flag_writer = LogicalTask('flag_writer.' + output_name, streams=[stream])
     flag_writer.image = 'katsdpdatawriter'
     flag_writer.command = ['flag_writer.py']
 
@@ -1549,7 +1549,7 @@ def _make_flag_writer(g: networkx.MultiDiGraph,
         ]
     }
 
-    def make_flag_writer_config(task: SDPPhysicalTask,
+    def make_flag_writer_config(task: PhysicalTask,
                                 resolver: 'product_controller.Resolver') -> Dict[str, Any]:
         conf = {
             'flags_name': stream.name,
@@ -1600,7 +1600,7 @@ def _make_beamformer_engineering_pol(
         src_stream: product_config.TiedArrayChannelisedVoltageStreamBase,
         node_name: str,
         ram: bool,
-        idx: int) -> SDPLogicalTask:
+        idx: int) -> LogicalTask:
     """Generate node for a single polarisation of beamformer engineering output.
 
     This handles two cases: either it is a capture to file, associated with a
@@ -1632,7 +1632,7 @@ def _make_beamformer_engineering_pol(
     src_multicast = find_node(g, 'multicast.' + src_stream.name)
     assert isinstance(src_multicast, LogicalMulticast)
 
-    bf_ingest = SDPLogicalTask(node_name, streams=[stream] if stream is not None else [])
+    bf_ingest = LogicalTask(node_name, streams=[stream] if stream is not None else [])
     bf_ingest.image = 'katsdpbfingest'
     bf_ingest.command = ['schedrr', 'bf_ingest.py']
     bf_ingest.cpus = 2
@@ -1674,7 +1674,7 @@ def _make_beamformer_engineering_pol(
     bf_ingest.transitions = CAPTURE_TRANSITIONS
 
     def make_beamformer_engineering_pol_config(
-            task: SDPPhysicalTask,
+            task: PhysicalTask,
             resolver: 'product_controller.Resolver') -> Dict[str, Any]:
         config = {
             'affinity': [task.cores['disk'], task.cores['network']],
@@ -1712,14 +1712,8 @@ def _make_beamformer_engineering_pol(
 def _make_beamformer_engineering(
         g: networkx.MultiDiGraph,
         configuration: Configuration,
-        stream: product_config.BeamformerEngineeringStream) -> Sequence[scheduler.LogicalTask]:
-    """Generate nodes for beamformer engineering output.
-
-    If `timeplot` is true, it generates services that only send data to
-    timeplot servers, without capturing the data. In this case `name` may
-    refer to an ``sdp.beamformer`` rather than an
-    ``sdp.beamformer_engineering`` stream.
-    """
+        stream: product_config.BeamformerEngineeringStream) -> Sequence[LogicalTask]:
+    """Generate nodes for beamformer engineering output."""
     ram = stream.store == 'ram'
     nodes = []
     for i, src in enumerate(stream.tied_array_channelised_voltage):
@@ -1879,7 +1873,7 @@ def build_logical_graph(configuration: Configuration,
     # don't create it.
     need_telstate = False
     for node in g:
-        if isinstance(node, SDPLogicalTask):
+        if isinstance(node, LogicalTask):
             if node.pass_telstate or node.katsdpservices_config:
                 need_telstate = True
     if need_telstate:
@@ -1896,7 +1890,7 @@ def build_logical_graph(configuration: Configuration,
         telstate_extra += data.get('telstate_extra', 0)
     seen = set()
     for node in g:
-        if isinstance(node, SDPLogicalTask):
+        if isinstance(node, LogicalTask):
             assert node.name not in seen, "{} appears twice in graph".format(node.name)
             seen.add(node.name)
             assert node.image in IMAGES, "{} missing from IMAGES".format(node.image)
@@ -1937,13 +1931,14 @@ def build_logical_graph(configuration: Configuration,
             if force_host is not None:
                 node.host = force_host
     # For any tasks that don't pick a more specific fake implementation, use
-    # either SDPFakePhysicalTask or FakePhysicalTask depending on the original.
+    # either tasks.FakePhysicalTask or scheduler.FakePhysicalTask depending on
+    # the original.
     if configuration.options.interface_mode:
         for node in g:
             if node.physical_factory == scheduler.PhysicalTask:
                 node.physical_factory = scheduler.FakePhysicalTask
-            elif node.physical_factory == SDPPhysicalTask:
-                node.physical_factory = SDPFakePhysicalTask
+            elif node.physical_factory == PhysicalTask:
+                node.physical_factory = FakePhysicalTask
             elif issubclass(node.physical_factory, scheduler.PhysicalTask):
                 raise TypeError(f'{node.name} needs to specify a fake physical factory')
 
@@ -2078,7 +2073,7 @@ async def _make_continuum_imager(g: networkx.MultiDiGraph,
 
     for target, obs_time in targets:
         target_name = target_mapper(target)
-        imager = SDPLogicalTask(f'continuum_image.{stream.name}.{target_name}', streams=[stream])
+        imager = LogicalTask(f'continuum_image.{stream.name}.{target_name}', streams=[stream])
         imager.cpus = cpus
         # These resources are very rough estimates
         imager.mem = 50000 if not configuration.options.develop else 8000
@@ -2178,7 +2173,7 @@ async def _make_spectral_imager(g: networkx.MultiDiGraph,
                                    extra=dict(capture_block_id=capture_block_id))
                     continue
 
-            imager = SDPLogicalTask('spectral_image.{}.{:05}-{:05}.{}'.format(
+            imager = LogicalTask('spectral_image.{}.{:05}-{:05}.{}'.format(
                 stream.name, first_channel, last_channel, target_name), streams=[stream])
             imager.cpus = _spectral_imager_cpus(configuration)
             # TODO: these resources are very rough estimates. The disk
@@ -2256,7 +2251,7 @@ def _make_spectral_imager_report(
         stream: product_config.SpectralImageStream,
         data_url: str,
         spectral_nodes: Sequence[scheduler.LogicalNode]) -> scheduler.LogicalNode:
-    report = SDPLogicalTask(f'spectral_image_report.{stream.name}', streams=[stream])
+    report = LogicalTask(f'spectral_image_report.{stream.name}', streams=[stream])
     report.cpus = 1.0
     # Memory is a guess - but since we don't open the chunk store it should be lightweight
     report.mem = 4 * 1024
@@ -2309,7 +2304,7 @@ async def build_postprocess_logical_graph(
 
     seen = set()
     for node in g:
-        if isinstance(node, SDPLogicalTask):
+        if isinstance(node, LogicalTask):
             # TODO: most of this code is shared by _build_logical_graph
             assert node.name not in seen, "{} appears twice in graph".format(node.name)
             seen.add(node.name)

--- a/katsdpcontroller/generator.py
+++ b/katsdpcontroller/generator.py
@@ -29,7 +29,7 @@ from . import scheduler, product_config, defaults
 from .defaults import LOCALHOST
 from .fake_servers import FakeCalDeviceServer, FakeFgpuDeviceServer, FakeIngestDeviceServer
 from .tasks import (
-    LogicalTask, PhysicalTask, FakePhysicalTask,
+    ProductLogicalTask, ProductPhysicalTask, ProductFakePhysicalTask,
     LogicalGroup, CaptureBlockState, KatcpTransition)
 from .product_config import (
     BYTES_PER_VIS, BYTES_PER_FLAG, BYTES_PER_VFW, data_rate,
@@ -130,7 +130,7 @@ class PhysicalMulticast(scheduler.PhysicalExternal):
         self._endpoint_sensor.value = str(Endpoint(self.host, self.ports['spead']))
 
 
-class TelstateTask(PhysicalTask):
+class TelstateTask(ProductPhysicalTask):
     async def resolve(self, resolver, graph):
         await super().resolve(resolver, graph)
         # Add a port mapping
@@ -150,7 +150,7 @@ class TelstateTask(PhysicalTask):
             parameters.append({'key': 'publish', 'value': f'{LOCALHOST}:{host_port}:6379'})
 
 
-class IngestTask(PhysicalTask):
+class IngestTask(ProductPhysicalTask):
     async def resolve(self, resolver, graph, image_path=None):
         # In develop mode, the GPU can be anything, and we need to pick a
         # matching image.
@@ -193,7 +193,7 @@ def _make_telstate(g: networkx.MultiDiGraph,
         if isinstance(stream, product_config.AntennaChannelisedVoltageStreamBase):
             n_antennas += len(stream.antennas)
 
-    telstate = LogicalTask('telstate')
+    telstate = ProductLogicalTask('telstate')
     # redis is nominally single-threaded, but has some helper threads
     # for background tasks so can occasionally exceed 1 CPU.
     telstate.cpus = 1.2 if not configuration.options.develop else 0.2
@@ -206,7 +206,7 @@ def _make_telstate(g: networkx.MultiDiGraph,
         {'key': 'workdir', 'value': '/mnt/mesos/sandbox'})
     telstate.command = ['redis-server', '/usr/local/etc/redis/redis.conf']
     if configuration.options.interface_mode:
-        telstate.physical_factory = FakePhysicalTask
+        telstate.physical_factory = ProductFakePhysicalTask
     else:
         telstate.physical_factory = TelstateTask
     telstate.katsdpservices_logging = False
@@ -220,7 +220,7 @@ def _make_telstate(g: networkx.MultiDiGraph,
 def _make_cam2telstate(g: networkx.MultiDiGraph,
                        configuration: Configuration,
                        stream: product_config.CamHttpStream) -> scheduler.LogicalNode:
-    cam2telstate = LogicalTask('cam2telstate')
+    cam2telstate = ProductLogicalTask('cam2telstate')
     cam2telstate.image = 'katsdpcam2telstate'
     cam2telstate.command = ['cam2telstate.py']
     cam2telstate.cpus = 0.75
@@ -241,7 +241,7 @@ def _make_cam2telstate(g: networkx.MultiDiGraph,
 
 def _make_meta_writer(g: networkx.MultiDiGraph,
                       configuration: Configuration) -> scheduler.LogicalNode:
-    meta_writer = LogicalTask('meta_writer')
+    meta_writer = ProductLogicalTask('meta_writer')
     meta_writer.image = 'katsdpmetawriter'
     meta_writer.command = ['meta_writer.py']
     meta_writer.cpus = 0.2
@@ -303,7 +303,7 @@ def _make_dsim(
     # Generate a unique name. The caller groups streams by
     # (antenna.name, adc_sample_rate), so that is guaranteed to be unique.
     name = f'sim.{streams[0].antenna.name}.{streams[0].adc_sample_rate}'
-    dsim = LogicalTask(name, streams=streams)
+    dsim = ProductLogicalTask(name, streams=streams)
     dsim.image = 'katgpucbf'
     dsim.mem = 2048
     dsim.ports = ['port', 'prometheus']
@@ -442,7 +442,7 @@ def _make_fgpu(
 
     for i in range(0, n_engines):
         srcs = stream.sources(i)
-        fgpu = LogicalTask(f'f.{stream.name}.{i}', streams=[stream])
+        fgpu = ProductLogicalTask(f'f.{stream.name}.{i}', streams=[stream])
         fgpu.image = 'katgpucbf'
         fgpu.fake_katcp_server_cls = FakeFgpuDeviceServer
         fgpu.cpus = 4
@@ -647,7 +647,7 @@ def _make_xbgpu(
     send_buffer = vis_size * 5  # Magic number is default in XSend class
 
     for i in range(0, stream.n_substreams):
-        xbgpu = LogicalTask(f'xb.{stream.name}.{i}', streams=[stream])
+        xbgpu = ProductLogicalTask(f'xb.{stream.name}.{i}', streams=[stream])
         xbgpu.image = 'katgpucbf'
         xbgpu.cpus = 0.5 * bw_scale if configuration.options.develop else 1.5
         xbgpu.mem = 512 + _mb(recv_buffer + send_buffer)
@@ -760,7 +760,7 @@ def _make_cbf_simulator(g: networkx.MultiDiGraph,
             n_sim *= 2
     ibv = not configuration.options.develop
 
-    def make_cbf_simulator_config(task: PhysicalTask,
+    def make_cbf_simulator_config(task: ProductPhysicalTask,
                                   resolver: 'product_controller.Resolver') -> Dict[str, Any]:
         conf = {
             'cbf_channels': stream.n_chans,
@@ -803,7 +803,7 @@ def _make_cbf_simulator(g: networkx.MultiDiGraph,
     init_telstate[('sub', 'band')] = stream.antenna_channelised_voltage.band
 
     for i in range(n_sim):
-        sim = LogicalTask('sim.{}.{}'.format(stream.name, i + 1), streams=[stream])
+        sim = ProductLogicalTask('sim.{}.{}'.format(stream.name, i + 1), streams=[stream])
         sim.image = 'katcbfsim'
         # create-*-stream is passed on the command-line instead of telstate
         # for now due to SR-462.
@@ -872,7 +872,7 @@ def _make_timeplot(g: networkx.MultiDiGraph, name: str, description: str,
                    extra_config: dict) -> scheduler.LogicalNode:
     """Common backend code for creating a single timeplot server."""
     multicast = find_node(g, 'multicast.timeplot.' + name)
-    timeplot = LogicalTask('timeplot.' + name)
+    timeplot = ProductLogicalTask('timeplot.' + name)
     timeplot.image = 'katsdpdisp'
     timeplot.command = ['time_plot.py']
     timeplot.cpus = cpus
@@ -1128,9 +1128,9 @@ def _make_ingest(g: networkx.MultiDiGraph, configuration: Configuration,
                config=lambda task, resolver, endpoint: {'cbf_spead': str(endpoint)})
 
     for i in range(1, n_ingest + 1):
-        ingest = LogicalTask('ingest.{}.{}'.format(name, i), streams=streams)
+        ingest = ProductLogicalTask('ingest.{}.{}'.format(name, i), streams=streams)
         if configuration.options.interface_mode:
-            ingest.physical_factory = FakePhysicalTask
+            ingest.physical_factory = ProductFakePhysicalTask
         else:
             ingest.physical_factory = IngestTask
         ingest.fake_katcp_server_cls = FakeIngestDeviceServer
@@ -1170,7 +1170,7 @@ def _make_ingest(g: networkx.MultiDiGraph, configuration: Configuration,
             data_rate_out += continuum.data_rate()
         ingest.interfaces[1].bandwidth_out = data_rate_out / n_ingest
 
-        def make_ingest_config(task: PhysicalTask,
+        def make_ingest_config(task: ProductPhysicalTask,
                                resolver: 'product_controller.Resolver',
                                server_id: int = i) -> Dict[str, Any]:
             conf = {
@@ -1299,8 +1299,8 @@ def _make_cal(g: networkx.MultiDiGraph,
 
     dask_prefix = '/gui/{0.subarray_product.subarray_product_id}/{0.name}/cal-diagnostics'
     for i in range(1, n_cal + 1):
-        cal = LogicalTask('{}.{}'.format(stream.name, i),
-                          streams=(stream,) + tuple(flags_streams))
+        cal = ProductLogicalTask('{}.{}'.format(stream.name, i),
+                                 streams=(stream,) + tuple(flags_streams))
         cal.fake_katcp_server_cls = FakeCalDeviceServer
         cal.image = 'katsdpcal'
         cal.command = ['run_cal.py']
@@ -1325,7 +1325,7 @@ def _make_cal(g: networkx.MultiDiGraph,
         cal.transitions = CAPTURE_TRANSITIONS
         cal.final_state = CaptureBlockState.POSTPROCESSING
 
-        def make_cal_config(task: PhysicalTask,
+        def make_cal_config(task: ProductPhysicalTask,
                             resolver: 'product_controller.Resolver',
                             server_id: int = i) -> Dict[str, Any]:
             cal_config = {
@@ -1355,7 +1355,7 @@ def _make_cal(g: networkx.MultiDiGraph,
             # streams. This is used as a config= function, but instead of
             # returning config we just stash information in the task object
             # which is retrieved by make_cal_config.
-            def add_flags_endpoint(task: PhysicalTask,
+            def add_flags_endpoint(task: ProductPhysicalTask,
                                    resolver: 'product_controller.Resolver',
                                    endpoint: Endpoint,
                                    name: str = flags_stream.name) -> Dict[str, Any]:
@@ -1427,7 +1427,7 @@ def _make_vis_writer(g: networkx.MultiDiGraph,
                      max_channels: Optional[int] = None):
     output_name = prefix + '.' + stream.name if prefix is not None else stream.name
     g.graph['archived_streams'].append(output_name)
-    vis_writer = LogicalTask('vis_writer.' + output_name, streams=[stream])
+    vis_writer = ProductLogicalTask('vis_writer.' + output_name, streams=[stream])
     vis_writer.image = 'katsdpdatawriter'
     vis_writer.command = ['vis_writer.py']
     # Don't yet have a good idea of real CPU usage. For now assume that 32
@@ -1464,7 +1464,7 @@ def _make_vis_writer(g: networkx.MultiDiGraph,
         ])
     vis_writer.transitions = CAPTURE_TRANSITIONS
 
-    def make_vis_writer_config(task: PhysicalTask,
+    def make_vis_writer_config(task: ProductPhysicalTask,
                                resolver: 'product_controller.Resolver') -> Dict[str, Any]:
         conf = {
             'l0_name': stream.name,
@@ -1504,7 +1504,7 @@ def _make_flag_writer(g: networkx.MultiDiGraph,
                       max_channels: Optional[int] = None) -> scheduler.LogicalNode:
     output_name = prefix + '.' + stream.name if prefix is not None else stream.name
     g.graph['archived_streams'].append(output_name)
-    flag_writer = LogicalTask('flag_writer.' + output_name, streams=[stream])
+    flag_writer = ProductLogicalTask('flag_writer.' + output_name, streams=[stream])
     flag_writer.image = 'katsdpdatawriter'
     flag_writer.command = ['flag_writer.py']
 
@@ -1549,7 +1549,7 @@ def _make_flag_writer(g: networkx.MultiDiGraph,
         ]
     }
 
-    def make_flag_writer_config(task: PhysicalTask,
+    def make_flag_writer_config(task: ProductPhysicalTask,
                                 resolver: 'product_controller.Resolver') -> Dict[str, Any]:
         conf = {
             'flags_name': stream.name,
@@ -1600,7 +1600,7 @@ def _make_beamformer_engineering_pol(
         src_stream: product_config.TiedArrayChannelisedVoltageStreamBase,
         node_name: str,
         ram: bool,
-        idx: int) -> LogicalTask:
+        idx: int) -> ProductLogicalTask:
     """Generate node for a single polarisation of beamformer engineering output.
 
     This handles two cases: either it is a capture to file, associated with a
@@ -1632,7 +1632,7 @@ def _make_beamformer_engineering_pol(
     src_multicast = find_node(g, 'multicast.' + src_stream.name)
     assert isinstance(src_multicast, LogicalMulticast)
 
-    bf_ingest = LogicalTask(node_name, streams=[stream] if stream is not None else [])
+    bf_ingest = ProductLogicalTask(node_name, streams=[stream] if stream is not None else [])
     bf_ingest.image = 'katsdpbfingest'
     bf_ingest.command = ['schedrr', 'bf_ingest.py']
     bf_ingest.cpus = 2
@@ -1674,7 +1674,7 @@ def _make_beamformer_engineering_pol(
     bf_ingest.transitions = CAPTURE_TRANSITIONS
 
     def make_beamformer_engineering_pol_config(
-            task: PhysicalTask,
+            task: ProductPhysicalTask,
             resolver: 'product_controller.Resolver') -> Dict[str, Any]:
         config = {
             'affinity': [task.cores['disk'], task.cores['network']],
@@ -1712,7 +1712,7 @@ def _make_beamformer_engineering_pol(
 def _make_beamformer_engineering(
         g: networkx.MultiDiGraph,
         configuration: Configuration,
-        stream: product_config.BeamformerEngineeringStream) -> Sequence[LogicalTask]:
+        stream: product_config.BeamformerEngineeringStream) -> Sequence[scheduler.LogicalTask]:
     """Generate nodes for beamformer engineering output."""
     ram = stream.store == 'ram'
     nodes = []
@@ -1873,7 +1873,7 @@ def build_logical_graph(configuration: Configuration,
     # don't create it.
     need_telstate = False
     for node in g:
-        if isinstance(node, LogicalTask):
+        if isinstance(node, ProductLogicalTask):
             if node.pass_telstate or node.katsdpservices_config:
                 need_telstate = True
     if need_telstate:
@@ -1890,7 +1890,7 @@ def build_logical_graph(configuration: Configuration,
         telstate_extra += data.get('telstate_extra', 0)
     seen = set()
     for node in g:
-        if isinstance(node, LogicalTask):
+        if isinstance(node, ProductLogicalTask):
             assert node.name not in seen, "{} appears twice in graph".format(node.name)
             seen.add(node.name)
             assert node.image in IMAGES, "{} missing from IMAGES".format(node.image)
@@ -1931,14 +1931,14 @@ def build_logical_graph(configuration: Configuration,
             if force_host is not None:
                 node.host = force_host
     # For any tasks that don't pick a more specific fake implementation, use
-    # either tasks.FakePhysicalTask or scheduler.FakePhysicalTask depending on
+    # either ProductFakePhysicalTask or FakePhysicalTask depending on
     # the original.
     if configuration.options.interface_mode:
         for node in g:
             if node.physical_factory == scheduler.PhysicalTask:
                 node.physical_factory = scheduler.FakePhysicalTask
-            elif node.physical_factory == PhysicalTask:
-                node.physical_factory = FakePhysicalTask
+            elif node.physical_factory == ProductPhysicalTask:
+                node.physical_factory = ProductFakePhysicalTask
             elif issubclass(node.physical_factory, scheduler.PhysicalTask):
                 raise TypeError(f'{node.name} needs to specify a fake physical factory')
 
@@ -2073,7 +2073,8 @@ async def _make_continuum_imager(g: networkx.MultiDiGraph,
 
     for target, obs_time in targets:
         target_name = target_mapper(target)
-        imager = LogicalTask(f'continuum_image.{stream.name}.{target_name}', streams=[stream])
+        imager = ProductLogicalTask(
+            f'continuum_image.{stream.name}.{target_name}', streams=[stream])
         imager.cpus = cpus
         # These resources are very rough estimates
         imager.mem = 50000 if not configuration.options.develop else 8000
@@ -2173,7 +2174,7 @@ async def _make_spectral_imager(g: networkx.MultiDiGraph,
                                    extra=dict(capture_block_id=capture_block_id))
                     continue
 
-            imager = LogicalTask('spectral_image.{}.{:05}-{:05}.{}'.format(
+            imager = ProductLogicalTask('spectral_image.{}.{:05}-{:05}.{}'.format(
                 stream.name, first_channel, last_channel, target_name), streams=[stream])
             imager.cpus = _spectral_imager_cpus(configuration)
             # TODO: these resources are very rough estimates. The disk
@@ -2251,7 +2252,7 @@ def _make_spectral_imager_report(
         stream: product_config.SpectralImageStream,
         data_url: str,
         spectral_nodes: Sequence[scheduler.LogicalNode]) -> scheduler.LogicalNode:
-    report = LogicalTask(f'spectral_image_report.{stream.name}', streams=[stream])
+    report = ProductLogicalTask(f'spectral_image_report.{stream.name}', streams=[stream])
     report.cpus = 1.0
     # Memory is a guess - but since we don't open the chunk store it should be lightweight
     report.mem = 4 * 1024
@@ -2304,7 +2305,7 @@ async def build_postprocess_logical_graph(
 
     seen = set()
     for node in g:
-        if isinstance(node, LogicalTask):
+        if isinstance(node, ProductLogicalTask):
             # TODO: most of this code is shared by _build_logical_graph
             assert node.name not in seen, "{} appears twice in graph".format(node.name)
             seen.add(node.name)

--- a/katsdpcontroller/product_controller.py
+++ b/katsdpcontroller/product_controller.py
@@ -451,7 +451,7 @@ class SubarrayProduct:
             value = 0.0
             gauge_name = gauge.collect()[0].name
             for node in self.logical_graph:
-                if isinstance(node, tasks.SDPLogicalTask):
+                if isinstance(node, tasks.LogicalTask):
                     value += node.static_gauges.get(gauge_name, 0.0)
             gauge.set(value)
 
@@ -544,16 +544,16 @@ class SubarrayProduct:
         self, *,
         task_type: Optional[str] = None,
         streams: Optional[Iterable[product_config.Stream]] = None
-    ) -> Generator[tasks.SDPAnyPhysicalTask, None, None]:
+    ) -> Generator[tasks.AnyPhysicalTask, None, None]:
         """Find physical nodes matching given criteria.
 
         Parameters
         ----------
         task_type
-            The :attr:`.SDPLogicalTask.task_type` attribute of the logical
+            The :attr:`.tasks.LogicalTask.task_type` attribute of the logical
             node. If ``None``, any node can match.
         streams
-            Streams to match against the :attr:`.SDPLogicalTask.streams`
+            Streams to match against the :attr:`.tasks.LogicalTask.streams`
             attribute of the logical node. To match, there must be at least
             one stream name in the intersection (only the names are matched,
             not the identity). If ``None``, any node can match.
@@ -561,7 +561,7 @@ class SubarrayProduct:
         stream_names = frozenset(stream.name for stream in streams) if streams is not None else None
         for node in self.physical_graph:
             logical_node = node.logical_node
-            if not isinstance(logical_node, tasks.SDPLogicalTask):
+            if not isinstance(logical_node, tasks.LogicalTask):
                 continue
             if task_type is not None and task_type != logical_node.task_type:
                 continue
@@ -570,7 +570,7 @@ class SubarrayProduct:
                 continue
             yield node
 
-    async def _exec_node_transition(self, node: tasks.SDPPhysicalTask,
+    async def _exec_node_transition(self, node: tasks.PhysicalTask,
                                     reqs: Sequence[KatcpTransition],
                                     deps: Sequence[asyncio.Future],
                                     state: CaptureBlockState,
@@ -591,7 +591,7 @@ class SubarrayProduct:
                 else:
                     for req in reqs:
                         await node.issue_req(req.name, req.args, timeout=req.timeout)
-            if isinstance(node, tasks.SDPPhysicalTask) and state == node.logical_node.final_state:
+            if isinstance(node, tasks.PhysicalTask) and state == node.logical_node.final_state:
                 observer = node.capture_block_state_observer
                 if observer is not None:
                     logger.info('Waiting for %s on %s', capture_block.name, node.name)
@@ -600,7 +600,7 @@ class SubarrayProduct:
                 else:
                     logger.debug('Task %s has no capture-block-state observer', node.name)
         finally:
-            if isinstance(node, tasks.SDPPhysicalTask) and state == node.logical_node.final_state:
+            if isinstance(node, tasks.PhysicalTask) and state == node.logical_node.final_state:
                 node.remove_capture_block(capture_block)
 
     async def exec_transitions(self, state: CaptureBlockState, reverse: bool,
@@ -636,7 +636,7 @@ class SubarrayProduct:
             try:
                 reqs = node.get_transition(state)
             except AttributeError:
-                # Not all nodes are SDPPhysicalTask
+                # Not all nodes are tasks.PhysicalTask
                 pass
             if reqs:
                 # Apply {} substitutions to request data
@@ -658,7 +658,7 @@ class SubarrayProduct:
 
     async def _multi_request(
             self,
-            nodes: Iterable[tasks.SDPAnyPhysicalTask],
+            nodes: Iterable[tasks.AnyPhysicalTask],
             messages: Iterable[Iterable]) -> None:
         """Send katcp requests for multiple nodes in parallel.
 
@@ -844,7 +844,7 @@ class SubarrayProduct:
             ready.set()
         else:
             def must_wait(node):
-                return (isinstance(node.logical_node, tasks.SDPLogicalTask)
+                return (isinstance(node.logical_node, tasks.LogicalTask)
                         and node.logical_node.final_state <= CaptureBlockState.BURNDOWN)
             # Start the shutdown in a separate task, so that we can monitor
             # for task shutdown.
@@ -882,7 +882,7 @@ class SubarrayProduct:
         # will update the sensor with the value removed
         capture_block.state = CaptureBlockState.DEAD
         for node in self.physical_graph:
-            if isinstance(node, tasks.SDPPhysicalTask):
+            if isinstance(node, tasks.PhysicalTask):
                 node.remove_capture_block(capture_block)
 
     def _update_capture_block_sensor(self) -> None:
@@ -899,7 +899,7 @@ class SubarrayProduct:
             assert self.telstate is not None
             await self.telstate.add('sdp_capture_block_id', capture_block.name)
             for node in self.physical_graph:
-                if isinstance(node, tasks.SDPPhysicalTask):
+                if isinstance(node, tasks.PhysicalTask):
                     node.add_capture_block(capture_block)
             await self.exec_transitions(CaptureBlockState.CAPTURING, True, capture_block)
             if self.state == ProductState.ERROR:
@@ -1308,12 +1308,12 @@ class SubarrayProduct:
                 result = False
         return result, died
 
-    def unexpected_death(self, task: tasks.SDPAnyPhysicalTask) -> None:
+    def unexpected_death(self, task: tasks.AnyPhysicalTask) -> None:
         logger.warning('Task %s died unexpectedly', task.name)
         if task.logical_node.critical:
             self._go_to_error()
 
-    def bad_device_status(self, task: tasks.SDPAnyPhysicalTask) -> None:
+    def bad_device_status(self, task: tasks.AnyPhysicalTask) -> None:
         logger.warning('Task %s has failed (device-status)', task.name)
         if task.logical_node.critical:
             self._go_to_error()
@@ -1393,7 +1393,7 @@ class DeviceServer(aiokatcp.DeviceServer):
         self.shutdown_delay = shutdown_delay
 
         super().__init__(host, port)
-        # setup sensors (note: SDPProductController adds other sensors)
+        # setup sensors (note: ProductController adds other sensors)
         self.sensors.add(Sensor(DeviceStatus, "device-status",
                                 "Devices status of the subarray product controller",
                                 default=DeviceStatus.OK,
@@ -1524,7 +1524,7 @@ class DeviceServer(aiokatcp.DeviceServer):
             raise
 
     async def request_product_configure(self, ctx, name: str, config: str) -> None:
-        """Configure a SDP subarray product instance.
+        """Configure a subarray product instance.
 
         Parameters
         ----------

--- a/katsdpcontroller/tasks.py
+++ b/katsdpcontroller/tasks.py
@@ -103,7 +103,7 @@ class KatcpTransition(object):
     *args : str
         Request arguments. String arguments are passed through
         :meth:`str.format`: see
-        :meth:`.SDPSubarrayProduct.exec_transitions` for the keys that can
+        :meth:`.SubarrayProduct.exec_transitions` for the keys that can
         be substituted.
     timeout : float
         Maximum time to wait for the query to succeed.
@@ -141,7 +141,7 @@ class SDPLogicalTask(scheduler.LogicalTask):
         self.gui_urls = []
         # Overrides for sensor name remapping
         self.sensor_renames = {}
-        # Passes values to SDPSubarrayProduct to set as gauges
+        # Passes values to SubarrayProduct to set as gauges
         self.static_gauges: MutableMapping[str, float] = defaultdict(float)
         # Whether we should abort the capture block if the task fails
         self.critical = True

--- a/katsdpcontroller/templates/index.html.j2
+++ b/katsdpcontroller/templates/index.html.j2
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="icon" href="static/favicon.ico"/>
     <link rel="stylesheet" href="static/bootstrap-4.3.1.min.css"/>
-    <title>SDP GUIs</title>
+    <title>GUIs</title>
   </head>
   <body>
     <div class="container">

--- a/katsdpcontroller/templates/missing_gui.html.j2
+++ b/katsdpcontroller/templates/missing_gui.html.j2
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="stylesheet" href="/static/bootstrap-4.3.1.min.css"/>
-    <title>SDP GUIs</title>
+    <title>GUIs</title>
   </head>
   <body>
     <div class="container">

--- a/katsdpcontroller/test/test_master_controller.py
+++ b/katsdpcontroller/test/test_master_controller.py
@@ -137,7 +137,7 @@ class DummyServer(aiokatcp.DeviceServer):
         self.sensors.add(Sensor(str, "products", "JSON list of subarray products",
                                 default="[]", initial_status=Sensor.Status.NOMINAL))
         self.sensors.add(Sensor(DeviceStatus, "device-status",
-                                "Devices status of the SDP Master Controller",
+                                "Devices status of the Master Controller",
                                 default=DeviceStatus.OK,
                                 status_func=device_status_to_sensor_status))
 

--- a/katsdpcontroller/test/test_product_controller.py
+++ b/katsdpcontroller/test/test_product_controller.py
@@ -38,7 +38,7 @@ import yarl
 from ..consul import ConsulService
 from ..controller import device_server_sockname
 from ..product_controller import (
-    DeviceServer, SDPSubarrayProduct, SDPResources,
+    DeviceServer, SubarrayProduct, Resources,
     ProductState, DeviceStatus, _redact_keys, _normalise_s3_config, _relative_url)
 from .. import scheduler
 from . import fake_katportalclient
@@ -849,7 +849,7 @@ class TestSDPController(BaseTestSDPController):
         # Verify the state of the subarray
         product = self.server.product
         assert product is not None       # mypy doesn't understand self.assertIsNotNone
-        assert isinstance(product, SDPSubarrayProduct)  # For mypy's benefit
+        assert isinstance(product, SubarrayProduct)  # For mypy's benefit
         self.assertFalse(product.async_busy)
         self.assertEqual(ProductState.IDLE, product.state)
 
@@ -1140,7 +1140,7 @@ class TestSDPController(BaseTestSDPController):
         """Capture-init fails if an asynchronous operation is already in progress"""
         await self._test_busy("capture-init", CAPTURE_BLOCK)
 
-    def _ingest_died(self, subarray_product: SDPSubarrayProduct) -> None:
+    def _ingest_died(self, subarray_product: SubarrayProduct) -> None:
         """Mark an ingest process as having died"""
         for node in subarray_product.physical_graph:
             if node.logical_node.name == 'ingest.sdp_l0.1':
@@ -1150,7 +1150,7 @@ class TestSDPController(BaseTestSDPController):
         else:
             raise ValueError('Could not find ingest node')
 
-    def _ingest_bad_device_status(self, subarray_product: SDPSubarrayProduct) -> None:
+    def _ingest_bad_device_status(self, subarray_product: SubarrayProduct) -> None:
         """Mark an ingest process as having bad status"""
         sensor = self.server.sensors['ingest.sdp_l0.1.device-status']
         sensor.set_value(DeviceStatus.FAIL, Sensor.Status.ERROR)
@@ -1222,7 +1222,7 @@ class TestSDPController(BaseTestSDPController):
         await self._test_busy("capture-done")
 
     async def _test_failure_while_capturing(
-            self, failfunc: Callable[[SDPSubarrayProduct], None]) -> None:
+            self, failfunc: Callable[[SubarrayProduct], None]) -> None:
         await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
         await self.client.request("capture-init", CAPTURE_BLOCK)
         product = self.server.product
@@ -1513,8 +1513,8 @@ class TestSDPController(BaseTestSDPController):
         self._check_prom('histogram', 'foo', 'histogram', 0, 'histogram_bucket', {'le': '10.0'})
 
 
-class TestSDPResources(asynctest.TestCase):
-    """Test :class:`katsdpcontroller.product_controller.SDPResources`."""
+class TestResources(asynctest.TestCase):
+    """Test :class:`katsdpcontroller.product_controller.Resources`."""
 
     async def setUp(self):
         mc_server = DummyMasterController('127.0.0.1', 0)
@@ -1522,7 +1522,7 @@ class TestSDPResources(asynctest.TestCase):
         self.addCleanup(mc_server.stop)
         mc_address = device_server_sockname(mc_server)
         mc_client = await aiokatcp.Client.connect(mc_address[0], mc_address[1])
-        self.resources = SDPResources(mc_client, SUBARRAY_PRODUCT)
+        self.resources = Resources(mc_client, SUBARRAY_PRODUCT)
 
     async def test_get_multicast_groups(self):
         self.assertEqual('239.192.0.1', await self.resources.get_multicast_groups(1))

--- a/katsdpcontroller/test/test_product_controller.py
+++ b/katsdpcontroller/test/test_product_controller.py
@@ -294,7 +294,7 @@ class TestRelativeUrl(unittest.TestCase):
             _relative_url(yarl.URL('relative/url'), self.base)
 
 
-class BaseTestSDPController(asynctest.TestCase):
+class BaseTestController(asynctest.TestCase):
     """Utilities for test classes"""
 
     def _setup_model(self, model: katsdpmodels.models.Model,
@@ -429,8 +429,8 @@ class BaseTestSDPController(asynctest.TestCase):
 
 
 @timelimit
-class TestSDPControllerInterface(BaseTestSDPController):
-    """Testing of the SDP controller in interface mode."""
+class TestControllerInterface(BaseTestController):
+    """Testing of the controller in interface mode."""
 
     async def setUp(self) -> None:
         await super().setUp()
@@ -505,8 +505,8 @@ class TestSDPControllerInterface(BaseTestSDPController):
 
 
 @timelimit
-class TestSDPController(BaseTestSDPController):
-    """Test :class:`katsdpcontroller.sdpcontroller.SDPController` using
+class TestController(BaseTestController):
+    """Test :class:`katsdpcontroller.product_controller.DeviceServer` using
     mocking of the scheduler.
     """
     def _request_slow(self, name: str, *args: Any, cancelled: bool = False) -> DelayedManager:


### PR DESCRIPTION
The controller is no longer SDP-specific, being used for the new CBF as well. Update it to remove the "SDP" term from a number of classes, docstrings, web page titles etc. This should have no functional impact, and is just designed to reduce programmer and user confusion.

I'm not totally happy with changing `tasks.SDPLogicalTask` to `tasks.LogicalTask` because it now has the same base name as `scheduler.LogicalTask` (the same applies to PhysicalTask etc). If anyone has a better name to reflect that this is the version with extra sauce that is specific to the use case within the product controller rather than suitable for a general-purpose scheduler I'm open to suggestions.

Closes NGC-546.