### PR TITLE
Add support for "subsystems"

### DIFF
--- a/katsdpcontroller/scheduler.py
+++ b/katsdpcontroller/scheduler.py
@@ -175,6 +175,17 @@ agent). By default, the priority is the total number of volumes, interfaces and
 GPUs it has. This can be overridden by assigning a `katsdpcontroller.priority`
 scalar attribute. Ties are broken by amount of available memory.
 
+Subsystems
+----------
+It may be desirable to restrict particular sets of tasks to particular sets of
+agents for administrative reasons. Each task may be assigned to a "subsystem"
+(a string). Each agent may belong to a set of subsystems, or be unassigned and
+able to run any task. A task with an assigned subsystem will only run on
+agents belonging to that subsystem (or agents without assigned subsystems).
+The subsystems for an agent are specified by assigning a
+`katsdpcontroller.subsystems` attribute as a base64url-encoded JSON string
+conforming to :const:`katsdpcontroller.schemas.SUBSYSTEMS`.
+
 Setting up agents
 -----------------
 The previous sections list a number of resources and attributes that need to be

--- a/katsdpcontroller/schemas/subsystems.json
+++ b/katsdpcontroller/schemas/subsystems.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "array",
+    "items": {
+        "type": "string"
+    },
+    "uniqueItems": true
+}

--- a/scripts/agent_mkconfig.py
+++ b/scripts/agent_mkconfig.py
@@ -301,6 +301,9 @@ def attributes_resources(args):
     if args.priority is not None:
         attributes['katsdpcontroller.priority'] = args.priority
 
+    if args.subsystems:
+        attributes['katsdpcontroller.subsystems'] = args.subsystems
+
     attributes['katsdpcontroller.numa'] = hwloc.cpus_by_node()
     resources['cores'] = collapse_ranges(hwloc.cpu_nodes().keys())
     resources['cpus'] = float(len(hwloc.cpu_nodes())) - args.reserve_cpu
@@ -411,6 +414,8 @@ def main():
                         metavar='NAME:PATH[:NUMA]',
                         help='Map host directory to a logical volume name')
     parser.add_argument('--priority', type=float, help='Set agent priority for placement')
+    parser.add_argument('--subsystem', dest='subsystems', action='append', default=[],
+                        help='Restrict agent to a subsystem (can be repeated)')
     args = parser.parse_args()
 
     attributes, resources = attributes_resources(args)


### PR DESCRIPTION
This will allow some machines to be reserved for SDP and others for CBF,
so that each can evaluate their respective hardware without tasks
wandering between them.

I would have preferred to do this with Mesos roles since that would
allow more flexibility (e.g. could partition a single machine), but
trying to launch a single subarray across multiple roles seemed fraught
with complication. I think Mesos would offer shared resources to one or
the other role, and the scheduler would need to be smart enough to
decline it where necessary to allow them to be offered again with the
other role.