### PR TITLE
Wait for CBF product controllers to die

### DIFF
--- a/katsdpcontroller/test/test_master_controller.py
+++ b/katsdpcontroller/test/test_master_controller.py
@@ -28,7 +28,7 @@ from ..master_controller import (ProductFailed, Product, SingularityProduct,
 from . import fake_zk, fake_singularity
 from .utils import (create_patch, assert_request_fails, assert_sensors, assert_sensor_value,
                     DelayedManager, Background, run_clocked,
-                    CONFIG, S3_CONFIG, EXPECTED_INTERFACE_SENSOR_LIST,
+                    CONFIG, CONFIG_CBF_ONLY, S3_CONFIG, EXPECTED_INTERFACE_SENSOR_LIST,
                     EXPECTED_PRODUCT_CONTROLLER_SENSOR_LIST)
 
 
@@ -781,6 +781,11 @@ class TestDeviceServer(asynctest.ClockedTestCase):
                 await self.client.request('product-reconfigure', 'product')
         # Check that the subarray was deconfigured cleanly
         self.assertEqual({}, self.server._manager.products)
+
+    async def test_product_configure_reuse_name(self) -> None:
+        await self.client.request('product-configure', 'product', CONFIG_CBF_ONLY)
+        await self.client.request('product-deconfigure', 'product')
+        await self.client.request('product-configure', 'product', CONFIG)
 
     async def test_help(self) -> None:
         reply, informs = await self.client.request('help')

--- a/katsdpcontroller/test/test_product_controller.py
+++ b/katsdpcontroller/test/test_product_controller.py
@@ -487,7 +487,8 @@ class TestControllerInterface(BaseTestController):
         # should not be able to deconfigure when not in idle state
         await assert_request_fails(self.client, "product-deconfigure")
         await self.client.request("capture-done")
-        await self.client.request("product-deconfigure")
+        reply, _informs = await self.client.request("product-deconfigure")
+        assert reply == [b'1']
         # server should now shut itself down
         await self.client.wait_disconnected()
 

--- a/katsdpcontroller/test/utils.py
+++ b/katsdpcontroller/test/utils.py
@@ -184,6 +184,51 @@ CONFIG = '''{
     "config": {}
 }'''     # noqa: E501
 
+CONFIG_CBF_ONLY = '''{
+    "version": "3.1",
+    "outputs": {
+        "gpucbf_m900v": {
+            "type": "sim.dig.raw_antenna_voltage",
+            "band": "l",
+            "adc_sample_rate": 1712000000.0,
+            "centre_frequency": 1284000000.0,
+            "antenna": "m900, 0:0:0, 0:0:0, 0, 0"
+        },
+        "gpucbf_m900h": {
+            "type": "sim.dig.raw_antenna_voltage",
+            "band": "l",
+            "adc_sample_rate": 1712000000.0,
+            "centre_frequency": 1284000000.0,
+            "antenna": "m900, 0:0:0, 0:0:0, 0, 0"
+        },
+        "gpucbf_m901v": {
+            "type": "sim.dig.raw_antenna_voltage",
+            "band": "l",
+            "adc_sample_rate": 1712000000.0,
+            "centre_frequency": 1284000000.0,
+            "antenna": "m901, 0:0:0, 0:0:0, 0, 0"
+        },
+        "gpucbf_m901h": {
+            "type": "sim.dig.raw_antenna_voltage",
+            "band": "l",
+            "adc_sample_rate": 1712000000.0,
+            "centre_frequency": 1284000000.0,
+            "antenna": "m901, 0:0:0, 0:0:0, 0, 0"
+        },
+        "gpucbf_antenna_channelised_voltage": {
+            "type": "gpucbf.antenna_channelised_voltage",
+            "src_streams": ["gpucbf_m900v", "gpucbf_m900h", "gpucbf_m901v", "gpucbf_m901h"],
+            "n_chans": 4096
+        },
+        "gpucbf_baseline_correlation_products": {
+            "type": "gpucbf.baseline_correlation_products",
+            "src_streams": ["gpucbf_antenna_channelised_voltage"],
+            "int_time": 0.5
+        }
+    },
+    "config": {}
+}'''
+
 S3_CONFIG = '''
 {
     "continuum": {


### PR DESCRIPTION
When a subarray product has no SDP components (specifically, components
that outlive product-deconfigure, but since telstate is one such, only
pure-CBF products are eligible), the product controller's
product-deconfigure will indicate this in its return value. The master
controller will then block until the product controller has died before
returning from product-configure. This ensures that the name can be
immediately reused.

Closes NGC-544
