### PR TITLE
Remove old .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: python
-python:
-  - 2.7
-# command to install dependencies
-install: "pip install -r requirements.txt --use-mirrors"
-# command to run tests
-script: nosetests


### PR DESCRIPTION
We haven't used Travis for years - this is just a rememnant that
probably doesn't work anyway.
