### PR TITLE
Remove unittest.TestCase and asynctest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,1 +1,2 @@
 [pytest]
+asyncio_mode = auto

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ test =
     pytest
     pytest-asyncio
     pytest-mock
+    pytest-timeout
 
 [options.package_data]
 katsdpcontroller =

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ agent =
 
 test =
     aioresponses>=0.6.4
+    async-solipsism
     asynctest
     open-mock-file
     pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,6 @@ agent =
 test =
     aioresponses>=0.6.4
     async-solipsism
-    asynctest
     open-mock-file
     pytest
     pytest-asyncio

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,7 @@ test =
     asynctest
     open-mock-file
     pytest
+    pytest-asyncio
 
 [options.package_data]
 katsdpcontroller =

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ test =
     open-mock-file
     pytest
     pytest-asyncio
+    pytest-mock
 
 [options.package_data]
 katsdpcontroller =

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -930,7 +930,9 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
         except (scheduler.ImageError, aiohttp.ClientError, singularity.SingularityError) as exc:
             raise ProductFailed(f'Failed to start product controller: {exc}') from exc
         finally:
-            if not success:
+            if success:
+                product.configure_task = None   # Stops died() from trying to cancel us
+            else:
                 if task_id is not None:
                     # Make best effort to kill it; it might be dead already though
                     kill_task = loop.create_task(self._try_kill_task(task_id))

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -2510,11 +2510,16 @@ class FakePhysicalTask(PhysicalNode):
         # `allocate` but we don't have that method.
         for port_name in self.logical_node.ports:
             if port_name is not None:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP)
-                sock.bind((self.host, 0))
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
+                sock = self._create_socket(self.host, 0)
                 self._sockets[port_name] = sock
                 self.ports[port_name] = sock.getsockname()[1]
+
+    def _create_socket(self, host: str, port: int) -> socket.socket:
+        # This method is mocked by the unit tests, so do not inline it.
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP)
+        sock.bind((host, port))
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
+        return sock
 
     @staticmethod
     async def _connected_cb(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:

--- a/src/katsdpcontroller/test/fake_singularity.py
+++ b/src/katsdpcontroller/test/fake_singularity.py
@@ -192,7 +192,7 @@ async def default_lifecycle(task: Task,
 
 
 class SingularityServer:
-    def __init__(self) -> None:
+    def __init__(self, *, aiohttp_server_kwargs: Mapping = {}) -> None:
         app = aiohttp.web.Application()
         app.add_routes([
             aiohttp.web.get('/api/requests/request/{request_id}', self._get_request),
@@ -205,7 +205,7 @@ class SingularityServer:
             aiohttp.web.get('/api/tasks/ids/request/{request_id}', self._get_request_tasks),
             aiohttp.web.get('/api/track/run/{request_id}/{run_id}', self._track_run)
         ])
-        self.server = aiohttp.test_utils.TestServer(app)
+        self.server = aiohttp.test_utils.TestServer(app, **aiohttp_server_kwargs)
         # Each time a task is created, the next class is taken from this deque and
         # used to construct it's lifecycle controller.
         self.lifecycles: Deque[Lifecycle] = deque()

--- a/src/katsdpcontroller/test/test_product_controller.py
+++ b/src/katsdpcontroller/test/test_product_controller.py
@@ -1,6 +1,5 @@
 """Tests for :mod:`katsdpcontroller.product_controller."""
 
-import unittest
 from unittest import mock
 import copy
 import itertools
@@ -150,8 +149,8 @@ def get_metric(metric):
     return metric.collect()[0].samples[0][2]
 
 
-class TestRedactKeys(unittest.TestCase):
-    def setUp(self) -> None:
+class TestRedactKeys:
+    def setup(self) -> None:
         self.s3_config = {
             'archive': {
                 'read': {
@@ -186,7 +185,7 @@ class TestRedactKeys(unittest.TestCase):
         assert result == ['--secret', 'REDACTED', '--key', 'REDACTED', '--other', 'safe']
 
 
-class TestNormaliseS3Config(unittest.TestCase):
+class TestNormaliseS3Config:
     def test_single_url(self) -> None:
         s3_config = {
             'archive': {
@@ -243,8 +242,8 @@ class TestNormaliseS3Config(unittest.TestCase):
         assert result == expected
 
 
-class TestRelativeUrl(unittest.TestCase):
-    def setUp(self):
+class TestRelativeUrl:
+    def setup(self):
         self.base = yarl.URL('http://test.invalid/foo/bar/')
 
     def test_success(self):

--- a/src/katsdpcontroller/test/test_product_controller.py
+++ b/src/katsdpcontroller/test/test_product_controller.py
@@ -2,6 +2,7 @@
 
 from unittest import mock
 import copy
+import functools
 import itertools
 import json
 import asyncio
@@ -10,9 +11,8 @@ import io
 from socket import getaddrinfo
 import ipaddress
 import typing
-from typing import List, Tuple, Set, Callable, Sequence, Mapping, Any
+from typing import List, Tuple, Set, Callable, Sequence, Mapping, Any, Generator, AsyncGenerator
 
-import asynctest
 from aioresponses import aioresponses
 import astropy.table
 import astropy.units as u
@@ -39,10 +39,10 @@ from ..controller import device_server_sockname
 from ..product_controller import (
     DeviceServer, SubarrayProduct, Resources,
     ProductState, DeviceStatus, _redact_keys, _normalise_s3_config, _relative_url)
-from .. import scheduler
+from .. import scheduler, sensor_proxy
 from . import fake_katportalclient
-from .utils import (create_patch, assert_request_fails, assert_sensor_value,
-                    assert_sensors, timelimit, DelayedManager,
+from .utils import (assert_request_fails, assert_sensor_value,
+                    assert_sensors, exhaust_callbacks, DelayedManager,
                     CONFIG, S3_CONFIG, EXPECTED_INTERFACE_SENSOR_LIST,
                     EXPECTED_PRODUCT_CONTROLLER_SENSOR_LIST)
 
@@ -293,32 +293,37 @@ class TestRelativeUrl:
             _relative_url(yarl.URL('relative/url'), self.base)
 
 
-class BaseTestController(asynctest.TestCase):
+class BaseTestController:
     """Utilities for test classes"""
 
-    def _setup_model(self, model: katsdpmodels.models.Model,
-                     current_path: str,
-                     config_path: str,
-                     fixed_path: str) -> None:
-        fh = io.BytesIO()
-        model.to_file(fh, content_type='application/x-hdf5')
-        self.aioresponses.get(
-            f'https://models.s3.invalid{current_path}',
-            content_type='text/plain',
-            body=f'{config_path}\n'
-        )
-        self.aioresponses.get(
-            f'https://models.s3.invalid{config_path}',
-            content_type='text/plain',
-            body=f'{fixed_path}\n'
-        )
-        self.aioresponses.get(
-            f'https://models.s3.invalid{fixed_path}',
-            content_type='application/x-hdf5',
-            body=fh.getvalue()
-        )
+    @pytest.fixture
+    def setup_model(self, mock_aioresponses: aioresponses) -> \
+            Callable[[katsdpmodels.models.Model, str, str, str], None]:
+        def _setup_model(model: katsdpmodels.models.Model,
+                         current_path: str,
+                         config_path: str,
+                         fixed_path: str) -> None:
+            fh = io.BytesIO()
+            model.to_file(fh, content_type='application/x-hdf5')
+            mock_aioresponses.get(
+                f'https://models.s3.invalid{current_path}',
+                content_type='text/plain',
+                body=f'{config_path}\n'
+            )
+            mock_aioresponses.get(
+                f'https://models.s3.invalid{config_path}',
+                content_type='text/plain',
+                body=f'{fixed_path}\n'
+            )
+            mock_aioresponses.get(
+                f'https://models.s3.invalid{fixed_path}',
+                content_type='application/x-hdf5',
+                body=fh.getvalue()
+            )
+        return _setup_model
 
-    def _setup_rfi_mask_model(self) -> None:
+    @pytest.fixture(autouse=True)
+    def _setup_rfi_mask_model(self, setup_model) -> None:
         model = katsdpmodels.rfi_mask.RFIMaskRanges(
             astropy.table.Table(
                 [[0.0] * u.Hz, [0.0] * u.Hz, [0.0] * u.m],
@@ -327,14 +332,15 @@ class BaseTestController(asynctest.TestCase):
             False
         )
         model.version = 1
-        self._setup_model(
+        setup_model(
             model,
             '/models/rfi_mask/current.alias',
             '/models/rfi_mask/config/2020-06-15.alias',
             '/models/rfi_mask/fixed/test.h5'
         )
 
-    def _setup_band_mask_model(self) -> None:
+    @pytest.fixture(autouse=True)
+    def _setup_band_mask_model(self, setup_model) -> None:
         model = katsdpmodels.band_mask.BandMaskRanges(
             astropy.table.Table(
                 rows=[[0.0, 0.05], [0.95, 1.0]],
@@ -342,14 +348,15 @@ class BaseTestController(asynctest.TestCase):
             )
         )
         model.version = 1
-        self._setup_model(
+        setup_model(
             model,
             '/models/band_mask/current/l/nb_ratio=1.alias',
             '/models/band_mask/config/l/nb_ratio=1/2020-06-22.alias',
             '/models/band_mask/fixed/test.h5'
         )
 
-    def _setup_primary_beam_model(self) -> None:
+    @pytest.fixture(autouse=True)
+    def _setup_primary_beam_model(self, setup_model) -> None:
         # Model is not used for anything, so do a minimal amount to get it working.
         model = katsdpmodels.primary_beam.PrimaryBeamAperturePlane(
             -1 * u.m, -1 * u.m,
@@ -360,42 +367,72 @@ class BaseTestController(asynctest.TestCase):
         model.version = 1
         for antenna in ANTENNAS:
             for group in ['individual', 'cohort']:
-                self._setup_model(
+                setup_model(
                     model,
                     f'/models/primary_beam/current/{group}/{antenna}/l.alias',
                     '/models/primary_beam/config/cohort/meerkat/l/v1.alias',
                     '/models/primary_beam/fixed/test.h5'
                 )
 
-    async def setup_server(self, **server_kwargs) -> None:
+    @pytest.fixture
+    async def mc_server(self) -> AsyncGenerator[DummyMasterController, None]:
         mc_server = DummyMasterController('127.0.0.1', 0)
         await mc_server.start()
-        self.addCleanup(mc_server.stop)
+        yield mc_server
+        await mc_server.stop()
+
+    @pytest.fixture
+    async def mc_client(self, mc_server) -> AsyncGenerator[aiokatcp.Client, None]:
         mc_address = device_server_sockname(mc_server)
         mc_client = await aiokatcp.Client.connect(mc_address[0], mc_address[1])
-        self.addCleanup(mc_client.wait_closed)
-        self.addCleanup(mc_client.close)
-        self.prometheus_registry = CollectorRegistry()
+        yield mc_client
+        mc_client.close()
+        await mc_client.wait_closed()
 
+    @pytest.fixture(autouse=True)
+    def mock_aioresponses(self) -> Generator[aioresponses, None, None]:
+        with aioresponses() as rmock:
+            yield rmock
+
+    @pytest.fixture(autouse=True)
+    def mock_consul(self, mocker) -> None:
+        # server.start will try to register with consul. Mock that out.
+        mocker.patch(
+            'katsdpcontroller.consul.ConsulService.register',
+            return_value=ConsulService(),
+            autospec=True
+        )
+
+    @pytest.fixture
+    def registry(self) -> CollectorRegistry:
+        return CollectorRegistry()
+
+    @pytest.fixture
+    async def server(
+            self, mc_client, mc_server, mock_aioresponses, mock_consul,
+            registry, server_kwargs) -> AsyncGenerator[DeviceServer, None]:
         if 'sched' not in server_kwargs:
             server_kwargs['sched'] = scheduler.SchedulerBase('realtime', '127.0.0.1', 0)
-        self.server = DeviceServer(
+        server = DeviceServer(
             master_controller=mc_client,
             subarray_product_id=SUBARRAY_PRODUCT,
-            prometheus_registry=self.prometheus_registry,
+            prometheus_registry=registry,
             shutdown_delay=0.0,
             **server_kwargs)
-        self._setup_rfi_mask_model()
-        self._setup_band_mask_model()
-        self._setup_primary_beam_model()
-        await self.server.start()
-        self.addCleanup(self.server.stop)
-        bind_address = device_server_sockname(self.server)
-        self.client = await aiokatcp.Client.connect(bind_address[0], bind_address[1])
-        self.addCleanup(self.client.wait_closed)
-        self.addCleanup(self.client.close)
+        await server.start()
+        yield server
+        await server.stop()
 
-    async def setUp(self) -> None:
+    @pytest.fixture
+    async def client(self, server: DeviceServer) -> AsyncGenerator[aiokatcp.Client, None]:
+        bind_address = device_server_sockname(server)
+        client = await aiokatcp.Client.connect(bind_address[0], bind_address[1])
+        yield client
+        client.close()
+        await client.wait_closed()
+
+    @pytest.fixture(autouse=True)
+    def mock_katportalclient(self, mocker) -> None:
         # Mock the CBF sensors
         dummy_client = fake_katportalclient.KATPortalClient(
             components={'cbf': 'cbf_1', 'sub': 'subarray_1'},
@@ -414,171 +451,164 @@ class BaseTestController(asynctest.TestCase):
                 'cbf_1_i0_tied_array_channelised_voltage_0y_n_chans_per_substream': 256,
                 'cbf_1_i0_tied_array_channelised_voltage_0y_beng_out_bits_per_sample': 8
             })
-        create_patch(self, 'katportalclient.KATPortalClient', return_value=dummy_client)
-        # server.start will try to register with consul. Mock that out.
-        create_patch(
-            self, 'katsdpcontroller.consul.ConsulService.register',
-            return_value=ConsulService(),
-            autospec=True
-        )
-        # Provide tests with aioresponses
-        self.aioresponses = aioresponses()
-        self.aioresponses.start()
-        self.addCleanup(self.aioresponses.stop)
+        mocker.patch('katportalclient.KATPortalClient', return_value=dummy_client)
 
 
-@timelimit
+@pytest.mark.timeout(5)
 class TestControllerInterface(BaseTestController):
     """Testing of the controller in interface mode."""
 
-    async def setUp(self) -> None:
-        await super().setUp()
+    @pytest.fixture
+    def server_kwargs(self) -> dict:
         image_resolver_factory = scheduler.ImageResolverFactory(scheduler.SimpleImageLookup('sdp'))
-        await self.setup_server(host='127.0.0.1', port=0,
-                                batch_role='batch',
-                                interface_mode=True,
-                                localhost=True,
-                                image_resolver_factory=image_resolver_factory,
-                                s3_config={})
-        create_patch(self, 'time.time', return_value=123456789.5)
+        return dict(host='127.0.0.1', port=0,
+                    batch_role='batch',
+                    interface_mode=True,
+                    localhost=True,
+                    image_resolver_factory=image_resolver_factory,
+                    s3_config={})
 
-    async def test_capture_init(self) -> None:
-        await assert_request_fails(self.client, "capture-init", CAPTURE_BLOCK)
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
-        await self.client.request("capture-init", CAPTURE_BLOCK)
+    @pytest.fixture(autouse=True)
+    def mock_time(self, mocker) -> None:
+        mocker.patch('time.time', return_value=123456789.5)
 
-        reply, informs = await self.client.request("capture-status")
+    async def test_capture_init(self, client: aiokatcp.Client) -> None:
+        await assert_request_fails(client, "capture-init", CAPTURE_BLOCK)
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        await client.request("capture-init", CAPTURE_BLOCK)
+
+        reply, informs = await client.request("capture-status")
         assert reply == [b"capturing"]
-        await assert_request_fails(self.client, "capture-init", CAPTURE_BLOCK)
+        await assert_request_fails(client, "capture-init", CAPTURE_BLOCK)
 
-    async def test_interface_sensors(self) -> None:
-        await assert_sensors(self.client, EXPECTED_PRODUCT_CONTROLLER_SENSOR_LIST)
+    async def test_interface_sensors(self, client: aiokatcp.Client) -> None:
+        await assert_sensors(client, EXPECTED_PRODUCT_CONTROLLER_SENSOR_LIST)
         interface_changed_callback = mock.MagicMock()
-        self.client.add_inform_callback('interface-changed', interface_changed_callback)
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        client.add_inform_callback('interface-changed', interface_changed_callback)
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
         interface_changed_callback.assert_called_with(b'sensor-list')
         await assert_sensors(
-            self.client,
+            client,
             EXPECTED_PRODUCT_CONTROLLER_SENSOR_LIST + EXPECTED_INTERFACE_SENSOR_LIST,
             subset=True)
 
         # Deconfigure and check that the server shuts down
         interface_changed_callback.reset_mock()
-        await self.client.request("product-deconfigure")
+        await client.request("product-deconfigure")
         interface_changed_callback.assert_called_with(b'sensor-list')
-        await self.client.wait_disconnected()
-        self.client.remove_inform_callback('interface-changed', interface_changed_callback)
+        await client.wait_disconnected()
+        client.remove_inform_callback('interface-changed', interface_changed_callback)
 
-    async def test_capture_done(self) -> None:
-        await assert_request_fails(self.client, "capture-done")
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
-        await assert_request_fails(self.client, "capture-done")
+    async def test_capture_done(self, client: aiokatcp.Client) -> None:
+        await assert_request_fails(client, "capture-done")
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        await assert_request_fails(client, "capture-done")
 
-        await self.client.request("capture-init", CAPTURE_BLOCK)
-        reply, informs = await self.client.request("capture-done")
+        await client.request("capture-init", CAPTURE_BLOCK)
+        reply, informs = await client.request("capture-done")
         assert reply == [CAPTURE_BLOCK.encode()]
-        await assert_request_fails(self.client, "capture-done")
+        await assert_request_fails(client, "capture-done")
 
-    async def test_deconfigure_subarray_product(self) -> None:
-        await assert_request_fails(self.client, "product-configure")
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
-        await self.client.request("capture-init", CAPTURE_BLOCK)
+    async def test_deconfigure_subarray_product(self, client: aiokatcp.Client) -> None:
+        await assert_request_fails(client, "product-configure")
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        await client.request("capture-init", CAPTURE_BLOCK)
         # should not be able to deconfigure when not in idle state
-        await assert_request_fails(self.client, "product-deconfigure")
-        await self.client.request("capture-done")
-        reply, _informs = await self.client.request("product-deconfigure")
+        await assert_request_fails(client, "product-deconfigure")
+        await client.request("capture-done")
+        reply, _informs = await client.request("product-deconfigure")
         assert reply == [b'1']
         # server should now shut itself down
-        await self.client.wait_disconnected()
+        await client.wait_disconnected()
 
-    async def test_configure_subarray_product(self) -> None:
-        await assert_request_fails(self.client, "product-deconfigure")
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+    async def test_configure_subarray_product(self, client: aiokatcp.Client) -> None:
+        await assert_request_fails(client, "product-deconfigure")
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
         # Can't reconfigure when already configured
-        await assert_request_fails(self.client, "product-configure", SUBARRAY_PRODUCT, CONFIG)
-        await self.client.request("product-deconfigure")
+        await assert_request_fails(client, "product-configure", SUBARRAY_PRODUCT, CONFIG)
+        await client.request("product-deconfigure")
 
-    async def test_help(self) -> None:
-        reply, informs = await self.client.request('help')
+    async def test_help(self, client: aiokatcp.Client) -> None:
+        reply, informs = await client.request('help')
         requests = [inform.arguments[0].decode('utf-8') for inform in informs]
         assert set(EXPECTED_REQUEST_LIST) == set(requests)
 
-    async def test_gain_single(self) -> None:
+    async def test_gain_single(self, client: aiokatcp.Client) -> None:
         """Test gain with a single gain to apply to all channels."""
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
-        reply, _ = await self.client.request(
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        reply, _ = await client.request(
             'gain', 'gpucbf_antenna_channelised_voltage', 'gpucbf_m901h', '1+2j')
         assert reply == [b'1.0+2.0j']
         await assert_sensor_value(
-            self.client,
+            client,
             'gpucbf_antenna_channelised_voltage-gpucbf_m901h-eq',
             '[1.0+2.0j]'
         )
-        await self.client.request("product-deconfigure")
+        await client.request("product-deconfigure")
 
-    async def test_gain_multi(self) -> None:
+    async def test_gain_multi(self, client: aiokatcp.Client) -> None:
         """Test gain with a different gain for each channel."""
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
         gains = [b'%d.0+2.0j' % i for i in range(4096)]
-        reply, _ = await self.client.request(
+        reply, _ = await client.request(
             'gain', 'gpucbf_antenna_channelised_voltage', 'gpucbf_m901h', *gains)
         assert reply == gains
         await assert_sensor_value(
-            self.client,
+            client,
             'gpucbf_antenna_channelised_voltage-gpucbf_m901h-eq',
             '[' + ', '.join(g.decode() for g in gains) + ']'
         )
-        await self.client.request("product-deconfigure")
+        await client.request("product-deconfigure")
 
-    async def test_gain_all_single(self) -> None:
+    async def test_gain_all_single(self, client: aiokatcp.Client) -> None:
         """Test gain-all with a single gain to apply to all channels."""
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
-        await self.client.request(
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        await client.request(
             'gain-all', 'gpucbf_antenna_channelised_voltage', '1.0+2.0j')
         for name in ['gpucbf_m900v', 'gpucbf_m900h', 'gpucbf_m901v', 'gpucbf_m901h']:
             await assert_sensor_value(
-                self.client,
+                client,
                 f'gpucbf_antenna_channelised_voltage-{name}-eq',
                 '[1.0+2.0j]'
             )
-        await self.client.request("product-deconfigure")
+        await client.request("product-deconfigure")
 
-    async def test_gain_all_multi(self) -> None:
+    async def test_gain_all_multi(self, client: aiokatcp.Client) -> None:
         """Test gain-all with a different gain for each channel."""
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
         gains = [b'%d.0+2.0j' % i for i in range(4096)]
-        await self.client.request(
+        await client.request(
             'gain-all', 'gpucbf_antenna_channelised_voltage', *gains)
         for name in ['gpucbf_m900v', 'gpucbf_m900h', 'gpucbf_m901v', 'gpucbf_m901h']:
             await assert_sensor_value(
-                self.client,
+                client,
                 f'gpucbf_antenna_channelised_voltage-{name}-eq',
                 '[' + ', '.join(g.decode() for g in gains) + ']'
             )
-        await self.client.request("product-deconfigure")
+        await client.request("product-deconfigure")
 
-    async def test_gain_all_default(self) -> None:
+    async def test_gain_all_default(self, client: aiokatcp.Client) -> None:
         """Test setting gains to default with gain-all."""
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
-        await self.client.request(
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        await client.request(
             'gain-all', 'gpucbf_antenna_channelised_voltage', 'default')
         for name in ['gpucbf_m900v', 'gpucbf_m900h', 'gpucbf_m901v', 'gpucbf_m901h']:
             await assert_sensor_value(
-                self.client,
+                client,
                 f'gpucbf_antenna_channelised_voltage-{name}-eq',
                 '[1.0+0.0j]'
             )
-        await self.client.request("product-deconfigure")
+        await client.request("product-deconfigure")
 
-    async def test_delays(self) -> None:
+    async def test_delays(self, client: aiokatcp.Client) -> None:
         """Test setting delays and retrieving the sensor."""
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
         await assert_sensor_value(
-            self.client,
+            client,
             'gpucbf_antenna_channelised_voltage-sync-time',
             123456789.0   # Just to detect any change in sync time logic in generator.py
         )
-        await self.client.request(
+        await client.request(
             'delays', 'gpucbf_antenna_channelised_voltage', '123456791.5',
             '0.5,0.0:0.0,0.0',
             '0.0,0.125:0.0,0.0',
@@ -586,158 +616,47 @@ class TestControllerInterface(BaseTestController):
             '0.0,0.0:0.0,1.0'
         )
         await assert_sensor_value(
-            self.client,
+            client,
             'gpucbf_antenna_channelised_voltage-gpucbf_m900v-delay',
             '(4280000000, 0.5, 0.0, 0.0, 0.0)'
         )
         await assert_sensor_value(
-            self.client,
+            client,
             'gpucbf_antenna_channelised_voltage-gpucbf_m900h-delay',
             '(4280000000, 0.0, 0.125, 0.0, 0.0)'
         )
         await assert_sensor_value(
-            self.client,
+            client,
             'gpucbf_antenna_channelised_voltage-gpucbf_m901v-delay',
             '(4280000000, 0.0, 0.0, 0.25, 0.0)'
         )
         await assert_sensor_value(
-            self.client,
+            client,
             'gpucbf_antenna_channelised_voltage-gpucbf_m901h-delay',
             '(4280000000, 0.0, 0.0, 0.0, 1.0)'
         )
-        await self.client.request("product-deconfigure")
+        await client.request("product-deconfigure")
 
 
-@timelimit
-class TestController(BaseTestController):
-    """Test :class:`katsdpcontroller.product_controller.DeviceServer` using
-    mocking of the scheduler.
+class DummyScheduler:
+    """Implements some functionality needed to mock a :class:`.Scheduler`.
+
+    It doesn't provide all the methods. Instead, a mock scheduler is created
+    by mocking the original scheduler and setting methods from this class as
+    side effects on its methods.
     """
-    def _request_slow(self, name: str, *args: Any, cancelled: bool = False) -> DelayedManager:
-        """Asynchronous context manager that runs its block with a request in progress.
 
-        The request must operate by issuing requests to the tasks, as this is
-        used to block it from completing.
-        """
-        sensor_proxy_client = self.sensor_proxy_client_class.return_value
-        return DelayedManager(
-            self.client.request(name, *args),
-            sensor_proxy_client.request,
-            ([], []),
-            cancelled)
-
-    def _capture_init_slow(self, capture_block: str, cancelled: bool = False) -> DelayedManager:
-        """Asynchronous context manager that runs its block with a capture-init
-        in progress. The subarray product must already be configured.
-        """
-        return self._request_slow('capture-init', capture_block, cancelled=cancelled)
-
-    def _capture_done_slow(self, cancelled: bool = False) -> DelayedManager:
-        """Asynchronous context manager that runs its block with a capture-done
-        in progress. The subarray product must already be configured and
-        capturing.
-        """
-        return self._request_slow('capture-done', cancelled=cancelled)
-
-    def _product_configure_slow(self, subarray_product: str,
-                                cancelled: bool = False) -> DelayedManager:
-        """Asynchronous context manager that runs its block with a
-        product-configure in progress.
-        """
-        sensor_proxy_client = self.sensor_proxy_client_class.return_value
-        return DelayedManager(
-            self.client.request(*self._configure_args(subarray_product)),
-            sensor_proxy_client.wait_synced,
-            None, cancelled)
-
-    # The return annotation is deliberately vague because typeshed changed
-    # its annotation at some point and so any more specific annotation will
-    # error out on *some* version of mypy.
-    def _getaddrinfo(self, host: str, *args, **kwargs) -> List[Any]:
-        """Mock getaddrinfo that replaces all hosts with a dummy IP address"""
-        if host.startswith('host'):
-            host = '127.0.0.2'
-        return getaddrinfo(host, *args, **kwargs)
-
-    async def setUp(self) -> None:
-        await super().setUp()
-        # Future that is already resolved with no return value
-        done_future: asyncio.Future[None] = asyncio.Future()
-        done_future.set_result(None)
-        create_patch(self, 'time.time', return_value=123456789.5)
-        create_patch(self, 'socket.getaddrinfo', side_effect=self._getaddrinfo)
-
-        # We don't have a delay_run.sh to abort when told to, so we need to
-        # ensure that dependency_abort actually kills the task.
-        orig_dependency_abort = scheduler.PhysicalTask.dependency_abort
-
-        def _dependency_abort(task: scheduler.PhysicalTask) -> None:
-            orig_dependency_abort(task)
-            asyncio.get_event_loop().call_soon(task.set_state, scheduler.TaskState.DEAD)
-        create_patch(self, 'katsdpcontroller.scheduler.PhysicalTask.dependency_abort',
-                     side_effect=_dependency_abort, autospec=True)
-
-        # Mock RedisBackend to create an in-memory telstate instead
-        self.telstate = katsdptelstate.aio.TelescopeState()
-        self.backend_from_url_mock = create_patch(
-            self, 'katsdptelstate.aio.redis.RedisBackend.from_url',
-            return_value=self.telstate.backend, autospec=True)
-
-        self.sensor_proxy_client_class = create_patch(
-            self, 'katsdpcontroller.sensor_proxy.SensorProxyClient', autospec=True)
-        sensor_proxy_client = self.sensor_proxy_client_class.return_value
-        sensor_proxy_client.wait_connected.return_value = done_future
-        sensor_proxy_client.wait_synced.return_value = done_future
-        sensor_proxy_client.wait_closed.return_value = done_future
-        sensor_proxy_client.request.side_effect = self._request
-        create_patch(
-            self, 'katsdpcontroller.scheduler.poll_ports', autospec=True, return_value=done_future)
-        create_patch(self, 'netifaces.interfaces', autospec=True, return_value=['lo', 'em1'])
-        create_patch(self, 'netifaces.ifaddresses', autospec=True, side_effect=self._ifaddresses)
-        self.sched = mock.create_autospec(spec=scheduler.Scheduler, instance=True)
-        self.sched.launch.side_effect = self._launch
-        self.sched.kill.side_effect = self._kill
-        self.sched.batch_run.side_effect = self._batch_run
+    def __init__(self) -> None:
         self.n_batch_tasks = 0
-        self.sched.close.return_value = done_future
-        self.sched.http_url = 'http://scheduler:8080/'
-        self.sched.http_port = 8080
-        self.sched.task_stats = scheduler.TaskStats()
         self.driver = mock.create_autospec(spec=pymesos.MesosSchedulerDriver, instance=True)
-        await self.setup_server(
-            host='127.0.0.1', port=0, sched=self.sched,
-            s3_config=json.loads(S3_CONFIG),
-            image_resolver_factory=scheduler.ImageResolverFactory(
-                scheduler.SimpleImageLookup('sdp')),
-            interface_mode=False,
-            localhost=True,
-            batch_role='batch')
-        # Creating the sensor here isn't quite accurate (it is a dynamic sensor
-        # created on subarray activation), but it shouldn't matter.
-        self.server.sensors.add(Sensor(
-            bytes, 'cal.1.capture-block-state',
-            'Dummy implementation of sensor', default=b'{}',
-            initial_status=Sensor.Status.NOMINAL))
-        self.server.sensors.add(Sensor(
-            DeviceStatus, 'ingest.sdp_l0.1.device-status',
-            'Dummy implementation of sensor',
-            initial_status=Sensor.Status.NOMINAL))
         # Dict mapping task name to Mesos task status string
         self.fail_launches: typing.Dict[str, str] = {}
-        # Set of katcp requests to return failures for
-        self.fail_requests: Set[str] = set()
-        # Return values for katcp requests
-        self.katcp_replies: typing.Dict[str, Tuple[List[bytes], List[Message]]] = {}
 
-        # Mock out use of katdal to get the targets
-        create_patch(self, 'katdal.open',
-                     return_value=DummyDataSet())
-
-    async def _launch(self, graph: networkx.MultiDiGraph,
-                      resolver: scheduler.Resolver,
-                      nodes: Sequence[scheduler.PhysicalNode] = None, *,
-                      queue: scheduler.LaunchQueue = None,
-                      resources_timeout: float = None) -> None:
+    async def launch(self, graph: networkx.MultiDiGraph,
+                     resolver: scheduler.Resolver,
+                     nodes: Sequence[scheduler.PhysicalNode] = None, *,
+                     queue: scheduler.LaunchQueue = None,
+                     resources_timeout: float = None) -> None:
         """Mock implementation of Scheduler.launch."""
         if nodes is None:
             nodes = graph.nodes()
@@ -784,12 +703,12 @@ class TestController(BaseTestController):
             futures.append(node.ready_event.wait())
         await asyncio.gather(*futures)
 
-    async def _batch_run(self, graph: networkx.MultiDiGraph,
-                         resolver: scheduler.Resolver,
-                         nodes: Sequence[scheduler.PhysicalNode] = None, *,
-                         queue: scheduler.LaunchQueue = None,
-                         resources_timeout: float = None,
-                         attempts: int = 1) -> None:
+    async def batch_run(self, graph: networkx.MultiDiGraph,
+                        resolver: scheduler.Resolver,
+                        nodes: Sequence[scheduler.PhysicalNode] = None, *,
+                        queue: scheduler.LaunchQueue = None,
+                        resources_timeout: float = None,
+                        attempts: int = 1) -> None:
         """Mock implementation of Scheduler.batch_run.
 
         For now this is a much lighter-weight emulation than :meth:`_launch`,
@@ -806,9 +725,9 @@ class TestController(BaseTestController):
             node.set_state(scheduler.TaskState.DEAD)
         self.n_batch_tasks += len(nodes)
 
-    async def _kill(self, graph: networkx.MultiDiGraph,
-                    nodes: Sequence[scheduler.PhysicalNode] = None,
-                    **kwargs) -> None:
+    async def kill(self, graph: networkx.MultiDiGraph,
+                   nodes: Sequence[scheduler.PhysicalNode] = None,
+                   **kwargs) -> None:
         """Mock implementation of Scheduler.kill."""
         if nodes is not None:
             kill_graph = graph.subgraph(nodes)
@@ -822,13 +741,178 @@ class TestController(BaseTestController):
                     node.kill(self.driver, **kwargs)
             node.set_state(scheduler.TaskState.DEAD)
 
-    async def _request(self, msg: str, *args: Any, **kwargs: Any) \
+    async def close(self) -> None:
+        pass
+
+
+class DummyClient:
+    """Mock implementation of :class:`aiokatcp.client.Client`.
+
+    Like :class:`DummyScheduler`, this isn't a complete mock. Its methods
+    should be set as side effects on a mock.
+    """
+
+    def __init__(self) -> None:
+        # Set of katcp requests to return failures for
+        self.fail_requests: Set[str] = set()
+        # Return values for katcp requests
+        self.katcp_replies: typing.Dict[str, Tuple[List[bytes], List[Message]]] = {}
+
+    async def request(self, msg: str, *args: Any, **kwargs: Any) \
             -> Tuple[List[bytes], List[Message]]:
         """Mock implementation of aiokatcp.Client.request"""
         if msg in self.fail_requests:
             raise FailReply('dummy failure')
         else:
             return self.katcp_replies.get(msg, ([], []))
+
+
+@pytest.mark.timeout(5)
+class TestController(BaseTestController):
+    """Test :class:`katsdpcontroller.product_controller.DeviceServer` by mocking the scheduler."""
+
+    def _request_slow(self, client: aiokatcp.Client, name: str, *args: Any,
+                      cancelled: bool = False) -> DelayedManager:
+        """Asynchronous context manager that runs its block with a request in progress.
+
+        The request must operate by issuing requests to the tasks, as this is
+        used to block it from completing.
+        """
+        sensor_proxy_client = sensor_proxy.SensorProxyClient.return_value  # grab the mock
+        return DelayedManager(
+            client.request(name, *args),
+            sensor_proxy_client.request,
+            ([], []),
+            cancelled)
+
+    def _capture_init_slow(self, client: aiokatcp.Client, capture_block: str,
+                           cancelled: bool = False) -> DelayedManager:
+        """Asynchronous context manager that runs its block with a capture-init
+        in progress. The subarray product must already be configured.
+        """
+        return self._request_slow(client, 'capture-init', capture_block, cancelled=cancelled)
+
+    def _capture_done_slow(self, client: aiokatcp.Client,
+                           cancelled: bool = False) -> DelayedManager:
+        """Asynchronous context manager that runs its block with a capture-done
+        in progress. The subarray product must already be configured and
+        capturing.
+        """
+        return self._request_slow(client, 'capture-done', cancelled=cancelled)
+
+    def _product_configure_slow(self, client: aiokatcp.Client, subarray_product: str,
+                                cancelled: bool = False) -> DelayedManager:
+        """Asynchronous context manager that runs its block with a
+        product-configure in progress.
+        """
+        sensor_proxy_client = sensor_proxy.SensorProxyClient.return_value  # grab the mock
+        return DelayedManager(
+            client.request(*self._configure_args(subarray_product)),
+            sensor_proxy_client.wait_synced,
+            None, cancelled)
+
+    # The return annotation is deliberately vague because typeshed changed
+    # its annotation at some point and so any more specific annotation will
+    # error out on *some* version of mypy.
+    def _getaddrinfo(self, host: str, *args, **kwargs) -> List[Any]:
+        """Mock getaddrinfo that replaces all hosts with a dummy IP address"""
+        if host.startswith('host'):
+            host = '127.0.0.2'
+        return getaddrinfo(host, *args, **kwargs)
+
+    @pytest.fixture
+    def dummy_sched(self) -> DummyScheduler:
+        return DummyScheduler()
+
+    @pytest.fixture
+    def sched(self, dummy_sched) -> mock.MagicMock:
+        sched = mock.create_autospec(spec=scheduler.Scheduler, instance=True)
+        sched.launch.side_effect = dummy_sched.launch
+        sched.kill.side_effect = dummy_sched.kill
+        sched.batch_run.side_effect = dummy_sched.batch_run
+        sched.close.side_effect = dummy_sched.close
+        sched.http_url = 'http://scheduler:8080/'
+        sched.http_port = 8080
+        sched.task_stats = scheduler.TaskStats()
+        return sched
+
+    @pytest.fixture
+    def dummy_client(self) -> DummyClient:
+        return DummyClient()
+
+    @pytest.fixture(autouse=True)
+    def sensor_proxy_client(self, dummy_client: DummyClient, mocker) -> mock.MagicMock:
+        # Future that is already resolved with no return value
+        done_future: asyncio.Future[None] = asyncio.Future()
+        done_future.set_result(None)
+
+        sensor_proxy_client_class = mocker.patch(
+            'katsdpcontroller.sensor_proxy.SensorProxyClient', autospec=True)
+        sensor_proxy_client = sensor_proxy_client_class.return_value
+        sensor_proxy_client.wait_connected.return_value = done_future
+        sensor_proxy_client.wait_synced.return_value = done_future
+        sensor_proxy_client.wait_closed.return_value = done_future
+        sensor_proxy_client.request.side_effect = dummy_client.request
+        return sensor_proxy_client
+
+    @pytest.fixture
+    def server_kwargs(self, sched: mock.MagicMock) -> dict:
+        return dict(
+            host='127.0.0.1', port=0, sched=sched,
+            s3_config=json.loads(S3_CONFIG),
+            image_resolver_factory=scheduler.ImageResolverFactory(
+                scheduler.SimpleImageLookup('sdp')),
+            interface_mode=False,
+            localhost=True,
+            batch_role='batch')
+
+    @pytest.fixture
+    def telstate(self) -> katsdptelstate.aio.TelescopeState:
+        return katsdptelstate.aio.TelescopeState()
+
+    @pytest.fixture(autouse=True)
+    def backend_from_url_mock(
+            self, telstate: katsdptelstate.aio.TelescopeState, mocker) -> mock.MagicMock:
+        # Mock RedisBackend to create an in-memory telstate instead
+        return mocker.patch(
+            'katsdptelstate.aio.redis.RedisBackend.from_url',
+            return_value=telstate.backend, autospec=True)
+
+    @pytest.fixture(autouse=True)
+    async def setup_fixture(self, server, backend_from_url_mock, mocker) -> None:
+        # Future that is already resolved with no return value
+        done_future: asyncio.Future[None] = asyncio.Future()
+        done_future.set_result(None)
+        mocker.patch('time.time', return_value=123456789.5)
+        mocker.patch('socket.getaddrinfo', side_effect=self._getaddrinfo)
+
+        # We don't have a delay_run.sh to abort when told to, so we need to
+        # ensure that dependency_abort actually kills the task.
+        orig_dependency_abort = scheduler.PhysicalTask.dependency_abort
+
+        def _dependency_abort(task: scheduler.PhysicalTask) -> None:
+            orig_dependency_abort(task)
+            asyncio.get_event_loop().call_soon(task.set_state, scheduler.TaskState.DEAD)
+        mocker.patch('katsdpcontroller.scheduler.PhysicalTask.dependency_abort',
+                     side_effect=_dependency_abort, autospec=True)
+
+        mocker.patch(
+            'katsdpcontroller.scheduler.poll_ports', autospec=True, return_value=done_future)
+        mocker.patch('netifaces.interfaces', autospec=True, return_value=['lo', 'em1'])
+        mocker.patch('netifaces.ifaddresses', autospec=True, side_effect=self._ifaddresses)
+        # Creating the sensor here isn't quite accurate (it is a dynamic sensor
+        # created on subarray activation), but it shouldn't matter.
+        server.sensors.add(Sensor(
+            bytes, 'cal.1.capture-block-state',
+            'Dummy implementation of sensor', default=b'{}',
+            initial_status=Sensor.Status.NOMINAL))
+        server.sensors.add(Sensor(
+            DeviceStatus, 'ingest.sdp_l0.1.device-status',
+            'Dummy implementation of sensor',
+            initial_status=Sensor.Status.NOMINAL))
+
+        # Mock out use of katdal to get the targets
+        mocker.patch('katdal.open', return_value=DummyDataSet())
 
     def _ifaddresses(self, interface: str) -> Mapping[int, Sequence[Mapping[str, str]]]:
         if interface == 'lo':
@@ -849,52 +933,63 @@ class TestController(BaseTestController):
     def _configure_args(self, subarray_product: str) -> Tuple[str, ...]:
         return ("product-configure", subarray_product, CONFIG)
 
-    async def _configure_subarray(self, subarray_product: str) -> None:
-        reply, informs = await self.client.request(*self._configure_args(subarray_product))
+    async def _configure_subarray(self, client: aiokatcp.Client, subarray_product: str) -> None:
+        reply, informs = await client.request(*self._configure_args(subarray_product))
 
     async def assert_immutable(
-            self, key: str, value: Any,
+            self, telstate: katsdptelstate.aio.TelescopeState, key: str, value: Any,
             key_type: katsdptelstate.KeyType = katsdptelstate.KeyType.IMMUTABLE) -> None:
         """Check the value of a telstate key and also that it is immutable"""
-        assert self.telstate is not None
+        assert telstate is not None
         # Uncomment for debugging
         # import json
         # with open('expected.json', 'w') as f:
         #     json.dump(value, f, indent=2, default=str, sort_keys=True)
         # with open('actual.json', 'w') as f:
-        #     json.dump(self.telstate[key], f, indent=2, default=str, sort_keys=True)
-        assert await self.telstate[key] == value
-        assert await self.telstate.key_type(key) == key_type
+        #     json.dump(telstate[key], f, indent=2, default=str, sort_keys=True)
+        assert await telstate[key] == value
+        assert await telstate.key_type(key) == key_type
 
-    async def test_product_configure_success(self) -> None:
+    async def test_product_configure_success(
+            self,
+            client: aiokatcp.Client,
+            server: DeviceServer,
+            telstate: katsdptelstate.aio.TelescopeState,
+            backend_from_url_mock) -> None:
         """A ?product-configure request must wait for the tasks to come up,
         then indicate success.
         """
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        self.backend_from_url_mock.assert_called_once_with(
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        backend_from_url_mock.assert_called_once_with(
             'redis://host.telstate:20000'
         )
 
         # Verify the telescope state.
         # This is not a complete list of calls. It checks that each category of stuff
         # is covered: base_params, per node, per edge
-        assert self.telstate is not None
-        await self.assert_immutable('subarray_product_id', SUBARRAY_PRODUCT)
-        await self.assert_immutable('sdp_model_base_url', 'https://models.s3.invalid/models/')
+        assert telstate is not None
+        await self.assert_immutable(telstate, 'subarray_product_id', SUBARRAY_PRODUCT)
         await self.assert_immutable(
-            self.telstate.join('model', 'rfi_mask', 'config'),
+            telstate, 'sdp_model_base_url', 'https://models.s3.invalid/models/')
+        await self.assert_immutable(
+            telstate,
+            telstate.join('model', 'rfi_mask', 'config'),
             'rfi_mask/config/2020-06-15.alias')
         await self.assert_immutable(
-            self.telstate.join('model', 'rfi_mask', 'fixed'),
+            telstate,
+            telstate.join('model', 'rfi_mask', 'fixed'),
             'rfi_mask/fixed/test.h5')
         await self.assert_immutable(
-            self.telstate.join('i0_antenna_channelised_voltage', 'model', 'band_mask', 'config'),
+            telstate,
+            telstate.join('i0_antenna_channelised_voltage', 'model', 'band_mask', 'config'),
             'band_mask/config/l/nb_ratio=1/2020-06-22.alias')
         await self.assert_immutable(
-            self.telstate.join('i0_antenna_channelised_voltage', 'model', 'band_mask', 'fixed'),
+            telstate,
+            telstate.join('i0_antenna_channelised_voltage', 'model', 'band_mask', 'fixed'),
             'band_mask/fixed/test.h5')
         await self.assert_immutable(
-            self.telstate.join(
+            telstate,
+            telstate.join(
                 'i0_antenna_channelised_voltage', 'model',
                 'primary_beam', 'cohort', 'config'),
             {
@@ -904,13 +999,14 @@ class TestController(BaseTestController):
             key_type=katsdptelstate.KeyType.INDEXED
         )
         await self.assert_immutable(
-            self.telstate.join(
+            telstate,
+            telstate.join(
                 'i0_antenna_channelised_voltage', 'model',
                 'primary_beam', 'individual', 'fixed'),
             {ant: 'primary_beam/fixed/test.h5' for ant in ['m000', 'm001', 'm062', 'm063']},
             key_type=katsdptelstate.KeyType.INDEXED
         )
-        await self.assert_immutable('config.vis_writer.sdp_l0', {
+        await self.assert_immutable(telstate, 'config.vis_writer.sdp_l0', {
             'external_hostname': 'host.vis_writer.sdp_l0',
             'npy_path': '/var/kat/data',
             'obj_size_mb': mock.ANY,
@@ -929,7 +1025,7 @@ class TestController(BaseTestController):
             'direct_write': True
         })
         # Test that the output channel rounding was done correctly
-        await self.assert_immutable('config.ingest.sdp_l0_continuum_only', {
+        await self.assert_immutable(telstate, 'config.ingest.sdp_l0_continuum_only', {
             'antenna_mask': mock.ANY,
             'cbf_spead': mock.ANY,
             'cbf_ibv': True,
@@ -951,7 +1047,7 @@ class TestController(BaseTestController):
         })
 
         # Verify the state of the subarray
-        product = self.server.product
+        product = server.product
         assert product is not None
         assert isinstance(product, SubarrayProduct)  # For mypy's benefit
         assert not product.async_busy
@@ -962,64 +1058,64 @@ class TestController(BaseTestController):
         n_xengs = 4  # Update if sizing logic changes
         # antenna-channelised-voltage sensors
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_antenna_channelised_voltage-adc-sample-rate",
             1712e6
         )
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_antenna_channelised_voltage-bandwidth",
             856e6
         )
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_antenna_channelised_voltage-scale-factor-timestamp",
             1712e6
         )
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_antenna_channelised_voltage-n-ants",
             2
         )
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_antenna_channelised_voltage-n-inputs",
             4
         )
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_antenna_channelised_voltage-n-fengs",
             2
         )
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_antenna_channelised_voltage-feng-out-bits-per-sample",
             8
         )
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_antenna_channelised_voltage-n-chans",
             4096
         )
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_antenna_channelised_voltage-n-chans-per-substream",
             4096 // n_xengs
         )
 
         # baseline-correlation-products sensors
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_baseline_correlation_products-n-accs",
             408 * 256
         )
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_baseline_correlation_products-int-time",
             408 * 256 * 4096 / 856e6
         )
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_baseline_correlation_products-xeng-out-bits-per-sample",
             32
         )
@@ -1038,22 +1134,22 @@ class TestController(BaseTestController):
             "('gpucbf_m901h', 'gpucbf_m901h')]"
         )
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_baseline_correlation_products-bls-ordering",
             expected_bls_ordering
         )
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_baseline_correlation_products-n-bls",
             12
         )
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_baseline_correlation_products-n-chans",
             4096
         )
         await assert_sensor_value(
-            self.client,
+            client,
             "gpucbf_baseline_correlation_products-n-chans-per-substream",
             4096 // n_xengs
         )
@@ -1061,92 +1157,110 @@ class TestController(BaseTestController):
         stream_name = 'gpucbf_baseline_correlation_products'
         node = product._nodes[f'multicast.{stream_name}']
         await assert_sensor_value(
-            self.client,
+            client,
             f'{stream_name}-destination',
             str(Endpoint(node.host, node.ports['spead']))
         )
 
-    async def test_product_configure_telstate_fail(self) -> None:
+    async def test_product_configure_telstate_fail(
+            self,
+            client: aiokatcp.Client,
+            server: DeviceServer,
+            sched,
+            dummy_sched: DummyScheduler,
+            backend_from_url_mock) -> None:
         """If the telstate task fails, product-configure must fail"""
-        self.fail_launches['telstate'] = 'TASK_FAILED'
-        self.backend_from_url_mock.side_effect = ConnectionError
-        await assert_request_fails(self.client, *self._configure_args(SUBARRAY_PRODUCT))
-        self.sched.launch.assert_called_with(mock.ANY, mock.ANY, mock.ANY)
-        self.sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
+        dummy_sched.fail_launches['telstate'] = 'TASK_FAILED'
+        backend_from_url_mock.side_effect = ConnectionError
+        await assert_request_fails(client, *self._configure_args(SUBARRAY_PRODUCT))
+        sched.launch.assert_called_with(mock.ANY, mock.ANY, mock.ANY)
+        sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
         # Must not have created the subarray product internally
-        assert self.server.product is None
+        assert server.product is None
 
-    async def test_product_configure_task_fail(self) -> None:
+    async def test_product_configure_task_fail(
+            self,
+            client: aiokatcp.Client,
+            server: DeviceServer,
+            sched,
+            dummy_sched: DummyScheduler,
+            backend_from_url_mock) -> None:
         """If a task other than telstate fails, product-configure must fail"""
-        self.fail_launches['ingest.sdp_l0.1'] = 'TASK_FAILED'
-        await assert_request_fails(self.client, *self._configure_args(SUBARRAY_PRODUCT))
-        self.backend_from_url_mock.assert_called_once_with(
+        dummy_sched.fail_launches['ingest.sdp_l0.1'] = 'TASK_FAILED'
+        await assert_request_fails(client, *self._configure_args(SUBARRAY_PRODUCT))
+        backend_from_url_mock.assert_called_once_with(
             'redis://host.telstate:20000'
         )
-        self.sched.launch.assert_called_with(mock.ANY, mock.ANY)
-        self.sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
+        sched.launch.assert_called_with(mock.ANY, mock.ANY)
+        sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
         # Must not have created the subarray product internally
-        assert self.server.product is None
+        assert server.product is None
 
-    async def test_product_deconfigure(self) -> None:
+    async def test_product_deconfigure(
+            self, client: aiokatcp.Client, sched, server: DeviceServer) -> None:
         """Checks success path of product-deconfigure"""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await self.client.request("product-deconfigure")
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await client.request("product-deconfigure")
         # Check that the graph was shut down
-        self.sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=False)
+        sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=False)
         # The server must shut itself down
-        await self.server.join()
+        await server.join()
 
-    async def test_product_deconfigure_capturing(self) -> None:
+    async def test_product_deconfigure_capturing(self, client: aiokatcp.Client) -> None:
         """product-deconfigure must fail while capturing"""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await self.client.request("capture-init", CAPTURE_BLOCK)
-        await assert_request_fails(self.client, "product-deconfigure")
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await client.request("capture-init", CAPTURE_BLOCK)
+        await assert_request_fails(client, "product-deconfigure")
 
-    async def test_product_deconfigure_capturing_force(self) -> None:
+    async def test_product_deconfigure_capturing_force(
+            self, client: aiokatcp.Client, server: DeviceServer) -> None:
         """forced product-deconfigure must succeed while capturing"""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await self.client.request("capture-init", CAPTURE_BLOCK)
-        await self.client.request("product-deconfigure", True)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await client.request("capture-init", CAPTURE_BLOCK)
+        await client.request("product-deconfigure", True)
         # The server must shut itself down
-        await self.server.join()
+        await server.join()
 
-    async def test_product_deconfigure_busy(self) -> None:
+    async def test_product_deconfigure_busy(
+            self, client: aiokatcp.Client, server: DeviceServer) -> None:
         """product-deconfigure cannot happen concurrently with capture-init"""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        async with self._capture_init_slow(CAPTURE_BLOCK):
-            await assert_request_fails(self.client, 'product-deconfigure', False)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        async with self._capture_init_slow(client, CAPTURE_BLOCK):
+            await assert_request_fails(client, 'product-deconfigure', False)
         # Check that the subarray still exists and has the right state
-        product = self.server.product
+        product = server.product
         assert product is not None
         assert not product.async_busy
         assert product.state == ProductState.CAPTURING
 
-    async def test_product_deconfigure_busy_force(self) -> None:
+    async def test_product_deconfigure_busy_force(
+            self, client: aiokatcp.Client, server: DeviceServer, sched) -> None:
         """forced product-deconfigure must succeed while in capture-init"""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        async with self._capture_init_slow(CAPTURE_BLOCK, cancelled=True):
-            await self.client.request("product-deconfigure", True)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        async with self._capture_init_slow(client, CAPTURE_BLOCK, cancelled=True):
+            await client.request("product-deconfigure", True)
         # Check that the graph was shut down
-        self.sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
+        sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
         # The server must shut itself down
-        await self.server.join()
+        await server.join()
 
-    async def test_product_deconfigure_while_configuring_force(self) -> None:
+    async def test_product_deconfigure_while_configuring_force(
+            self, client: aiokatcp.Client, server: DeviceServer, sched) -> None:
         """forced product-deconfigure must succeed while in product-configure"""
-        async with self._product_configure_slow(SUBARRAY_PRODUCT, cancelled=True):
-            await self.client.request("product-deconfigure", True)
+        async with self._product_configure_slow(client, SUBARRAY_PRODUCT, cancelled=True):
+            await client.request("product-deconfigure", True)
         # Check that the graph was shut down
-        self.sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
+        sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
         # Verify the state
-        assert self.server.product is None
+        assert server.product is None
 
-    async def test_capture_init(self) -> None:
+    async def test_capture_init(
+            self, client: aiokatcp.Client, server: DeviceServer, sensor_proxy_client) -> None:
         """Checks that capture-init succeeds and sets appropriate state"""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await self.client.request("capture-init", CAPTURE_BLOCK)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await client.request("capture-init", CAPTURE_BLOCK)
         # check that the subarray is in an appropriate state
-        product = self.server.product
+        product = server.product
         assert product is not None
         assert not product.async_busy
         assert product.state == ProductState.CAPTURING
@@ -1154,7 +1268,7 @@ class TestController(BaseTestController):
         # multiple times, depending on the number of instances of each child.
         # We thus collapse them into groups of equal calls and don't worry
         # about the number, which would otherwise make the test fragile.
-        katcp_client = self.sensor_proxy_client_class.return_value
+        katcp_client = sensor_proxy_client
         sorted_calls = sorted(katcp_client.request.mock_calls,
                               key=lambda call: call[1])
         grouped_calls = [k for k, g in itertools.groupby(sorted_calls)]
@@ -1166,83 +1280,87 @@ class TestController(BaseTestController):
         ]
         assert grouped_calls == expected_calls
 
-    async def test_capture_init_bad_json(self) -> None:
+    async def test_capture_init_bad_json(self, client: aiokatcp.Client) -> None:
         """Check that capture-init fails if an override is illegal"""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         with pytest.raises(FailReply):
-            await self.client.request("capture-init", CAPTURE_BLOCK, 'not json')
+            await client.request("capture-init", CAPTURE_BLOCK, 'not json')
 
-    async def test_capture_init_bad_override(self) -> None:
+    async def test_capture_init_bad_override(self, client: aiokatcp.Client) -> None:
         """Check that capture-init fails if an override makes the config illegal"""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         with pytest.raises(FailReply):
-            await self.client.request("capture-init", CAPTURE_BLOCK, '{"outputs": null}')
+            await client.request("capture-init", CAPTURE_BLOCK, '{"outputs": null}')
 
-    async def test_capture_init_bad_override_change(self) -> None:
+    async def test_capture_init_bad_override_change(self, client: aiokatcp.Client) -> None:
         """Check that capture-init fails if an override makes an invalid change"""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         with pytest.raises(FailReply):
-            await self.client.request(
+            await client.request(
                 "capture-init", CAPTURE_BLOCK,
                 '{"inputs": {"camdata": {"url": "http://127.0.0.1:8888"}}}')
 
-    async def test_capture_init_failed_req(self) -> None:
+    async def test_capture_init_failed_req(
+            self, client: aiokatcp.Client, server: DeviceServer,
+            dummy_client: DummyClient) -> None:
         """Capture-init fails on some task"""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        self.fail_requests.add('capture-init')
-        await assert_request_fails(self.client, "capture-init", CAPTURE_BLOCK)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        dummy_client.fail_requests.add('capture-init')
+        await assert_request_fails(client, "capture-init", CAPTURE_BLOCK)
         # check that the subarray is in an appropriate state
-        product = self.server.product
+        product = server.product
         assert product is not None
         assert product.state == ProductState.ERROR
-        assert self.server.sensors['state'].value == ProductState.ERROR
-        assert self.server.sensors['device-status'].value == DeviceStatus.FAIL
-        assert self.server.sensors['device-status'].status == Sensor.Status.ERROR
+        assert server.sensors['state'].value == ProductState.ERROR
+        assert server.sensors['device-status'].value == DeviceStatus.FAIL
+        assert server.sensors['device-status'].status == Sensor.Status.ERROR
         assert product.capture_blocks == {}
         # check that the subarray can be safely deconfigured, and that it
         # goes via DECONFIGURING state. Rather than trying to directly
         # observe the internal state during deconfigure (e.g. with
         # DelayedManager), we'll just observe the sensor
         state_observer = mock.Mock()
-        self.server.sensors['state'].attach(state_observer)
-        await self.client.request('product-deconfigure')
+        server.sensors['state'].attach(state_observer)
+        await client.request('product-deconfigure')
         # call 0, arguments, argument 1
         assert state_observer.mock_calls[0][1][1].value == ProductState.DECONFIGURING
         assert product.state == ProductState.DEAD
 
-    async def test_capture_done_failed_req(self) -> None:
+    async def test_capture_done_failed_req(
+            self, client: aiokatcp.Client, server: DeviceServer,
+            dummy_client: DummyClient, sensor_proxy_client) -> None:
         """Capture-done fails on some task"""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        self.fail_requests.add('capture-done')
-        reply, informs = await self.client.request("capture-init", CAPTURE_BLOCK)
-        await assert_request_fails(self.client, "capture-done")
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        dummy_client.fail_requests.add('capture-done')
+        reply, informs = await client.request("capture-init", CAPTURE_BLOCK)
+        await assert_request_fails(client, "capture-done")
         # check that the subsequent transitions still run
-        katcp_client = self.sensor_proxy_client_class.return_value
+        katcp_client = sensor_proxy_client
         katcp_client.request.assert_called_with('write-meta', CAPTURE_BLOCK, True)
         # check that postprocessing transitions still run.
-        await asynctest.exhaust_callbacks(self.loop)
+        await exhaust_callbacks()
         katcp_client.request.assert_called_with('write-meta', CAPTURE_BLOCK, False)
         # check that the subarray is in an appropriate state
-        product = self.server.product
+        product = server.product
         assert product is not None
         assert product.state == ProductState.ERROR
         assert product.capture_blocks == {}
         # check that the subarray can be safely deconfigured
-        await self.client.request('product-deconfigure')
+        await client.request('product-deconfigure')
         assert product.state == ProductState.DEAD
 
-    async def _test_busy(self, command: str, *args: Any) -> None:
+    async def _test_busy(self, client: aiokatcp.Client, command: str, *args: Any) -> None:
         """Test that a command fails if issued while ?capture-init or
         ?product-configure is in progress
         """
-        async with self._product_configure_slow(SUBARRAY_PRODUCT):
-            await assert_request_fails(self.client, command, *args)
-        async with self._capture_init_slow(CAPTURE_BLOCK):
-            await assert_request_fails(self.client, command, *args)
+        async with self._product_configure_slow(client, SUBARRAY_PRODUCT):
+            await assert_request_fails(client, command, *args)
+        async with self._capture_init_slow(client, CAPTURE_BLOCK):
+            await assert_request_fails(client, command, *args)
 
-    async def test_capture_init_busy(self) -> None:
+    async def test_capture_init_busy(self, client: aiokatcp.Client) -> None:
         """Capture-init fails if an asynchronous operation is already in progress"""
-        await self._test_busy("capture-init", CAPTURE_BLOCK)
+        await self._test_busy(client, "capture-init", CAPTURE_BLOCK)
 
     def _ingest_died(self, subarray_product: SubarrayProduct) -> None:
         """Mark an ingest process as having died"""
@@ -1254,338 +1372,364 @@ class TestController(BaseTestController):
         else:
             raise ValueError('Could not find ingest node')
 
-    def _ingest_bad_device_status(self, subarray_product: SubarrayProduct) -> None:
+    def _ingest_bad_device_status(
+            self, server: DeviceServer, subarray_product: SubarrayProduct) -> None:
         """Mark an ingest process as having bad status"""
-        sensor = self.server.sensors['ingest.sdp_l0.1.device-status']
+        sensor = server.sensors['ingest.sdp_l0.1.device-status']
         sensor.set_value(DeviceStatus.FAIL, Sensor.Status.ERROR)
 
-    async def test_capture_init_dead_process(self) -> None:
+    async def test_capture_init_dead_process(
+            self, client: aiokatcp.Client, server: DeviceServer) -> None:
         """Capture-init fails if a child process is dead."""
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
-        product = self.server.product
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        product = server.product
         assert product is not None
         self._ingest_died(product)
         assert product.state == ProductState.ERROR
-        await assert_request_fails(self.client, "capture-init", CAPTURE_BLOCK)
+        await assert_request_fails(client, "capture-init", CAPTURE_BLOCK)
         # check that the subarray is in an appropriate state
         assert product.state == ProductState.ERROR
         assert product.capture_blocks == {}
 
-    async def test_capture_init_process_dies(self) -> None:
+    async def test_capture_init_process_dies(self, client: aiokatcp.Client, server) -> None:
         """Capture-init fails if a child dies half-way through."""
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
-        product = self.server.product
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        product = server.product
         assert product is not None
         with pytest.raises(FailReply):
-            async with self._capture_init_slow(CAPTURE_BLOCK):
+            async with self._capture_init_slow(client, CAPTURE_BLOCK):
                 self._ingest_died(product)
         # check that the subarray is in an appropriate state
         assert product.state == ProductState.ERROR
         assert product.capture_blocks == {}
 
-    async def test_capture_done(self) -> None:
+    async def test_capture_done(
+            self, client: aiokatcp.Client, server: aiokatcp.DeviceServer,
+            sensor_proxy_client, dummy_sched: DummyScheduler) -> None:
         """Checks that capture-done succeeds and sets appropriate state"""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await self.client.request("capture-init", CAPTURE_BLOCK)
-        cal_sensor = self.server.sensors['cal.1.capture-block-state']
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await client.request("capture-init", CAPTURE_BLOCK)
+        cal_sensor = server.sensors['cal.1.capture-block-state']
         cal_sensor.value = b'{"1122334455: "capturing"}'
-        await self.client.request("capture-done")
+        await client.request("capture-done")
         # check that the subarray is in an appropriate state
-        product = self.server.product
+        product = server.product
         assert product is not None
         assert not product.async_busy
         assert product.state == ProductState.IDLE
         # Check that the graph transitions succeeded
-        katcp_client = self.sensor_proxy_client_class.return_value
+        katcp_client = sensor_proxy_client
         katcp_client.request.assert_any_call('capture-done')
         katcp_client.request.assert_called_with('write-meta', CAPTURE_BLOCK, True)
         # Now simulate cal finishing with the capture block
         cal_sensor.value = b'{}'
-        await asynctest.exhaust_callbacks(self.loop)
+        await exhaust_callbacks()
         # write-meta full dump must be last, hence assert_called_with not assert_any_call
         katcp_client.request.assert_called_with('write-meta', CAPTURE_BLOCK, False)
 
         # Check that postprocessing ran and didn't fail
         assert product.capture_blocks == {}
-        assert self.n_batch_tasks == 11    # 4 continuum, 3x2 spectral, 1 report
+        assert dummy_sched.n_batch_tasks == 11    # 4 continuum, 3x2 spectral, 1 report
 
-    async def test_capture_done_disable_batch(self) -> None:
+    async def test_capture_done_disable_batch(
+            self, client: aiokatcp.Client, server: DeviceServer,
+            dummy_sched: DummyScheduler) -> None:
         """Checks that capture-init with override takes effect"""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await self.client.request(
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await client.request(
             "capture-init", CAPTURE_BLOCK, '{"outputs": {"spectral_image": null}}')
-        cal_sensor = self.server.sensors['cal.1.capture-block-state']
+        cal_sensor = server.sensors['cal.1.capture-block-state']
         cal_sensor.value = b'{"1122334455": "capturing"}'
-        await self.client.request("capture-done")
+        await client.request("capture-done")
         cal_sensor.value = b'{}'
-        await asynctest.exhaust_callbacks(self.loop)
-        assert self.n_batch_tasks == 4    # 4 continuum, no spectral
+        await exhaust_callbacks()
+        assert dummy_sched.n_batch_tasks == 4    # 4 continuum, no spectral
 
-    async def test_capture_done_busy(self):
+    async def test_capture_done_busy(self, client: aiokatcp.Client):
         """Capture-done fails if an asynchronous operation is already in progress"""
-        await self._test_busy("capture-done")
+        await self._test_busy(client, "capture-done")
 
     async def _test_failure_while_capturing(
-            self, failfunc: Callable[[SubarrayProduct], None]) -> None:
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
-        await self.client.request("capture-init", CAPTURE_BLOCK)
-        product = self.server.product
+            self, client: aiokatcp.Client, server: DeviceServer,
+            sensor_proxy_client, failfunc: Callable[[SubarrayProduct], None]) -> None:
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        await client.request("capture-init", CAPTURE_BLOCK)
+        product = server.product
         assert product is not None
         assert product.state == ProductState.CAPTURING
         failfunc(product)
         assert product.state == ProductState.ERROR
         assert product.capture_blocks == {CAPTURE_BLOCK: mock.ANY}
         # In the background it will terminate the capture block
-        await asynctest.exhaust_callbacks(self.loop)
+        await exhaust_callbacks()
         assert product.capture_blocks == {}
-        katcp_client = self.sensor_proxy_client_class.return_value
+        katcp_client = sensor_proxy_client
         katcp_client.request.assert_called_with('write-meta', CAPTURE_BLOCK, False)
 
-    async def test_process_dies_while_capturing(self) -> None:
-        await self._test_failure_while_capturing(self._ingest_died)
+    async def test_process_dies_while_capturing(
+            self, client: aiokatcp.Client, server: DeviceServer, sensor_proxy_client) -> None:
+        await self._test_failure_while_capturing(
+            client, server, sensor_proxy_client, self._ingest_died)
 
-    async def test_bad_device_status_while_capturing(self) -> None:
-        await self._test_failure_while_capturing(self._ingest_bad_device_status)
+    async def test_bad_device_status_while_capturing(
+            self, client: aiokatcp.Client, server: DeviceServer, sensor_proxy_client) -> None:
+        await self._test_failure_while_capturing(
+            client, server, sensor_proxy_client,
+            functools.partial(self._ingest_bad_device_status, server))
 
-    async def test_capture_done_process_dies(self) -> None:
+    async def test_capture_done_process_dies(
+            self, client: aiokatcp.Client, server: DeviceServer,
+            sensor_proxy_client) -> None:
         """Capture-done fails if a child dies half-way through."""
-        await self.client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
-        await self.client.request("capture-init", CAPTURE_BLOCK)
-        product = self.server.product
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        await client.request("capture-init", CAPTURE_BLOCK)
+        product = server.product
         assert product is not None
         assert product.state == ProductState.CAPTURING
         assert product.capture_blocks == {CAPTURE_BLOCK: mock.ANY}
         with pytest.raises(FailReply):
-            async with self._capture_done_slow():
+            async with self._capture_done_slow(client):
                 self._ingest_died(product)
         # check that the subarray is in an appropriate state and that final
         # writeback occurred.
         assert product.state == ProductState.ERROR
-        await asynctest.exhaust_callbacks(self.loop)
-        katcp_client = self.sensor_proxy_client_class.return_value
+        await exhaust_callbacks()
+        katcp_client = sensor_proxy_client
         katcp_client.request.assert_called_with('write-meta', CAPTURE_BLOCK, False)
         assert product.capture_blocks == {}
 
-    async def test_deconfigure_on_stop(self) -> None:
+    async def test_deconfigure_on_stop(
+            self, client: aiokatcp.Client, server: DeviceServer,
+            sensor_proxy_client,
+            sched) -> None:
         """Calling stop will force-deconfigure existing subarrays, even if capturing."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await self.client.request('capture-init', CAPTURE_BLOCK)
-        await self.server.stop()
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await client.request('capture-init', CAPTURE_BLOCK)
+        await server.stop()
 
-        sensor_proxy_client = self.sensor_proxy_client_class.return_value
         sensor_proxy_client.request.assert_any_call('capture-done')
         # Forced deconfigure, so we only get the light dump
         sensor_proxy_client.request.assert_called_with('write-meta', mock.ANY, True)
-        self.sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
+        sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
 
-    async def test_deconfigure_on_stop_busy(self) -> None:
+    async def test_deconfigure_on_stop_busy(
+            self, client: aiokatcp.Client, server: DeviceServer, sched) -> None:
         """Calling deconfigure_on_exit while a capture-init or capture-done is busy
         kills off the graph anyway.
         """
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        async with self._capture_init_slow(CAPTURE_BLOCK, cancelled=True):
-            await self.server.stop()
-        self.sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        async with self._capture_init_slow(client, CAPTURE_BLOCK, cancelled=True):
+            await server.stop()
+        sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
 
-    async def test_deconfigure_on_stop_cancel(self) -> None:
+    async def test_deconfigure_on_stop_cancel(
+            self, client: aiokatcp.Client, server: DeviceServer, sched) -> None:
         """Calling deconfigure_on_exit while a configure is in process cancels
         that configure and kills off the graph."""
-        async with self._product_configure_slow(SUBARRAY_PRODUCT, cancelled=True):
-            await self.server.stop()
+        async with self._product_configure_slow(client, SUBARRAY_PRODUCT, cancelled=True):
+            await server.stop()
         # We must have killed off the partially-launched graph
-        self.sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
+        sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
 
-    async def test_telstate_endpoint(self) -> None:
+    async def test_telstate_endpoint(self, client: aiokatcp.Client) -> None:
         """Test telstate-endpoint"""
-        await assert_request_fails(self.client, 'telstate-endpoint')
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        reply, _ = await self.client.request('telstate-endpoint')
+        await assert_request_fails(client, 'telstate-endpoint')
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        reply, _ = await client.request('telstate-endpoint')
         assert reply == [b'host.telstate:20000']
 
-    async def test_capture_status(self) -> None:
+    async def test_capture_status(self, client: aiokatcp.Client) -> None:
         """Test capture-status"""
-        await assert_request_fails(self.client, 'capture-status')
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        reply, _ = await self.client.request('capture-status')
+        await assert_request_fails(client, 'capture-status')
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        reply, _ = await client.request('capture-status')
         assert reply == [b'idle']
-        await self.client.request('capture-init', CAPTURE_BLOCK)
-        reply, _ = await self.client.request('capture-status')
+        await client.request('capture-init', CAPTURE_BLOCK)
+        reply, _ = await client.request('capture-status')
         assert reply == [b'capturing']
 
-    async def test_gain_bad_stream(self) -> None:
+    async def test_gain_bad_stream(self, client: aiokatcp.Client) -> None:
         """Test gain with a stream that doesn't exist."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await assert_request_fails(self.client, 'gain', 'foo', 'm000h', '1')
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await assert_request_fails(client, 'gain', 'foo', 'm000h', '1')
 
-    async def test_gain_wrong_stream_type(self) -> None:
+    async def test_gain_wrong_stream_type(self, client: aiokatcp.Client) -> None:
         """Test gain with a stream that is of the wrong type."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await assert_request_fails(
-            self.client, 'gain', 'i0_antenna_channelised_voltage', 'm000h', '1')
+            client, 'gain', 'i0_antenna_channelised_voltage', 'm000h', '1')
 
-    async def test_gain_wrong_length(self) -> None:
+    async def test_gain_wrong_length(self, client: aiokatcp.Client) -> None:
         """Test gain with the wrong number of channels."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await assert_request_fails(
-            self.client, 'gain', 'gpucbf_antenna_channelised_voltage', 'gpucbf_m900h', '1', '0.5')
+            client, 'gain', 'gpucbf_antenna_channelised_voltage', 'gpucbf_m900h', '1', '0.5')
 
-    async def test_gain_bad_format(self) -> None:
+    async def test_gain_bad_format(self, client: aiokatcp.Client) -> None:
         """Test gain with badly-formatted gains."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await assert_request_fails(
-            self.client, 'gain', 'gpucbf_antenna_channelised_voltage', 'gpucbf_m900h',
+            client, 'gain', 'gpucbf_antenna_channelised_voltage', 'gpucbf_m900h',
             'not a complex number')
 
-    async def test_gain_single(self) -> None:
+    async def test_gain_single(
+            self, client: aiokatcp.Client, dummy_client: DummyClient, sensor_proxy_client) -> None:
         """Test gain with a single gain to apply to all channels."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        self.katcp_replies['gain'] = ([b'1.0+2.0j'], [])
-        reply, _ = await self.client.request(
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        dummy_client.katcp_replies['gain'] = ([b'1.0+2.0j'], [])
+        reply, _ = await client.request(
             'gain', 'gpucbf_antenna_channelised_voltage', 'gpucbf_m901h', '1.0+2.0j')
         # TODO: this doesn't check that it goes to the correct node
-        katcp_client = self.sensor_proxy_client_class.return_value
+        katcp_client = sensor_proxy_client
         katcp_client.request.assert_any_call('gain', 1, '1.0+2.0j')
         assert reply == [b'1.0+2.0j']
 
-    async def test_gain_multi(self) -> None:
+    async def test_gain_multi(
+            self, client: aiokatcp.Client, dummy_client: DummyClient, sensor_proxy_client) -> None:
         """Test gain with a different gain for each channel."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         gains = [b'%d.0+2.0j' % i for i in range(4096)]
-        self.katcp_replies['gain'] = (gains, [])
-        reply, _ = await self.client.request(
+        dummy_client.katcp_replies['gain'] = (gains, [])
+        reply, _ = await client.request(
             'gain', 'gpucbf_antenna_channelised_voltage', 'gpucbf_m901h', *gains)
         # TODO: this doesn't check that it goes to the correct node
-        katcp_client = self.sensor_proxy_client_class.return_value
+        katcp_client = sensor_proxy_client
         katcp_client.request.assert_any_call('gain', 1, *[g.decode() for g in gains])
         assert reply == gains
 
-    async def test_gain_all_bad_stream(self) -> None:
+    async def test_gain_all_bad_stream(self, client: aiokatcp.Client) -> None:
         """Test gain-all with a stream that doesn't exist."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await assert_request_fails(self.client, 'gain-all', 'foo', '1')
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await assert_request_fails(client, 'gain-all', 'foo', '1')
 
-    async def test_gain_all_wrong_stream_type(self) -> None:
+    async def test_gain_all_wrong_stream_type(self, client: aiokatcp.Client) -> None:
         """Test gain-all with a stream that is of the wrong type."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await assert_request_fails(
-            self.client, 'gain-all', 'i0_antenna_channelised_voltage', '1')
+            client, 'gain-all', 'i0_antenna_channelised_voltage', '1')
 
-    async def test_gain_all_wrong_length(self) -> None:
+    async def test_gain_all_wrong_length(self, client: aiokatcp.Client) -> None:
         """Test gain-all with the wrong number of channels."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await assert_request_fails(
-            self.client, 'gain-all', 'gpucbf_antenna_channelised_voltage', '1', '0.5')
+            client, 'gain-all', 'gpucbf_antenna_channelised_voltage', '1', '0.5')
 
-    async def test_gain_all_bad_format(self) -> None:
+    async def test_gain_all_bad_format(self, client: aiokatcp.Client) -> None:
         """Test gain-all with badly-formatted gains."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await assert_request_fails(
-            self.client, 'gain-all', 'gpucbf_antenna_channelised_voltage',
+            client, 'gain-all', 'gpucbf_antenna_channelised_voltage',
             'not a complex number')
 
-    async def test_gain_all_single(self) -> None:
+    async def test_gain_all_single(self, client: aiokatcp.Client, sensor_proxy_client) -> None:
         """Test gain-all with a single gain to apply to all channels."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await self.client.request(
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await client.request(
             'gain-all', 'gpucbf_antenna_channelised_voltage', '1+2j')
         # TODO: this doesn't check that it goes to the correct nodes
-        katcp_client = self.sensor_proxy_client_class.return_value
+        katcp_client = sensor_proxy_client
         katcp_client.request.assert_any_call('gain-all', '1+2j')
 
-    async def test_gain_all_multi(self) -> None:
+    async def test_gain_all_multi(self, client: aiokatcp.Client, sensor_proxy_client) -> None:
         """Test gain-all with a different gain for each channel."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         gains = [b'%d+2j' % i for i in range(4096)]
-        await self.client.request(
+        await client.request(
             'gain-all', 'gpucbf_antenna_channelised_voltage', *gains)
         # TODO: this doesn't check that it goes to the correct nodes
-        katcp_client = self.sensor_proxy_client_class.return_value
+        katcp_client = sensor_proxy_client
         katcp_client.request.assert_any_call('gain-all', *[g.decode() for g in gains])
 
-    async def test_gain_all_default(self) -> None:
+    async def test_gain_all_default(self, client: aiokatcp.Client, sensor_proxy_client) -> None:
         """Test setting gains to default with gain-all."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await self.client.request(
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await client.request(
             'gain-all', 'gpucbf_antenna_channelised_voltage', 'default')
         # TODO: this doesn't check that it goes to the correct nodes
-        katcp_client = self.sensor_proxy_client_class.return_value
+        katcp_client = sensor_proxy_client
         katcp_client.request.assert_any_call('gain-all', 'default')
 
-    async def test_delays_bad_stream(self) -> None:
+    async def test_delays_bad_stream(self, client: aiokatcp.Client) -> None:
         """Test delays with a stream that doesn't exist."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await assert_request_fails(self.client, 'delays', 'foo', 1234567890.0, '0,0:0,0')
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await assert_request_fails(client, 'delays', 'foo', 1234567890.0, '0,0:0,0')
 
-    async def test_delays_wrong_stream_type(self) -> None:
+    async def test_delays_wrong_stream_type(self, client: aiokatcp.Client) -> None:
         """Test delays with a stream that is of the wrong type."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await assert_request_fails(
-            self.client, 'delays', 'i0_antenna_channelised_voltage', 1234567890.0, '0,0:0,0')
+            client, 'delays', 'i0_antenna_channelised_voltage', 1234567890.0, '0,0:0,0')
 
-    async def test_delays_wrong_length(self) -> None:
+    async def test_delays_wrong_length(self, client: aiokatcp.Client) -> None:
         """Test delays with the wrong number of arguments."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await assert_request_fails(
-            self.client, 'delays', 'gpucbf_antenna_channelised_voltage', 1234567890.0, '0,0:0,0')
+            client, 'delays', 'gpucbf_antenna_channelised_voltage', 1234567890.0, '0,0:0,0')
 
-    async def test_delays_bad_format(self) -> None:
+    async def test_delays_bad_format(self, client: aiokatcp.Client) -> None:
         """Test delays with a badly-formatted coefficient set."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await assert_request_fails(
-            self.client, 'delays', 'gpucbf_antenna_channelised_voltage', 1234567890.0,
+            client, 'delays', 'gpucbf_antenna_channelised_voltage', 1234567890.0,
             '0,0:0,0:extra', '0,0:0,0', '0,0:0,0', '0,0:0,0')
         await assert_request_fails(
-            self.client, 'delays', 'gpucbf_antenna_channelised_voltage', 1234567890.0,
+            client, 'delays', 'gpucbf_antenna_channelised_voltage', 1234567890.0,
             '0,0:0,0,extra', '0,0:0,0', '0,0:0,0', '0,0:0,0')
         await assert_request_fails(
-            self.client, 'delays', 'gpucbf_antenna_channelised_voltage', 1234567890.0,
+            client, 'delays', 'gpucbf_antenna_channelised_voltage', 1234567890.0,
             'a,0:0,0', '0,0:0,0', '0,0:0,0', '0,0:0,0')
 
-    async def test_delays_success(self) -> None:
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await self.client.request(
+    async def test_delays_success(self, client: aiokatcp.Client, sensor_proxy_client) -> None:
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await client.request(
             'delays', 'gpucbf_antenna_channelised_voltage', 1234567890.0,
             '0,0:0,0', '0,0:0,1', '0,1:0,0', '0,1:0,1')
-        katcp_client = self.sensor_proxy_client_class.return_value
+        katcp_client = sensor_proxy_client
         # TODO: this doesn't check that the requests are going to the correct
         # nodes.
         katcp_client.request.assert_any_call('delays', 1234567890.0, '0,0:0,0', '0,0:0,1')
         katcp_client.request.assert_any_call('delays', 1234567890.0, '0,1:0,0', '0,1:0,1')
 
-    async def test_capture_start(self) -> None:
+    async def test_capture_start(self, client: aiokatcp.Client, sensor_proxy_client) -> None:
         """Test capture-start in the success case."""
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await self.client.request(
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await client.request(
             'capture-start', 'gpucbf_baseline_correlation_products')
-        katcp_client = self.sensor_proxy_client_class.return_value
+        katcp_client = sensor_proxy_client
         # TODO: this doesn't check that the requests are going to the correct
         # nodes.
         katcp_client.request.assert_any_call('capture-start')
 
-    async def test_capture_start_bad_stream(self) -> None:
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await assert_request_fails(self.client, 'capture-start', 'foo')
+    async def test_capture_start_bad_stream(self, client: aiokatcp.Client) -> None:
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await assert_request_fails(client, 'capture-start', 'foo')
 
-    async def test_capture_start_wrong_stream_type(self) -> None:
-        await self._configure_subarray(SUBARRAY_PRODUCT)
+    async def test_capture_start_wrong_stream_type(self, client: aiokatcp.Client) -> None:
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await assert_request_fails(
-            self.client, 'capture-start', 'gpucbf_antenna_channelised_voltage')
+            client, 'capture-start', 'gpucbf_antenna_channelised_voltage')
 
-    async def test_capture_stop(self) -> None:
+    async def test_capture_stop(self, client: aiokatcp.Client, sensor_proxy_client) -> None:
         # Note: most of the code for capture-stop is shared with capture-start,
         # so the testing does not need to be as thorough.
-        await self._configure_subarray(SUBARRAY_PRODUCT)
-        await self.client.request(
+        await self._configure_subarray(client, SUBARRAY_PRODUCT)
+        await client.request(
             'capture-start', 'gpucbf_baseline_correlation_products')
-        katcp_client = self.sensor_proxy_client_class.return_value
+        katcp_client = sensor_proxy_client
         # TODO: this doesn't check that the requests are going to the correct
         # nodes.
         katcp_client.request.assert_any_call('capture-start')
 
-    def _check_prom(self, name: str, service: str, type: str, value: float,
-                    sample_name: str = None, extra_labels: Mapping[str, str] = None) -> None:
+    def _check_prom(
+            self,
+            registry: CollectorRegistry,
+            name: str,
+            service: str,
+            type: str,
+            value: float,
+            sample_name: str = None,
+            extra_labels: Mapping[str, str] = None) -> None:
         name = 'katsdpcontroller_' + name
-        registry = self.prometheus_registry
         for metric in registry.collect():
             if metric.name == name:
                 break
@@ -1601,32 +1745,45 @@ class TestController(BaseTestController):
             labels.update(extra_labels)
         assert registry.get_sample_value(sample_name, labels) == value
 
-    async def test_prom_sensors(self) -> None:
+    async def test_prom_sensors(self, registry: CollectorRegistry, server: DeviceServer) -> None:
         """Test that sensors are mirrored into Prometheus."""
-        self.server.sensors.add(aiokatcp.Sensor(
+        server.sensors.add(aiokatcp.Sensor(
             float, 'foo.gauge', '(prometheus: gauge)', default=1.5,
             initial_status=Sensor.Status.NOMINAL))
-        self.server.sensors.add(aiokatcp.Sensor(
+        server.sensors.add(aiokatcp.Sensor(
             float, 'foo.cheese.labelled-gauge', '(prometheus: gauge labels: type)', default=1,
             initial_status=Sensor.Status.NOMINAL))
-        self.server.sensors.add(aiokatcp.Sensor(
+        server.sensors.add(aiokatcp.Sensor(
             int, 'foo.histogram', '(prometheus: histogram(1, 10, 100))'))
-        self._check_prom('gauge', 'foo', 'gauge', 1.5)
-        self._check_prom('labelled_gauge', 'foo', 'gauge', 1, extra_labels={'type': 'cheese'})
-        self._check_prom('histogram', 'foo', 'histogram', 0, 'histogram_bucket', {'le': '10.0'})
+        self._check_prom(registry, 'gauge', 'foo', 'gauge', 1.5)
+        self._check_prom(
+            registry, 'labelled_gauge', 'foo', 'gauge', 1, extra_labels={'type': 'cheese'})
+        self._check_prom(
+            registry, 'histogram', 'foo', 'histogram', 0, 'histogram_bucket', {'le': '10.0'})
 
 
-class TestResources(asynctest.TestCase):
+class TestResources:
     """Test :class:`katsdpcontroller.product_controller.Resources`."""
 
-    async def setUp(self):
+    @pytest.fixture
+    async def mc_server(self) -> AsyncGenerator[DummyMasterController, None]:
         mc_server = DummyMasterController('127.0.0.1', 0)
         await mc_server.start()
-        self.addCleanup(mc_server.stop)
+        yield mc_server
+        await mc_server.stop()
+
+    @pytest.fixture
+    async def mc_client(self, mc_server) -> AsyncGenerator[aiokatcp.Client, None]:
         mc_address = device_server_sockname(mc_server)
         mc_client = await aiokatcp.Client.connect(mc_address[0], mc_address[1])
-        self.resources = Resources(mc_client, SUBARRAY_PRODUCT)
+        yield mc_client
+        mc_client.close()
+        await mc_client.wait_closed()
 
-    async def test_get_multicast_groups(self):
-        assert '239.192.0.1' == await self.resources.get_multicast_groups(1)
-        assert '239.192.0.2+3' == await self.resources.get_multicast_groups(4)
+    @pytest.fixture
+    def resources(self, mc_client):
+        return Resources(mc_client, SUBARRAY_PRODUCT)
+
+    async def test_get_multicast_groups(self, resources) -> None:
+        assert '239.192.0.1' == await resources.get_multicast_groups(1)
+        assert '239.192.0.2+3' == await resources.get_multicast_groups(4)

--- a/src/katsdpcontroller/test/test_scheduler.py
+++ b/src/katsdpcontroller/test/test_scheduler.py
@@ -14,16 +14,16 @@ from typing import Optional, Callable, Generator, Any
 import networkx
 import pymesos
 from addict import Dict
-import asynctest
 import aioresponses
 import open_file_mock
 import aiohttp
 import pytest
+import async_solipsism
 from yarl import URL
 
 from .. import scheduler
 from ..scheduler import TaskState
-from .utils import create_patch, exhaust_callbacks, future_return
+from .utils import exhaust_callbacks, future_return
 
 
 class AnyOrderList(list):
@@ -298,7 +298,7 @@ class TestPollPorts:
         # temporary DNS failure
         assert not future.done()
         # wait for retry loop (currently 5s)
-        # Note: it's tempting to try asynctest.ClockedTestCase, but that
+        # Note: it's tempting to try async_solipsism, but that
         # only works if ALL interactions with the outside world are mocked
         # to be instantaneous.
         await asyncio.sleep(6)
@@ -1460,58 +1460,15 @@ class TestSubgraph:
         assert set(out.nodes()) == {'a', 'b', 'c'}
 
 
-class TestScheduler(asynctest.ClockedTestCase):
+class TestScheduler:
     """Tests for :class:`katsdpcontroller.scheduler.Scheduler`."""
-    def _make_offer(self, resources, agent_num=0, attrs=()):
-        return _make_offer(self.framework_id, 'agentid{}'.format(agent_num),
-                           'agenthost{}'.format(agent_num), resources, attrs)
 
-    def _make_offers(self, ports=None):
-        if ports is None:
-            ports = [(30000, 31000)]
-        return [
-            # Suitable for node0
-            self._make_offer({
-                'cpus': 2.0, 'mem': 1024.0, 'ports': ports,
-                'katsdpcontroller.gpu.0.compute': 0.25,
-                'katsdpcontroller.gpu.0.mem': 2048.0,
-                'katsdpcontroller.gpu.1.compute': 1.0,
-                'katsdpcontroller.gpu.1.mem': 1024.0,
-                'katsdpcontroller.interface.0.bandwidth_in': 1e9,
-                'katsdpcontroller.interface.0.bandwidth_out': 1e9
-            }, 0, self.agent0_attrs),
-            # Suitable for node1
-            self._make_offer({
-                'cpus': 0.5, 'mem': 128.0, 'ports': [(31000, 32000)],
-                'cores': [(0, 8)]
-            }, 1, [self.numa_attr])
-        ]
-
-    def _status_update(self, task_id, state):
-        status = _make_status(task_id, state)
-        self.sched.statusUpdate(self.driver, status)
-        return status
-
-    def _make_physical(self):
-        self.physical_graph = scheduler.instantiate(self.logical_graph)
-        self.physical_batch_graph = scheduler.instantiate(self.logical_batch_graph)
-        self.nodes = []
-        for i in range(3):
-            self.nodes.append(next(node for node in self.physical_graph
-                                   if node.name == 'node{}'.format(i)))
-        self.nodes[2].host = 'remotehost'
-        self.nodes[2].ports['foo'] = 10000
-        self.batch_nodes = []
-        for i in range(2):
-            self.batch_nodes.append(next(node for node in self.physical_batch_graph
-                                         if node.name == 'batch{}'.format(i)))
-
-    async def _wait_request(self, task_id):
-        async with aiohttp.ClientSession() as session:
-            async with session.get('http://127.0.0.1:{}/tasks/{}/wait_start'.format(
-                    self.sched.http_port, task_id)) as resp:
-                resp.raise_for_status()
-                await resp.read()
+    # Override pytest-asyncio to use async-solipsism event loop
+    @pytest.fixture
+    def event_loop(self):
+        loop = async_solipsism.EventLoop()
+        yield loop
+        loop.close()
 
     @staticmethod
     def _dummy_random():
@@ -1521,109 +1478,245 @@ class TestScheduler(asynctest.ClockedTestCase):
     def _dummy_randint(a, b):
         return a
 
-    def _driver_calls(self):
-        """self.driver.mock_calls, with reconcileTasks filtered out."""
-        return [call for call in self.driver.mock_calls if call[0] != 'reconcileTasks']
+    class Fixture:
+        def __init__(self) -> None:
+            self.framework_id = 'frameworkid'
+            # Normally TaskIDAllocator's constructor returns a singleton to keep
+            # IDs globally unique, but we want the test to be isolated. Bypass its
+            # __new__.
+            self.image_resolver = scheduler.ImageResolver(scheduler.SimpleImageLookup('sdp'))
+            self.task_id_allocator = object.__new__(scheduler.TaskIDAllocator)
+            self.task_id_allocator._prefix = 'test-'
+            self.task_id_allocator._next_id = 0
+            node0 = scheduler.LogicalTask('node0')
+            node0.cpus = 1.0
+            node0.command = ['hello', '--port={ports[port]}']
+            node0.ports = ['port']
+            node0.image = 'image0'
+            node0.gpus.append(scheduler.GPURequest())
+            node0.gpus[-1].compute = 0.5
+            node0.gpus[-1].mem = 256.0
+            node0.interfaces = [
+                scheduler.InterfaceRequest('net0', infiniband=True, multicast_out={'mc'})
+            ]
+            node0.interfaces[-1].bandwidth_in = 500e6
+            node0.interfaces[-1].bandwidth_out = 200e6
+            node0.volumes = [scheduler.VolumeRequest('vol0', '/container-path', 'RW')]
+            node1 = scheduler.LogicalTask('node1')
+            node1.cpus = 0.5
+            node1.command = ['test', '--host={host}', '--remote={endpoints[node0_port]}',
+                             '--another={endpoints[node2_foo]}']
+            node1.image = 'image1'
+            node1.cores = ['core0', 'core1']
+            node2 = scheduler.LogicalExternal('node2')
+            node2.wait_ports = []
+            batch_nodes = []
+            for i in range(2):
+                batch_node = scheduler.LogicalTask('batch{}'.format(i))
+                batch_node.image = 'batch_image'
+                batch_node.cpus = 0.5
+                batch_node.mem = 256
+                batch_node.max_run_time = 10
+                batch_node.command = ['/bin/echo', 'Hello']
+                batch_nodes.append(batch_node)
+            # The order is determined by the lexicographical_topological_sort done in _launch_group
+            self.task_ids = ['test-00000000', 'test-00000001', None]
+            self.logical_graph = networkx.MultiDiGraph()
+            self.logical_graph.add_nodes_from([node0, node1, node2])
+            self.logical_graph.add_edge(node1, node0, port='port',
+                                        depends_ready=True, depends_kill=True)
+            self.logical_graph.add_edge(node1, node2, port='foo',
+                                        depends_ready=True, depends_kill=True)
+            self.logical_batch_graph = networkx.MultiDiGraph()
+            self.logical_batch_graph.add_node(batch_nodes[0])
+            self.logical_batch_graph.add_node(batch_nodes[1])
+            self.logical_batch_graph.add_edge(batch_nodes[1], batch_nodes[0], depends_finished=True)
+            self.numa_attr = _make_json_attr('katsdpcontroller.numa', [[0, 2, 4, 6], [1, 3, 5, 7]])
+            self.agent0_attrs = [
+                _make_json_attr('katsdpcontroller.gpus', [
+                    {'uuid': 'GPU-123',
+                     'name': 'Dummy GPU', 'device_attributes': {}, 'compute_capability': (5, 2)},
+                    {'uuid': 'GPU-456',
+                     'name': 'Dummy GPU', 'device_attributes': {}, 'compute_capability': (5, 2)}
+                ]),
+                _make_json_attr('katsdpcontroller.volumes', [
+                    {'name': 'vol0', 'host_path': '/host0'}
+                ]),
+                _make_json_attr('katsdpcontroller.interfaces', [
+                    {'name': 'eth0', 'network': 'net0', 'ipv4_address': '192.168.1.1',
+                     'infiniband_devices': ['/dev/infiniband/rdma_cm', '/dev/infiniband/uverbs0'],
+                     'infiniband_multicast_loopback': False}]),
+                self.numa_attr
+            ]
+            self._make_physical()
+            self.task_stats = SimpleTaskStats()
+            self.sched = scheduler.Scheduler('default', '127.0.0.1', 80, 'http://scheduler/',
+                                             task_stats=self.task_stats)
+            self.resolver = scheduler.Resolver(self.image_resolver, self.task_id_allocator,
+                                               self.sched.http_url)
+            self.driver = mock.create_autospec(pymesos.MesosSchedulerDriver,
+                                               spec_set=True, instance=True)
+            self.sched.set_driver(self.driver)
+            self.sched.registered(self.driver, 'framework', mock.sentinel.master_info)
 
-    async def setUp(self):
-        self.framework_id = 'frameworkid'
-        # Normally TaskIDAllocator's constructor returns a singleton to keep
-        # IDs globally unique, but we want the test to be isolated. Bypass its
-        # __new__.
-        self.image_resolver = scheduler.ImageResolver(scheduler.SimpleImageLookup('sdp'))
-        self.task_id_allocator = object.__new__(scheduler.TaskIDAllocator)
-        self.task_id_allocator._prefix = 'test-'
-        self.task_id_allocator._next_id = 0
-        node0 = scheduler.LogicalTask('node0')
-        node0.cpus = 1.0
-        node0.command = ['hello', '--port={ports[port]}']
-        node0.ports = ['port']
-        node0.image = 'image0'
-        node0.gpus.append(scheduler.GPURequest())
-        node0.gpus[-1].compute = 0.5
-        node0.gpus[-1].mem = 256.0
-        node0.interfaces = [
-            scheduler.InterfaceRequest('net0', infiniband=True, multicast_out={'mc'})
-        ]
-        node0.interfaces[-1].bandwidth_in = 500e6
-        node0.interfaces[-1].bandwidth_out = 200e6
-        node0.volumes = [scheduler.VolumeRequest('vol0', '/container-path', 'RW')]
-        node1 = scheduler.LogicalTask('node1')
-        node1.cpus = 0.5
-        node1.command = ['test', '--host={host}', '--remote={endpoints[node0_port]}',
-                         '--another={endpoints[node2_foo]}']
-        node1.image = 'image1'
-        node1.cores = ['core0', 'core1']
-        node2 = scheduler.LogicalExternal('node2')
-        node2.wait_ports = []
-        batch_nodes = []
-        for i in range(2):
-            batch_node = scheduler.LogicalTask('batch{}'.format(i))
-            batch_node.image = 'batch_image'
-            batch_node.cpus = 0.5
-            batch_node.mem = 256
-            batch_node.max_run_time = 10
-            batch_node.command = ['/bin/echo', 'Hello']
-            batch_nodes.append(batch_node)
-        # The order is determined by the lexicographical_topological_sort done in _launch_group
-        self.task_ids = ['test-00000000', 'test-00000001', None]
-        self.logical_graph = networkx.MultiDiGraph()
-        self.logical_graph.add_nodes_from([node0, node1, node2])
-        self.logical_graph.add_edge(node1, node0, port='port',
-                                    depends_ready=True, depends_kill=True)
-        self.logical_graph.add_edge(node1, node2, port='foo', depends_ready=True, depends_kill=True)
-        self.logical_batch_graph = networkx.MultiDiGraph()
-        self.logical_batch_graph.add_node(batch_nodes[0])
-        self.logical_batch_graph.add_node(batch_nodes[1])
-        self.logical_batch_graph.add_edge(batch_nodes[1], batch_nodes[0], depends_finished=True)
-        self.numa_attr = _make_json_attr('katsdpcontroller.numa', [[0, 2, 4, 6], [1, 3, 5, 7]])
-        self.agent0_attrs = [
-            _make_json_attr('katsdpcontroller.gpus', [
-                {'uuid': 'GPU-123',
-                 'name': 'Dummy GPU', 'device_attributes': {}, 'compute_capability': (5, 2)},
-                {'uuid': 'GPU-456',
-                 'name': 'Dummy GPU', 'device_attributes': {}, 'compute_capability': (5, 2)}
-            ]),
-            _make_json_attr('katsdpcontroller.volumes', [
-                {'name': 'vol0', 'host_path': '/host0'}
-            ]),
-            _make_json_attr('katsdpcontroller.interfaces', [
-                {'name': 'eth0', 'network': 'net0', 'ipv4_address': '192.168.1.1',
-                 'infiniband_devices': ['/dev/infiniband/rdma_cm', '/dev/infiniband/uverbs0'],
-                 'infiniband_multicast_loopback': False}]),
-            self.numa_attr
-        ]
-        self._make_physical()
-        self.task_stats = SimpleTaskStats()
-        self.sched = scheduler.Scheduler('default', '127.0.0.1', 0, 'http://scheduler/',
-                                         task_stats=self.task_stats)
-        self.resolver = scheduler.Resolver(self.image_resolver, self.task_id_allocator,
-                                           self.sched.http_url)
-        self.driver = mock.create_autospec(pymesos.MesosSchedulerDriver,
-                                           spec_set=True, instance=True)
-        self.sched.set_driver(self.driver)
-        self.sched.registered(self.driver, 'framework', mock.sentinel.master_info)
+        def _make_offer(self, resources, agent_num=0, attrs=()):
+            return _make_offer(self.framework_id, 'agentid{}'.format(agent_num),
+                               'agenthost{}'.format(agent_num), resources, attrs)
+
+        def _make_offers(self, ports=None):
+            if ports is None:
+                ports = [(30000, 31000)]
+            return [
+                # Suitable for node0
+                self._make_offer({
+                    'cpus': 2.0, 'mem': 1024.0, 'ports': ports,
+                    'katsdpcontroller.gpu.0.compute': 0.25,
+                    'katsdpcontroller.gpu.0.mem': 2048.0,
+                    'katsdpcontroller.gpu.1.compute': 1.0,
+                    'katsdpcontroller.gpu.1.mem': 1024.0,
+                    'katsdpcontroller.interface.0.bandwidth_in': 1e9,
+                    'katsdpcontroller.interface.0.bandwidth_out': 1e9
+                }, 0, self.agent0_attrs),
+                # Suitable for node1
+                self._make_offer({
+                    'cpus': 0.5, 'mem': 128.0, 'ports': [(31000, 32000)],
+                    'cores': [(0, 8)]
+                }, 1, [self.numa_attr])
+            ]
+
+        def _status_update(self, task_id, state):
+            status = _make_status(task_id, state)
+            self.sched.statusUpdate(self.driver, status)
+            return status
+
+        def _make_physical(self):
+            self.physical_graph = scheduler.instantiate(self.logical_graph)
+            self.physical_batch_graph = scheduler.instantiate(self.logical_batch_graph)
+            self.nodes = []
+            for i in range(3):
+                self.nodes.append(next(node for node in self.physical_graph
+                                       if node.name == 'node{}'.format(i)))
+            self.nodes[2].host = 'remotehost'
+            self.nodes[2].ports['foo'] = 10000
+            self.batch_nodes = []
+            for i in range(2):
+                self.batch_nodes.append(next(node for node in self.physical_batch_graph
+                                             if node.name == 'batch{}'.format(i)))
+
+        async def _wait_request(self, task_id):
+            async with aiohttp.ClientSession() as session:
+                async with session.get('http://127.0.0.1:{}/tasks/{}/wait_start'.format(
+                        self.sched.http_port, task_id)) as resp:
+                    resp.raise_for_status()
+                    await resp.read()
+
+        def _driver_calls(self):
+            """self.driver.mock_calls, with reconcileTasks filtered out."""
+            return [call for call in self.driver.mock_calls if call[0] != 'reconcileTasks']
+
+        async def _transition_node0(self, target_state, nodes=None, ports=None):
+            """Launch the graph and proceed until node0 is in `target_state`.
+
+            This is intended to be used in test setup. It is assumed that this
+            functionality is more fully tested in test_launch_serial, so minimal
+            assertions are made.
+
+            Returns
+            -------
+            launch, kill : :class:`asyncio.Task`
+                Asynchronous tasks for launching and killing the graph. If
+                `target_state` is not :const:`TaskState.KILLING` or
+                :const:`TaskState.DEAD`, then `kill` is ``None``
+            """
+            assert target_state > TaskState.NOT_READY
+            offers = self._make_offers(ports)
+            launch = asyncio.ensure_future(
+                self.sched.launch(self.physical_graph, self.resolver, nodes))
+            kill = None
+            await exhaust_callbacks()
+            assert self.nodes[0].state == TaskState.STARTING
+            with mock.patch.object(scheduler, 'poll_ports', autospec=True) as poll_ports:
+                poll_future = future_return(poll_ports)
+                if target_state > TaskState.STARTING:
+                    self.sched.resourceOffers(self.driver, offers)
+                    await exhaust_callbacks()
+                    assert self.nodes[0].state == TaskState.STARTED
+                    task_id = self.nodes[0].taskinfo.task_id.value
+                    if target_state > TaskState.STARTED:
+                        self._status_update(task_id, 'TASK_RUNNING')
+                        await exhaust_callbacks()
+                        assert self.nodes[0].state == TaskState.RUNNING
+                        if target_state > TaskState.RUNNING:
+                            poll_future.set_result(None)   # Mark ports as ready
+                            await exhaust_callbacks()
+                            assert self.nodes[0].state == TaskState.READY
+                            if target_state > TaskState.READY:
+                                kill = asyncio.ensure_future(
+                                    self.sched.kill(self.physical_graph, nodes))
+                                await exhaust_callbacks()
+                                assert self.nodes[0].state == TaskState.KILLING
+                                if target_state > TaskState.KILLING:
+                                    self._status_update(task_id, 'TASK_KILLED')
+                                await exhaust_callbacks()
+            self.driver.reset_mock()
+            assert self.nodes[0].state == target_state
+            return (launch, kill)
+
+        async def _transition_batch_run(
+                self, node: scheduler.PhysicalTask, state: TaskState) -> None:
+            """Interact with scheduler to get batch task to state `state`.
+
+            It is assumed that it has already been launched.
+            """
+            if state >= TaskState.STARTED:
+                await exhaust_callbacks()
+                self.sched.resourceOffers(self.driver, self._make_offers())
+                await exhaust_callbacks()
+                assert node.state == TaskState.STARTED
+                if state >= TaskState.READY:
+                    task_id = node.taskinfo.task_id.value  # type: ignore
+                    self._status_update(task_id, 'TASK_RUNNING')
+                    await exhaust_callbacks()
+                    assert node.state == TaskState.READY
+                    if state >= TaskState.DEAD:
+                        self._status_update(task_id, 'TASK_FINISHED')
+                        await exhaust_callbacks()
+                        assert node.state == TaskState.DEAD
+
+        async def _ready_graph(self):
+            """Gets the whole graph to READY state"""
+            launch, kill = await self._transition_node0(TaskState.READY)
+            self._status_update(self.nodes[1].taskinfo.task_id.value, 'TASK_RUNNING')
+            await exhaust_callbacks()
+            assert launch.done()  # Ensures the next line won't hang the test
+            await launch
+            self.driver.reset_mock()
+
+    @pytest.fixture(autouse=True)
+    async def fix(self, mocker) -> 'TestScheduler.Fixture':
         # Mock out the random generator so that port allocations will be
         # predictable.
-        create_patch(self, 'katsdpcontroller.scheduler.Agent._random.random', self._dummy_random)
-        create_patch(self, 'katsdpcontroller.scheduler.Agent._random.randint', self._dummy_randint)
-        await self.sched.start()
+        mocker.patch('katsdpcontroller.scheduler.Agent._random.random', self._dummy_random)
+        mocker.patch('katsdpcontroller.scheduler.Agent._random.randint', self._dummy_randint)
+        fix = TestScheduler.Fixture()
+        await fix.sched.start()
+        return fix
 
-    async def test_initial_offers(self):
+    async def test_initial_offers(self, fix: 'TestScheduler.Fixture') -> None:
         """Offers passed to resourcesOffers in initial state are declined"""
         offers = [
-            self._make_offer({'cpus': 2.0}, 0),
-            self._make_offer({'cpus': 1.0}, 1),
-            self._make_offer({'cpus': 1.5}, 0)
+            fix._make_offer({'cpus': 2.0}, 0),
+            fix._make_offer({'cpus': 1.0}, 1),
+            fix._make_offer({'cpus': 1.5}, 0)
         ]
-        self.sched.resourceOffers(self.driver, offers)
+        fix.sched.resourceOffers(fix.driver, offers)
         await exhaust_callbacks()
-        assert self._driver_calls() == AnyOrderList([
+        assert fix._driver_calls() == AnyOrderList([
             mock.call.declineOffer(AnyOrderList([offers[0].id, offers[1].id, offers[2].id])),
             mock.call.suppressOffers({'default'})
         ])
 
-    async def test_launch_cycle(self):
+    async def test_launch_cycle(self, fix: 'TestScheduler.Fixture') -> None:
         """Launch raises CycleError if there is a cycle of depends_ready edges"""
         nodes = [scheduler.LogicalExternal('node{}'.format(i)) for i in range(4)]
         logical_graph = networkx.MultiDiGraph()
@@ -1634,9 +1727,9 @@ class TestScheduler(asynctest.ClockedTestCase):
         logical_graph.add_edge(nodes[3], nodes[1], depends_ready=True)
         physical_graph = scheduler.instantiate(logical_graph)
         with pytest.raises(scheduler.CycleError):
-            await self.sched.launch(physical_graph, self.resolver)
+            await fix.sched.launch(physical_graph, fix.resolver)
 
-    async def test_launch_omit_dependency(self):
+    async def test_launch_omit_dependency(self, fix: 'TestScheduler.Fixture') -> None:
         """Launch raises DependencyError if launching a subset of nodes that
         depends on a node that is outside the set and not running.
         """
@@ -1647,40 +1740,40 @@ class TestScheduler(asynctest.ClockedTestCase):
         physical_graph = scheduler.instantiate(logical_graph)
         target = [node for node in physical_graph if node.name == 'node1']
         with pytest.raises(scheduler.DependencyError):
-            await self.sched.launch(physical_graph, self.resolver, target)
+            await fix.sched.launch(physical_graph, fix.resolver, target)
 
-    async def test_add_queue_twice(self):
+    async def test_add_queue_twice(self, fix: 'TestScheduler.Fixture') -> None:
         queue = scheduler.LaunchQueue('default')
-        self.sched.add_queue(queue)
+        fix.sched.add_queue(queue)
         with pytest.raises(ValueError):
-            self.sched.add_queue(queue)
+            fix.sched.add_queue(queue)
 
-    async def test_remove_nonexistent_queue(self):
+    async def test_remove_nonexistent_queue(self, fix: 'TestScheduler.Fixture') -> None:
         with pytest.raises(ValueError):
-            self.sched.remove_queue(scheduler.LaunchQueue('default'))
+            fix.sched.remove_queue(scheduler.LaunchQueue('default'))
 
-    async def test_launch_bad_queue(self):
+    async def test_launch_bad_queue(self, fix: 'TestScheduler.Fixture') -> None:
         """Launch raises ValueError if queue has been added"""
         queue = scheduler.LaunchQueue('default')
         with pytest.raises(ValueError):
-            await self.sched.launch(self.physical_graph, self.resolver, queue=queue)
+            await fix.sched.launch(fix.physical_graph, fix.resolver, queue=queue)
 
-    async def test_launch_closing(self):
+    async def test_launch_closing(self, fix: 'TestScheduler.Fixture') -> None:
         """Launch raises asyncio.InvalidStateError if close has been called"""
-        await self.sched.close()
+        await fix.sched.close()
         with pytest.raises(asyncio.InvalidStateError):
             # Timeout is just to ensure the test won't hang
-            await asyncio.wait_for(self.sched.launch(self.physical_graph, self.resolver),
+            await asyncio.wait_for(fix.sched.launch(fix.physical_graph, fix.resolver),
                                    timeout=1)
 
-    async def test_launch_serial(self):
+    async def test_launch_serial(self, fix: 'TestScheduler.Fixture') -> None:
         """Test launch on the success path, with no concurrent calls."""
         # TODO: still need to extend this to test:
         # - custom wait_ports
-        offer0, offer1 = self._make_offers()
+        offer0, offer1 = fix._make_offers()
         expected_taskinfo0 = Dict()
         expected_taskinfo0.name = 'node0'
-        expected_taskinfo0.task_id.value = self.task_ids[0]
+        expected_taskinfo0.task_id.value = fix.task_ids[0]
         expected_taskinfo0.agent_id.value = 'agentid0'
         expected_taskinfo0.command.shell = False
         expected_taskinfo0.command.value = 'hello'
@@ -1712,7 +1805,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         expected_taskinfo0.discovery.ports.ports = [Dict(number=30000, name='port', protocol='tcp')]
         expected_taskinfo1 = Dict()
         expected_taskinfo1.name = 'node1'
-        expected_taskinfo1.task_id.value = self.task_ids[1]
+        expected_taskinfo1.task_id.value = fix.task_ids[1]
         expected_taskinfo1.agent_id.value = 'agentid1'
         expected_taskinfo1.command.shell = False
         uri = Dict()
@@ -1721,7 +1814,7 @@ class TestScheduler(asynctest.ClockedTestCase):
         expected_taskinfo1.command.uris = [uri]
         expected_taskinfo1.command.value = '/mnt/mesos/sandbox/delay_run.sh'
         expected_taskinfo1.command.arguments = [
-            'http://scheduler/tasks/{}/wait_start'.format(self.task_ids[1]),
+            'http://scheduler/tasks/{}/wait_start'.format(fix.task_ids[1]),
             'test', '--host=agenthost1', '--remote=agenthost0:30000',
             '--another=remotehost:10000']
         expected_taskinfo1.container.type = 'DOCKER'
@@ -1733,67 +1826,67 @@ class TestScheduler(asynctest.ClockedTestCase):
         expected_taskinfo1.discovery.name = 'node1'
         expected_taskinfo1.discovery.ports.ports = []
 
-        launch = asyncio.ensure_future(self.sched.launch(
-            self.physical_graph, self.resolver))
+        launch = asyncio.ensure_future(fix.sched.launch(
+            fix.physical_graph, fix.resolver))
         await exhaust_callbacks()
         # The tasks must be in state STARTING, but not yet RUNNING because
         # there are no offers.
-        for node in self.nodes:
+        for node in fix.nodes:
             assert node.state == TaskState.STARTING
             assert not node.ready_event.is_set()
             assert not node.dead_event.is_set()
-        assert self.task_stats.state_counts == {TaskState.STARTING: 2}
-        assert self._driver_calls() == [mock.call.reviveOffers({'default'})]
-        self.driver.reset_mock()
+        assert fix.task_stats.state_counts == {TaskState.STARTING: 2}
+        assert fix._driver_calls() == [mock.call.reviveOffers({'default'})]
+        fix.driver.reset_mock()
         # Now provide an offer that is suitable for node1 but not node0.
         # Nothing should happen, because we don't yet have enough resources.
-        self.sched.resourceOffers(self.driver, [offer1])
+        fix.sched.resourceOffers(fix.driver, [offer1])
         await exhaust_callbacks()
-        assert self._driver_calls() == []
-        for node in self.nodes:
+        assert fix._driver_calls() == []
+        for node in fix.nodes:
             assert node.state == TaskState.STARTING
             assert not node.ready_event.is_set()
             assert not node.dead_event.is_set()
         # Provide offer suitable for launching node0. At this point all nodes
         # should launch.
-        self.sched.resourceOffers(self.driver, [offer0])
-        await self.advance(60)   # For the benefit of test_launch_slow_resolve
+        fix.sched.resourceOffers(fix.driver, [offer0])
+        await asyncio.sleep(60)   # For the benefit of test_launch_slow_resolve
 
-        assert self.nodes[0].state == TaskState.STARTED
-        assert self.nodes[0].taskinfo.resources == expected_taskinfo0.resources
-        assert self.nodes[0].taskinfo == expected_taskinfo0
-        assert self.nodes[0].host == 'agenthost0'
-        assert self.nodes[0].agent_id == 'agentid0'
-        assert self.nodes[0].ports == {'port': 30000}
-        assert self.nodes[0].cores == {}
-        assert self.nodes[0].status is None
+        assert fix.nodes[0].state == TaskState.STARTED
+        assert fix.nodes[0].taskinfo.resources == expected_taskinfo0.resources
+        assert fix.nodes[0].taskinfo == expected_taskinfo0
+        assert fix.nodes[0].host == 'agenthost0'
+        assert fix.nodes[0].agent_id == 'agentid0'
+        assert fix.nodes[0].ports == {'port': 30000}
+        assert fix.nodes[0].cores == {}
+        assert fix.nodes[0].status is None
 
-        assert self.nodes[1].taskinfo == expected_taskinfo1
-        assert self.nodes[1].agent_id == 'agentid1'
-        assert self.nodes[1].state == TaskState.STARTED
+        assert fix.nodes[1].taskinfo == expected_taskinfo1
+        assert fix.nodes[1].agent_id == 'agentid1'
+        assert fix.nodes[1].state == TaskState.STARTED
 
-        assert self.nodes[2].state == TaskState.READY
-        assert self._driver_calls() == AnyOrderList([
+        assert fix.nodes[2].state == TaskState.READY
+        assert fix._driver_calls() == AnyOrderList([
             mock.call.launchTasks([offer0.id], [expected_taskinfo0]),
             mock.call.launchTasks([offer1.id], [expected_taskinfo1]),
             mock.call.suppressOffers({'default'})
         ])
-        self.driver.reset_mock()
-        assert self.task_stats.state_counts == {TaskState.STARTED: 2}
+        fix.driver.reset_mock()
+        assert fix.task_stats.state_counts == {TaskState.STARTED: 2}
 
         # Tell scheduler that node1 is now running. It should go to RUNNING
         # but not READY, because node0 isn't ready yet.
-        status = self._status_update(self.task_ids[1], 'TASK_RUNNING')
+        status = fix._status_update(fix.task_ids[1], 'TASK_RUNNING')
         await exhaust_callbacks()
-        assert self.nodes[1].state == TaskState.RUNNING
-        assert self.nodes[1].status == status
-        assert self._driver_calls() == [mock.call.acknowledgeStatusUpdate(status)]
-        self.driver.reset_mock()
-        assert self.task_stats.state_counts == {TaskState.STARTED: 1, TaskState.RUNNING: 1}
+        assert fix.nodes[1].state == TaskState.RUNNING
+        assert fix.nodes[1].status == status
+        assert fix._driver_calls() == [mock.call.acknowledgeStatusUpdate(status)]
+        fix.driver.reset_mock()
+        assert fix.task_stats.state_counts == {TaskState.STARTED: 1, TaskState.RUNNING: 1}
 
         # A real node1 would issue an HTTP request back to the scheduler. Fake
         # it instead, to check the timing.
-        wait_request = self.loop.create_task(self._wait_request(self.task_ids[1]))
+        wait_request = asyncio.create_task(fix._wait_request(fix.task_ids[1]))
         await exhaust_callbacks()
         assert not wait_request.done()
 
@@ -1801,27 +1894,27 @@ class TestScheduler(asynctest.ClockedTestCase):
         # the waiter, so we need to mock poll_ports.
         with mock.patch.object(scheduler, 'poll_ports', autospec=True) as poll_ports:
             poll_future = future_return(poll_ports)
-            status = self._status_update(self.task_ids[0], 'TASK_RUNNING')
+            status = fix._status_update(fix.task_ids[0], 'TASK_RUNNING')
             await exhaust_callbacks()
-            assert self.nodes[0].state == TaskState.RUNNING
-            assert self.nodes[0].status == status
-            assert self._driver_calls() == [mock.call.acknowledgeStatusUpdate(status)]
-            self.driver.reset_mock()
+            assert fix.nodes[0].state == TaskState.RUNNING
+            assert fix.nodes[0].status == status
+            assert fix._driver_calls() == [mock.call.acknowledgeStatusUpdate(status)]
+            fix.driver.reset_mock()
             poll_ports.assert_called_once_with('agenthost0', [30000])
-        assert self.task_stats.state_counts == {TaskState.RUNNING: 2}
+        assert fix.task_stats.state_counts == {TaskState.RUNNING: 2}
 
         # Make poll_ports ready. Node 0 should now become ready, which will
         # make node 1 ready too.
         poll_future.set_result(None)
         await exhaust_callbacks()
-        assert self.nodes[0].state == TaskState.READY
+        assert fix.nodes[0].state == TaskState.READY
         await wait_request
-        assert self.nodes[1].state == TaskState.READY
+        assert fix.nodes[1].state == TaskState.READY
         assert launch.done()
-        assert self.task_stats.state_counts == {TaskState.READY: 2}
+        assert fix.task_stats.state_counts == {TaskState.READY: 2}
         await launch
 
-    async def test_launch_slow_resolve(self):
+    async def test_launch_slow_resolve(self, fix: 'TestScheduler.Fixture') -> None:
         """Like test_launch_serial, but where a task has a slow resolve call.
 
         This is a regression test for SR-1093.
@@ -1831,177 +1924,121 @@ class TestScheduler(asynctest.ClockedTestCase):
                 await asyncio.sleep(30)
                 await super().resolve(resolver, graph, image_path=None)
 
-        for node in self.logical_graph.nodes():
+        for node in fix.logical_graph.nodes():
             if node.name == 'node0':
                 node.physical_factory = SlowResolve
                 break
         else:
             raise KeyError('Could not find node0')
-        self._make_physical()
-        await self.test_launch_serial()
+        fix._make_physical()
+        await self.test_launch_serial(fix)
 
-    async def _transition_node0(self, target_state, nodes=None, ports=None):
-        """Launch the graph and proceed until node0 is in `target_state`.
-
-        This is intended to be used in test setup. It is assumed that this
-        functionality is more fully tested in test_launch_serial, so minimal
-        assertions are made.
-
-        Returns
-        -------
-        launch, kill : :class:`asyncio.Task`
-            Asynchronous tasks for launching and killing the graph. If
-            `target_state` is not :const:`TaskState.KILLING` or
-            :const:`TaskState.DEAD`, then `kill` is ``None``
-        """
-        assert target_state > TaskState.NOT_READY
-        offers = self._make_offers(ports)
-        launch = asyncio.ensure_future(
-            self.sched.launch(self.physical_graph, self.resolver, nodes))
-        kill = None
-        await exhaust_callbacks()
-        assert self.nodes[0].state == TaskState.STARTING
-        with mock.patch.object(scheduler, 'poll_ports', autospec=True) as poll_ports:
-            poll_future = future_return(poll_ports)
-            if target_state > TaskState.STARTING:
-                self.sched.resourceOffers(self.driver, offers)
-                await exhaust_callbacks()
-                assert self.nodes[0].state == TaskState.STARTED
-                task_id = self.nodes[0].taskinfo.task_id.value
-                if target_state > TaskState.STARTED:
-                    self._status_update(task_id, 'TASK_RUNNING')
-                    await exhaust_callbacks()
-                    assert self.nodes[0].state == TaskState.RUNNING
-                    if target_state > TaskState.RUNNING:
-                        poll_future.set_result(None)   # Mark ports as ready
-                        await exhaust_callbacks()
-                        assert self.nodes[0].state == TaskState.READY
-                        if target_state > TaskState.READY:
-                            kill = asyncio.ensure_future(
-                                self.sched.kill(self.physical_graph, nodes))
-                            await exhaust_callbacks()
-                            assert self.nodes[0].state == TaskState.KILLING
-                            if target_state > TaskState.KILLING:
-                                self._status_update(task_id, 'TASK_KILLED')
-                            await exhaust_callbacks()
-        self.driver.reset_mock()
-        assert self.nodes[0].state == target_state
-        return (launch, kill)
-
-    async def _ready_graph(self):
-        """Gets the whole graph to READY state"""
-        launch, kill = await self._transition_node0(TaskState.READY)
-        self._status_update(self.nodes[1].taskinfo.task_id.value, 'TASK_RUNNING')
-        await exhaust_callbacks()
-        assert launch.done()  # Ensures the next line won't hang the test
-        await launch
-        self.driver.reset_mock()
-
-    async def test_multiple_queues(self):
+    async def test_multiple_queues(self, fix: 'TestScheduler.Fixture') -> None:
         # Remove the dependency between nodes so that they can be launched
         # independently
-        self.physical_graph.remove_edge(self.nodes[1], self.nodes[0])
-        self.nodes[1].logical_node.command = [
+        fix.physical_graph.remove_edge(fix.nodes[1], fix.nodes[0])
+        fix.nodes[1].logical_node.command = [
             'test', '--host={host}', '--another={endpoints[node2_foo]}']
         # Schedule the nodes separately on separate queues
         queue = scheduler.LaunchQueue('default')
-        self.sched.add_queue(queue)
-        launch0, kill0 = await self._transition_node0(TaskState.STARTING, [self.nodes[0]])
+        fix.sched.add_queue(queue)
+        launch0, kill0 = await fix._transition_node0(TaskState.STARTING, [fix.nodes[0]])
         launch1 = asyncio.ensure_future(
-            self.sched.launch(self.physical_graph, self.resolver,
-                              self.nodes[1:], queue=queue))
+            fix.sched.launch(fix.physical_graph, fix.resolver,
+                             fix.nodes[1:], queue=queue))
         # Make an offer so that node1 can start
-        offers = self._make_offers()
-        self.sched.resourceOffers(self.driver, [offers[1]])
+        offers = fix._make_offers()
+        fix.sched.resourceOffers(fix.driver, [offers[1]])
         await exhaust_callbacks()
-        assert self.nodes[1].state == TaskState.STARTED
-        self._status_update(self.nodes[1].taskinfo.task_id.value, 'TASK_RUNNING')
+        assert fix.nodes[1].state == TaskState.STARTED
+        fix._status_update(fix.nodes[1].taskinfo.task_id.value, 'TASK_RUNNING')
         await exhaust_callbacks()
         assert launch1.done()
 
         # Now unblock node0
-        assert self.nodes[0].state == TaskState.STARTING
-        self.sched.resourceOffers(self.driver, [offers[0]])
+        assert fix.nodes[0].state == TaskState.STARTING
+        fix.sched.resourceOffers(fix.driver, [offers[0]])
         await exhaust_callbacks()
-        assert self.nodes[0].state == TaskState.STARTED
+        assert fix.nodes[0].state == TaskState.STARTED
         with mock.patch.object(scheduler, 'poll_ports', autospec=True) as poll_ports:
             poll_future = future_return(poll_ports)
             poll_future.set_result(None)   # Mark ports as ready
-            self._status_update(self.nodes[0].taskinfo.task_id.value, 'TASK_RUNNING')
+            fix._status_update(fix.nodes[0].taskinfo.task_id.value, 'TASK_RUNNING')
             await exhaust_callbacks()
-        assert self.nodes[0].state == TaskState.READY
+        assert fix.nodes[0].state == TaskState.READY
         assert launch0.done()
 
-    async def _test_launch_cancel(self, target_state):
-        launch, kill = await self._transition_node0(target_state)
+    async def _test_launch_cancel(
+            self, target_state: TaskState, fix: 'TestScheduler.Fixture') -> None:
+        launch, kill = await fix._transition_node0(target_state)
         assert not launch.done()
         # Now cancel and check that nodes go back to NOT_READY if they were
         # in STARTING, otherwise keep their state.
         launch.cancel()
         await exhaust_callbacks()
         if target_state == TaskState.STARTING:
-            for node in self.nodes:
+            for node in fix.nodes:
                 assert node.state == TaskState.NOT_READY
         else:
-            assert self.nodes[0].state == target_state
+            assert fix.nodes[0].state == target_state
 
-    async def test_launch_cancel_wait_task(self):
+    async def test_launch_cancel_wait_task(self, fix: 'TestScheduler.Fixture') -> None:
         """Test cancelling a launch while waiting for a task to become READY"""
-        await self._test_launch_cancel(TaskState.RUNNING)
+        await self._test_launch_cancel(TaskState.RUNNING, fix)
 
-    async def test_launch_cancel_wait_resource(self):
+    async def test_launch_cancel_wait_resource(self, fix: 'TestScheduler.Fixture') -> None:
         """Test cancelling a launch while waiting for resources"""
-        await self._test_launch_cancel(TaskState.STARTING)
+        await self._test_launch_cancel(TaskState.STARTING, fix)
 
-    async def test_launch_resources_timeout(self):
+    async def test_launch_resources_timeout(self, fix: 'TestScheduler.Fixture') -> None:
         """Test a launch failing due to insufficient resources within the timeout"""
-        launch, kill = await self._transition_node0(TaskState.STARTING)
-        await self.advance(30)
+        launch, kill = await fix._transition_node0(TaskState.STARTING)
+        await asyncio.sleep(30)
         with pytest.raises(scheduler.InsufficientResourcesError):
             await launch
-        assert self.nodes[0].state == TaskState.NOT_READY
-        assert self.nodes[1].state == TaskState.NOT_READY
-        assert self.nodes[2].state == TaskState.NOT_READY
+        assert fix.nodes[0].state == TaskState.NOT_READY
+        assert fix.nodes[1].state == TaskState.NOT_READY
+        assert fix.nodes[2].state == TaskState.NOT_READY
         # Once we abort, we should no longer be interested in offers
-        assert self._driver_calls() == [mock.call.suppressOffers({'default'})]
+        assert fix._driver_calls() == [mock.call.suppressOffers({'default'})]
 
-    async def test_launch_queue_busy(self):
+    async def test_launch_queue_busy(self, fix: 'TestScheduler.Fixture') -> None:
         """Test a launch failing due to tasks ahead of it blocking the queue."""
-        launch, kill = await self._transition_node0(TaskState.STARTING, nodes=[self.nodes[0]])
+        launch, kill = await fix._transition_node0(TaskState.STARTING, nodes=[fix.nodes[0]])
         launch1 = asyncio.ensure_future(
-            self.sched.launch(self.physical_graph, self.resolver, [self.nodes[2]],
-                              resources_timeout=2))
-        await self.advance(3)
+            fix.sched.launch(fix.physical_graph, fix.resolver, [fix.nodes[2]],
+                             resources_timeout=2))
+        await asyncio.sleep(3)
         with pytest.raises(scheduler.QueueBusyError, match='(2s)') as cm:
             await launch1
         assert cm.value.timeout == 2
         assert not launch.done()
-        await self.advance(30)
+        await asyncio.sleep(30)
         with pytest.raises(scheduler.InsufficientResourcesError):
             await launch
 
-    async def test_launch_force_host(self):
+    async def test_launch_force_host(self, fix: 'TestScheduler.Fixture') -> None:
         """Like test_launch_serial, but tests forcing a logical task to a node."""
-        for node in self.logical_graph.nodes():
+        for node in fix.logical_graph.nodes():
             if node.name == 'node0':
                 node.host = 'agenthost0'
-        self._make_physical()
-        await self.test_launch_serial()
+        fix._make_physical()
+        await self.test_launch_serial(fix)
 
-    async def test_launch_bad_host(self):
+    async def test_launch_bad_host(self, fix: 'TestScheduler.Fixture') -> None:
         """Force a host which doesn't have sufficient resources"""
-        for node in self.logical_graph.nodes():
+        for node in fix.logical_graph.nodes():
             if node.name == 'node0':
                 node.host = 'agenthost1'
-        self._make_physical()
-        launch, kill = await self._transition_node0(TaskState.STARTING, [self.nodes[0]])
-        offers = self._make_offers()
-        self.sched.resourceOffers(self.driver, offers)
-        await self.advance(30)
+        fix._make_physical()
+        launch, kill = await fix._transition_node0(TaskState.STARTING, [fix.nodes[0]])
+        offers = fix._make_offers()
+        fix.sched.resourceOffers(fix.driver, offers)
+        await asyncio.sleep(30)
         with pytest.raises(scheduler.InsufficientResourcesError):
             await launch
 
-    async def test_launch_multicast_conflict(self):
+    async def test_launch_multicast_conflict(self, fix: 'TestScheduler.Fixture') -> None:
         """Test launching when an interface can't be used due to multicast loopback limitations."""
         node3 = scheduler.LogicalTask('node3')
         node3.command = ['hello']
@@ -2015,417 +2052,372 @@ class TestScheduler(asynctest.ClockedTestCase):
         ]
         node3.interfaces[-1].bandwidth_in = 1e6
         node3.interfaces[-1].bandwidth_out = 1e6
-        self.logical_graph.add_node(node3)
+        fix.logical_graph.add_node(node3)
 
-        self._make_physical()
-        launch, kill = await self._transition_node0(TaskState.STARTING)
-        offers = self._make_offers()
-        self.sched.resourceOffers(self.driver, offers)
-        await self.advance(30)
+        fix._make_physical()
+        launch, kill = await fix._transition_node0(TaskState.STARTING)
+        offers = fix._make_offers()
+        fix.sched.resourceOffers(fix.driver, offers)
+        await asyncio.sleep(30)
         with pytest.raises(scheduler.InsufficientResourcesError):
             await launch
 
-    async def test_launch_resolve_raises(self):
+    async def test_launch_resolve_raises(self, fix: 'TestScheduler.Fixture') -> None:
         async def resolve_raise(resolver, graph, image_path=None):
             raise ValueError('Testing')
 
-        self.nodes[0].resolve = resolve_raise
-        launch, kill = await self._transition_node0(TaskState.STARTING)
-        offers = self._make_offers()
-        self.sched.resourceOffers(self.driver, offers)
+        fix.nodes[0].resolve = resolve_raise
+        launch, kill = await fix._transition_node0(TaskState.STARTING)
+        offers = fix._make_offers()
+        fix.sched.resourceOffers(fix.driver, offers)
         with pytest.raises(ValueError, match='Testing'):
             await launch
         # The offers must be returned to Mesos
-        assert self._driver_calls() == AnyOrderList([
+        assert fix._driver_calls() == AnyOrderList([
             mock.call.declineOffer(AnyOrderList([offers[0].id, offers[1].id])),
             mock.call.suppressOffers({'default'})
         ])
 
-    async def test_offer_rescinded(self):
+    async def test_offer_rescinded(self, fix: 'TestScheduler.Fixture') -> None:
         """Test offerRescinded"""
-        launch, kill = await self._transition_node0(TaskState.STARTING)
-        offers = self._make_offers()
+        launch, kill = await fix._transition_node0(TaskState.STARTING)
+        offers = fix._make_offers()
         # Provide an offer that is sufficient only for node 0
-        self.sched.resourceOffers(self.driver, [offers[0]])
+        fix.sched.resourceOffers(fix.driver, [offers[0]])
         await exhaust_callbacks()
-        assert self.nodes[0].state == TaskState.STARTING
+        assert fix.nodes[0].state == TaskState.STARTING
         # Rescind the offer
-        self.sched.offerRescinded(self.driver, offers[0].id)
+        fix.sched.offerRescinded(fix.driver, offers[0].id)
         # Make a new offer, which is also insufficient, but which with the
         # original one would have been sufficient.
-        self.sched.resourceOffers(self.driver, [offers[1]])
+        fix.sched.resourceOffers(fix.driver, [offers[1]])
         await exhaust_callbacks()
-        assert self.nodes[0].state == TaskState.STARTING
+        assert fix.nodes[0].state == TaskState.STARTING
         # Rescind an unknown offer. This can happen if an offer was accepted at
         # the same time as it was rescinded.
-        offer2 = self._make_offer({'cpus': 0.8, 'mem': 128.0, 'ports': [(31000, 32000)]}, 1)
-        self.sched.offerRescinded(self.driver, offer2.id)
+        offer2 = fix._make_offer({'cpus': 0.8, 'mem': 128.0, 'ports': [(31000, 32000)]}, 1)
+        fix.sched.offerRescinded(fix.driver, offer2.id)
         await exhaust_callbacks()
-        assert self._driver_calls() == []
+        assert fix._driver_calls() == []
         launch.cancel()
 
-    async def test_decline_unneeded_offers(self):
+    async def test_decline_unneeded_offers(self, fix: 'TestScheduler.Fixture') -> None:
         """Test that useless offers are not hoarded."""
-        launch, kill = await self._transition_node0(TaskState.STARTING)
-        offers = self._make_offers()
+        launch, kill = await fix._transition_node0(TaskState.STARTING)
+        offers = fix._make_offers()
         # Replace offer 0 with a useless offer
-        offers[0] = self._make_offer({'cpus': 0.1})
-        self.sched.resourceOffers(self.driver, offers)
+        offers[0] = fix._make_offer({'cpus': 0.1})
+        fix.sched.resourceOffers(fix.driver, offers)
         await exhaust_callbacks()
-        assert self.nodes[0].state == TaskState.STARTING
-        assert self._driver_calls() == [mock.call.declineOffer([offers[0].id])]
+        assert fix.nodes[0].state == TaskState.STARTING
+        assert fix._driver_calls() == [mock.call.declineOffer([offers[0].id])]
         launch.cancel()
 
-    async def test_unavailability(self):
+    @pytest.mark.parametrize('end_time', [True, False])
+    async def test_unavailability(self, end_time: bool, fix: 'TestScheduler.Fixture') -> None:
         """Test offers with unavailability information"""
-        launch, kill = await self._transition_node0(TaskState.STARTING, [self.nodes[0]])
+        launch, kill = await fix._transition_node0(TaskState.STARTING, [fix.nodes[0]])
         # Provide an offer that would be sufficient if not for unavailability
-        offer0 = self._make_offers()[0]
+        offer0 = fix._make_offers()[0]
         offer0.unavailability.start.nanoseconds = int(time.time() * 1e9)
-        offer0.unavailability.duration.nanoseconds = int(3600e9)
-        self.sched.resourceOffers(self.driver, [offer0])
+        if end_time:
+            offer0.unavailability.duration.nanoseconds = int(3600e9)
+        fix.sched.resourceOffers(fix.driver, [offer0])
         await exhaust_callbacks()
-        assert self.nodes[0].state == TaskState.STARTING
-        assert self._driver_calls() == [mock.call.declineOffer([offer0.id])]
+        assert fix.nodes[0].state == TaskState.STARTING
+        assert fix._driver_calls() == [mock.call.declineOffer([offer0.id])]
         launch.cancel()
 
-    async def test_unavailability_forever(self):
-        """Test offers with unavailability and no end time."""
-        # TODO: once we've switched to pytest, parametrise this test with the
-        # previous one.
-        launch, kill = await self._transition_node0(TaskState.STARTING, [self.nodes[0]])
-        # Provide an offer that would be sufficient if not for unavailability
-        offer0 = self._make_offers()[0]
-        offer0.unavailability.start.nanoseconds = int(time.time() * 1e9)
-        self.sched.resourceOffers(self.driver, [offer0])
-        await exhaust_callbacks()
-        assert self.nodes[0].state == TaskState.STARTING
-        assert self._driver_calls() == [mock.call.declineOffer([offer0.id])]
-        launch.cancel()
-
-    async def test_unavailability_past(self):
+    async def test_unavailability_past(self, fix: 'TestScheduler.Fixture') -> None:
         """Test offers with unavailability information in the past"""
-        launch, kill = await self._transition_node0(TaskState.STARTING, [self.nodes[0]])
+        launch, kill = await fix._transition_node0(TaskState.STARTING, [fix.nodes[0]])
         # Provide an offer that would be sufficient if not for unavailability
-        offer0 = self._make_offers()[0]
+        offer0 = fix._make_offers()[0]
         offer0.unavailability.start.nanoseconds = int(time.time() * 1e9 - 7200e9)
         offer0.unavailability.duration.nanoseconds = int(3600e9)
-        self.sched.resourceOffers(self.driver, [offer0])
+        fix.sched.resourceOffers(fix.driver, [offer0])
         await exhaust_callbacks()
-        assert self.nodes[0].state == TaskState.STARTED
-        assert self._driver_calls() == [
+        assert fix.nodes[0].state == TaskState.STARTED
+        assert fix._driver_calls() == [
             mock.call.launchTasks([offer0.id], mock.ANY),
             mock.call.suppressOffers({'default'})
         ]
         launch.cancel()
 
-    async def _test_kill_in_state(self, state):
+    @pytest.mark.parametrize(
+        'state',
+        [
+            TaskState.STARTING,
+            TaskState.STARTED,
+            TaskState.RUNNING,
+            TaskState.READY,
+            TaskState.KILLING
+        ]
+    )
+    async def test_kill_in_state(self, state: TaskState, fix: 'TestScheduler.Fixture') -> None:
         """Test killing a node while it is in the given state"""
-        launch, kill = await self._transition_node0(state, [self.nodes[0]])
-        kill = asyncio.ensure_future(self.sched.kill(self.physical_graph, [self.nodes[0]]))
+        launch, kill = await fix._transition_node0(state, [fix.nodes[0]])
+        kill = asyncio.ensure_future(fix.sched.kill(fix.physical_graph, [fix.nodes[0]]))
         await exhaust_callbacks()
         if state > TaskState.STARTING:
-            assert self.nodes[0].state == TaskState.KILLING
-            status = self._status_update(self.nodes[0].taskinfo.task_id.value, 'TASK_KILLED')
+            assert fix.nodes[0].state == TaskState.KILLING
+            status = fix._status_update(fix.nodes[0].taskinfo.task_id.value, 'TASK_KILLED')
             await exhaust_callbacks()
-            assert status is self.nodes[0].status
-            assert self.task_stats.state_counts == {TaskState.DEAD: 1}
-        assert self.nodes[0].state == TaskState.DEAD
+            assert status is fix.nodes[0].status
+            assert fix.task_stats.state_counts == {TaskState.DEAD: 1}
+        assert fix.nodes[0].state == TaskState.DEAD
         await launch
         await kill
 
-    async def test_kill_while_starting(self):
-        """Test killing a node while in state STARTING"""
-        await self._test_kill_in_state(TaskState.STARTING)
-
-    async def test_kill_while_started(self):
-        """Test killing a node while in state STARTED"""
-        await self._test_kill_in_state(TaskState.STARTED)
-
-    async def test_kill_while_running(self):
-        """Test killing a node while in state RUNNING"""
-        await self._test_kill_in_state(TaskState.RUNNING)
-
-    async def test_kill_while_ready(self):
-        """Test killing a node while in state READY"""
-        await self._test_kill_in_state(TaskState.READY)
-
-    async def test_kill_while_killed(self):
-        """Test killing a node while in state KILLING"""
-        await self._test_kill_in_state(TaskState.KILLING)
-
-    async def _test_die_in_state(self, state):
+    @pytest.mark.parametrize(
+        'state',
+        [
+            TaskState.STARTED,
+            TaskState.RUNNING,
+            TaskState.READY,
+        ]
+    )
+    async def test_die_in_state(self, state: TaskState, fix: 'TestScheduler.Fixture') -> None:
         """Test a node dying on its own while it is in the given state"""
-        launch, kill = await self._transition_node0(state, [self.nodes[0]])
-        status = self._status_update(self.nodes[0].taskinfo.task_id.value, 'TASK_FINISHED')
+        launch, kill = await fix._transition_node0(state, [fix.nodes[0]])
+        status = fix._status_update(fix.nodes[0].taskinfo.task_id.value, 'TASK_FINISHED')
         await exhaust_callbacks()
-        assert status is self.nodes[0].status
-        assert self.nodes[0].state == TaskState.DEAD
-        assert self.nodes[0].ready_event.is_set()
-        assert self.nodes[0].dead_event.is_set()
+        assert status is fix.nodes[0].status
+        assert fix.nodes[0].state == TaskState.DEAD
+        assert fix.nodes[0].ready_event.is_set()
+        assert fix.nodes[0].dead_event.is_set()
         await launch
 
-    async def test_die_while_started(self):
-        """Test a process dying on its own while in state STARTED"""
-        await self._test_die_in_state(TaskState.STARTED)
-
-    async def test_die_while_running(self):
-        """Test a process dying on its own while in state RUNNING"""
-        await self._test_die_in_state(TaskState.RUNNING)
-
-    async def test_die_while_ready(self):
-        """Test a process dying on its own while in state READY"""
-        await self._test_die_in_state(TaskState.READY)
-
-    async def test_kill_order(self):
+    async def test_kill_order(self, fix: 'TestScheduler.Fixture') -> None:
         """Kill must respect dependency ordering"""
-        await self._ready_graph()
+        await fix._ready_graph()
         # Now kill it. node1 must be dead before node0, node2 get killed
-        kill = asyncio.ensure_future(self.sched.kill(self.physical_graph))
+        kill = asyncio.ensure_future(fix.sched.kill(fix.physical_graph))
         await exhaust_callbacks()
-        assert self._driver_calls() == [mock.call.killTask(self.nodes[1].taskinfo.task_id)]
-        assert self.nodes[0].state == TaskState.READY
-        assert self.nodes[1].state == TaskState.KILLING
-        assert self.nodes[2].state == TaskState.READY
-        self.driver.reset_mock()
+        assert fix._driver_calls() == [mock.call.killTask(fix.nodes[1].taskinfo.task_id)]
+        assert fix.nodes[0].state == TaskState.READY
+        assert fix.nodes[1].state == TaskState.KILLING
+        assert fix.nodes[2].state == TaskState.READY
+        fix.driver.reset_mock()
         # node1 now dies, and node0 and node2 should be killed
-        status = self._status_update(self.nodes[1].taskinfo.task_id.value, 'TASK_KILLED')
+        status = fix._status_update(fix.nodes[1].taskinfo.task_id.value, 'TASK_KILLED')
         await exhaust_callbacks()
-        assert self._driver_calls() == AnyOrderList([
-            mock.call.killTask(self.nodes[0].taskinfo.task_id),
+        assert fix._driver_calls() == AnyOrderList([
+            mock.call.killTask(fix.nodes[0].taskinfo.task_id),
             mock.call.acknowledgeStatusUpdate(status)
         ])
-        assert self.nodes[0].state == TaskState.KILLING
-        assert self.nodes[1].state == TaskState.DEAD
-        assert self.nodes[2].state == TaskState.DEAD
+        assert fix.nodes[0].state == TaskState.KILLING
+        assert fix.nodes[1].state == TaskState.DEAD
+        assert fix.nodes[2].state == TaskState.DEAD
         assert not kill.done()
         # node0 now dies, to finish the cleanup
-        self._status_update(self.nodes[0].taskinfo.task_id.value, 'TASK_KILLED')
+        fix._status_update(fix.nodes[0].taskinfo.task_id.value, 'TASK_KILLED')
         await exhaust_callbacks()
-        assert self.nodes[0].state == TaskState.DEAD
-        assert self.nodes[1].state == TaskState.DEAD
-        assert self.nodes[2].state == TaskState.DEAD
+        assert fix.nodes[0].state == TaskState.DEAD
+        assert fix.nodes[1].state == TaskState.DEAD
+        assert fix.nodes[2].state == TaskState.DEAD
         assert kill.done()
         await kill
 
-    async def _transition_batch_run(self, node, state):
-        """Interact with scheduler to get batch task to state `state`.
-
-        It is assumed that it has already been launched.
-        """
-        if state >= TaskState.STARTED:
-            await exhaust_callbacks()
-            self.sched.resourceOffers(self.driver, self._make_offers())
-            await exhaust_callbacks()
-            assert node.state == TaskState.STARTED
-            if state >= TaskState.READY:
-                task_id = node.taskinfo.task_id.value
-                self._status_update(task_id, 'TASK_RUNNING')
-                await exhaust_callbacks()
-                assert node.state == TaskState.READY
-                if state >= TaskState.DEAD:
-                    self._status_update(task_id, 'TASK_FINISHED')
-                    await exhaust_callbacks()
-                    assert node.state == TaskState.DEAD
-
-    async def test_batch_run_success(self):
+    async def test_batch_run_success(self, fix: 'TestScheduler.Fixture') -> None:
         """batch_run for the case of a successful run"""
-        task = asyncio.ensure_future(self.sched.batch_run(
-            self.physical_batch_graph, self.resolver, [self.batch_nodes[0]]))
-        await self._transition_batch_run(self.batch_nodes[0], TaskState.DEAD)
+        task = asyncio.ensure_future(fix.sched.batch_run(
+            fix.physical_batch_graph, fix.resolver, [fix.batch_nodes[0]]))
+        await fix._transition_batch_run(fix.batch_nodes[0], TaskState.DEAD)
         results = await task
-        assert results == {self.batch_nodes[0]: None}
-        assert self.task_stats.batch_created == 1
-        assert self.task_stats.batch_started == 1
-        assert self.task_stats.batch_done == 1
-        assert self.task_stats.batch_retried == 0
-        assert self.task_stats.batch_failed == 0
-        assert self.task_stats.batch_skipped == 0
+        assert results == {fix.batch_nodes[0]: None}
+        assert fix.task_stats.batch_created == 1
+        assert fix.task_stats.batch_started == 1
+        assert fix.task_stats.batch_done == 1
+        assert fix.task_stats.batch_retried == 0
+        assert fix.task_stats.batch_failed == 0
+        assert fix.task_stats.batch_skipped == 0
 
-    async def test_batch_run_failure(self):
+    async def test_batch_run_failure(self, fix: 'TestScheduler.Fixture') -> None:
         """batch_run with a failing task"""
-        task = asyncio.ensure_future(self.sched.batch_run(
-            self.physical_batch_graph, self.resolver, [self.batch_nodes[0]]))
-        await self._transition_batch_run(self.batch_nodes[0], TaskState.READY)
-        task_id = self.batch_nodes[0].taskinfo.task_id.value
-        self._status_update(task_id, 'TASK_FAILED')
+        task = asyncio.ensure_future(fix.sched.batch_run(
+            fix.physical_batch_graph, fix.resolver, [fix.batch_nodes[0]]))
+        await fix._transition_batch_run(fix.batch_nodes[0], TaskState.READY)
+        task_id = fix.batch_nodes[0].taskinfo.task_id.value
+        fix._status_update(task_id, 'TASK_FAILED')
         results = await task
         with pytest.raises(scheduler.TaskError):
             raise next(iter(results.values()))
-        assert self.task_stats.batch_created == 1
-        assert self.task_stats.batch_started == 1
-        assert self.task_stats.batch_done == 1
-        assert self.task_stats.batch_retried == 0
-        assert self.task_stats.batch_failed == 1
-        assert self.task_stats.batch_skipped == 0
+        assert fix.task_stats.batch_created == 1
+        assert fix.task_stats.batch_started == 1
+        assert fix.task_stats.batch_done == 1
+        assert fix.task_stats.batch_retried == 0
+        assert fix.task_stats.batch_failed == 1
+        assert fix.task_stats.batch_skipped == 0
 
-    async def test_batch_run_resources_timeout(self):
+    async def test_batch_run_resources_timeout(self, fix: 'TestScheduler.Fixture') -> None:
         """batch_run with a task that doesn't get resources in time"""
-        task = asyncio.ensure_future(self.sched.batch_run(
-            self.physical_batch_graph, self.resolver, [self.batch_nodes[0]]))
-        await self.advance(30)
+        task = asyncio.ensure_future(fix.sched.batch_run(
+            fix.physical_batch_graph, fix.resolver, [fix.batch_nodes[0]]))
+        await asyncio.sleep(30)
         results = await task
         with pytest.raises(scheduler.TaskInsufficientResourcesError):
             raise next(iter(results.values()))
-        assert self.task_stats.batch_created == 1
-        assert self.task_stats.batch_started == 1
-        assert self.task_stats.batch_done == 1
-        assert self.task_stats.batch_retried == 0
-        assert self.task_stats.batch_failed == 1
-        assert self.task_stats.batch_skipped == 0
+        assert fix.task_stats.batch_created == 1
+        assert fix.task_stats.batch_started == 1
+        assert fix.task_stats.batch_done == 1
+        assert fix.task_stats.batch_retried == 0
+        assert fix.task_stats.batch_failed == 1
+        assert fix.task_stats.batch_skipped == 0
 
-    async def _batch_run_retry_second(self, task):
+    async def _batch_run_retry_second(
+            self, task: asyncio.Future, fix: 'TestScheduler.Fixture') -> None:
         """Do the retry on a test_batch_run_retry_* test."""
         # The graph should now have been modified in place, so we need to
         # get the new physical node
-        self.batch_nodes[0] = next(node for node in self.physical_batch_graph
-                                   if node.name == 'batch0')
-        await self._transition_batch_run(self.batch_nodes[0], TaskState.DEAD)
+        fix.batch_nodes[0] = next(node for node in fix.physical_batch_graph
+                                  if node.name == 'batch0')
+        await fix._transition_batch_run(fix.batch_nodes[0], TaskState.DEAD)
         await task
-        assert self.task_stats.batch_created == 1
-        assert self.task_stats.batch_started == 1
-        assert self.task_stats.batch_done == 1
-        assert self.task_stats.batch_retried == 1
-        assert self.task_stats.batch_failed == 0
-        assert self.task_stats.batch_skipped == 0
+        assert fix.task_stats.batch_created == 1
+        assert fix.task_stats.batch_started == 1
+        assert fix.task_stats.batch_done == 1
+        assert fix.task_stats.batch_retried == 1
+        assert fix.task_stats.batch_failed == 0
+        assert fix.task_stats.batch_skipped == 0
 
-    async def test_batch_run_retry(self):
+    async def test_batch_run_retry(self, fix: 'TestScheduler.Fixture') -> None:
         """batch_run where first attempt fails, later attempt succeeds."""
-        task = asyncio.ensure_future(self.sched.batch_run(
-            self.physical_batch_graph, self.resolver, [self.batch_nodes[0]], attempts=2))
-        await self._transition_batch_run(self.batch_nodes[0], TaskState.READY)
-        task_id = self.batch_nodes[0].taskinfo.task_id.value
-        self._status_update(task_id, 'TASK_FAILED')
+        task = asyncio.ensure_future(fix.sched.batch_run(
+            fix.physical_batch_graph, fix.resolver, [fix.batch_nodes[0]], attempts=2))
+        await fix._transition_batch_run(fix.batch_nodes[0], TaskState.READY)
+        task_id = fix.batch_nodes[0].taskinfo.task_id.value
+        fix._status_update(task_id, 'TASK_FAILED')
         await exhaust_callbacks()
-        await self._batch_run_retry_second(task)
+        await self._batch_run_retry_second(task, fix)
 
-    async def test_batch_run_depends(self):
+    async def test_batch_run_depends(self, fix: 'TestScheduler.Fixture') -> None:
         """Batch launch with one task depending on another"""
-        task = asyncio.ensure_future(self.sched.batch_run(self.physical_batch_graph, self.resolver))
-        await self._transition_batch_run(self.batch_nodes[0], TaskState.READY)
+        task = asyncio.ensure_future(fix.sched.batch_run(fix.physical_batch_graph, fix.resolver))
+        await fix._transition_batch_run(fix.batch_nodes[0], TaskState.READY)
         # Ensure that we haven't even tried to launch the second one
-        assert self.batch_nodes[1].state == TaskState.NOT_READY
+        assert fix.batch_nodes[1].state == TaskState.NOT_READY
         # Kill it, the next one should start up
-        self._status_update(self.batch_nodes[0].taskinfo.task_id.value, 'TASK_FINISHED')
+        fix._status_update(fix.batch_nodes[0].taskinfo.task_id.value, 'TASK_FINISHED')
         await exhaust_callbacks()
-        assert self.batch_nodes[0].state == TaskState.DEAD
-        assert self.batch_nodes[1].state == TaskState.STARTING
+        assert fix.batch_nodes[0].state == TaskState.DEAD
+        assert fix.batch_nodes[1].state == TaskState.STARTING
 
-        await self._transition_batch_run(self.batch_nodes[1], TaskState.DEAD)
+        await fix._transition_batch_run(fix.batch_nodes[1], TaskState.DEAD)
         results = await task
-        assert results == {self.batch_nodes[0]: None, self.batch_nodes[1]: None}
+        assert results == {fix.batch_nodes[0]: None, fix.batch_nodes[1]: None}
 
-    async def test_batch_run_skip(self):
+    async def test_batch_run_skip(self, fix: 'TestScheduler.Fixture') -> None:
         """If a dependency fails, the dependent task is skipped"""
-        task = asyncio.ensure_future(self.sched.batch_run(self.physical_batch_graph, self.resolver))
-        await self._transition_batch_run(self.batch_nodes[0], TaskState.READY)
+        task = asyncio.ensure_future(fix.sched.batch_run(fix.physical_batch_graph, fix.resolver))
+        await fix._transition_batch_run(fix.batch_nodes[0], TaskState.READY)
         # Kill it
-        self._status_update(self.batch_nodes[0].taskinfo.task_id.value, 'TASK_FAILED')
+        fix._status_update(fix.batch_nodes[0].taskinfo.task_id.value, 'TASK_FAILED')
         await exhaust_callbacks()
-        assert self.batch_nodes[0].state == TaskState.DEAD
+        assert fix.batch_nodes[0].state == TaskState.DEAD
         # Next task shouldn't even try to start
-        assert self.batch_nodes[1].state == TaskState.NOT_READY
+        assert fix.batch_nodes[1].state == TaskState.NOT_READY
         results = await task
         with pytest.raises(scheduler.TaskError):
-            raise results[self.batch_nodes[0]]
+            raise results[fix.batch_nodes[0]]
         with pytest.raises(scheduler.TaskSkipped):
-            raise results[self.batch_nodes[1]]
-        assert self.task_stats.batch_created == 2
-        assert self.task_stats.batch_started == 1
-        assert self.task_stats.batch_done == 2
-        assert self.task_stats.batch_retried == 0
-        assert self.task_stats.batch_failed == 1
-        assert self.task_stats.batch_skipped == 1
+            raise results[fix.batch_nodes[1]]
+        assert fix.task_stats.batch_created == 2
+        assert fix.task_stats.batch_started == 1
+        assert fix.task_stats.batch_done == 2
+        assert fix.task_stats.batch_retried == 0
+        assert fix.task_stats.batch_failed == 1
+        assert fix.task_stats.batch_skipped == 1
 
-    async def test_batch_run_non_critical_failure(self):
+    async def test_batch_run_non_critical_failure(self, fix: 'TestScheduler.Fixture') -> None:
         """If a non-critical dependency fails, the dependent task runs anyway."""
         # Modify graph to make dependency non-critical
-        for u, v, data in self.logical_batch_graph.edges(data=True):
+        for u, v, data in fix.logical_batch_graph.edges(data=True):
             if data.get('depends_finished', False):
                 data['depends_finished_critical'] = False
-        for u, v, data in self.logical_batch_graph.edges(data=True):
+        for u, v, data in fix.logical_batch_graph.edges(data=True):
             print(u, v, data)
-        self._make_physical()
+        fix._make_physical()
 
-        task = asyncio.ensure_future(self.sched.batch_run(self.physical_batch_graph, self.resolver))
-        await self._transition_batch_run(self.batch_nodes[0], TaskState.READY)
-        assert self.batch_nodes[1].state == TaskState.NOT_READY
+        task = asyncio.ensure_future(fix.sched.batch_run(fix.physical_batch_graph, fix.resolver))
+        await fix._transition_batch_run(fix.batch_nodes[0], TaskState.READY)
+        assert fix.batch_nodes[1].state == TaskState.NOT_READY
         # Kill it
-        self._status_update(self.batch_nodes[0].taskinfo.task_id.value, 'TASK_FAILED')
+        fix._status_update(fix.batch_nodes[0].taskinfo.task_id.value, 'TASK_FAILED')
         await exhaust_callbacks()
-        assert self.batch_nodes[0].state == TaskState.DEAD
+        assert fix.batch_nodes[0].state == TaskState.DEAD
         # Next task should now start
-        assert self.batch_nodes[1].state == TaskState.STARTING
-        await self._transition_batch_run(self.batch_nodes[1], TaskState.DEAD)
+        assert fix.batch_nodes[1].state == TaskState.STARTING
+        await fix._transition_batch_run(fix.batch_nodes[1], TaskState.DEAD)
         results = await task
         with pytest.raises(scheduler.TaskError):
-            raise results[self.batch_nodes[0]]
-        assert results[self.batch_nodes[1]] is None
-        assert self.task_stats.batch_created == 2
-        assert self.task_stats.batch_started == 2
-        assert self.task_stats.batch_done == 2
-        assert self.task_stats.batch_retried == 0
-        assert self.task_stats.batch_failed == 1
-        assert self.task_stats.batch_skipped == 0
+            raise results[fix.batch_nodes[0]]
+        assert results[fix.batch_nodes[1]] is None
+        assert fix.task_stats.batch_created == 2
+        assert fix.task_stats.batch_started == 2
+        assert fix.task_stats.batch_done == 2
+        assert fix.task_stats.batch_retried == 0
+        assert fix.task_stats.batch_failed == 1
+        assert fix.task_stats.batch_skipped == 0
 
-    async def test_batch_run_depends_retry(self):
+    async def test_batch_run_depends_retry(self, fix: 'TestScheduler.Fixture') -> None:
         """If a dependencies fails once, wait until it's retried."""
-        task = asyncio.ensure_future(self.sched.batch_run(
-            self.physical_batch_graph, self.resolver, attempts=3))
-        await self._transition_batch_run(self.batch_nodes[0], TaskState.READY)
-        task_id = self.batch_nodes[0].taskinfo.task_id.value
-        self._status_update(task_id, 'TASK_FAILED')
+        task = asyncio.ensure_future(fix.sched.batch_run(
+            fix.physical_batch_graph, fix.resolver, attempts=3))
+        await fix._transition_batch_run(fix.batch_nodes[0], TaskState.READY)
+        task_id = fix.batch_nodes[0].taskinfo.task_id.value
+        fix._status_update(task_id, 'TASK_FAILED')
         await exhaust_callbacks()
         # The graph should now have been modified in place, so we need to
         # get the new physical node
-        self.batch_nodes[0] = next(node for node in self.physical_batch_graph
-                                   if node.name == 'batch0')
+        fix.batch_nodes[0] = next(node for node in fix.physical_batch_graph
+                                  if node.name == 'batch0')
         # Retry the first task. The next task must not have started yet.
-        await self._transition_batch_run(self.batch_nodes[0], TaskState.READY)
+        await fix._transition_batch_run(fix.batch_nodes[0], TaskState.READY)
         await exhaust_callbacks()
-        assert self.batch_nodes[1].state == TaskState.NOT_READY
+        assert fix.batch_nodes[1].state == TaskState.NOT_READY
         # Finish the retried first task.
-        self._status_update(self.batch_nodes[0].taskinfo.task_id.value, 'TASK_FINISHED')
+        fix._status_update(fix.batch_nodes[0].taskinfo.task_id.value, 'TASK_FINISHED')
         await exhaust_callbacks()
-        assert self.batch_nodes[0].state == TaskState.DEAD
-        assert self.batch_nodes[1].state == TaskState.STARTING
+        assert fix.batch_nodes[0].state == TaskState.DEAD
+        assert fix.batch_nodes[1].state == TaskState.STARTING
         # Finish the second task
-        await self._transition_batch_run(self.batch_nodes[1], TaskState.DEAD)
+        await fix._transition_batch_run(fix.batch_nodes[1], TaskState.DEAD)
         results = await task
         assert list(results.values()) == [None, None]
 
-    async def test_close(self):
+    async def test_close(self, fix: 'TestScheduler.Fixture') -> None:
         """Close must kill off all remaining tasks and abort any pending launches"""
-        await self._ready_graph()
+        await fix._ready_graph()
         # Start launching a second graph, but do not give it resources
-        physical_graph2 = scheduler.instantiate(self.logical_graph)
-        launch = asyncio.ensure_future(self.sched.launch(physical_graph2, self.resolver))
+        physical_graph2 = scheduler.instantiate(fix.logical_graph)
+        launch = asyncio.ensure_future(fix.sched.launch(physical_graph2, fix.resolver))
         await exhaust_callbacks()
-        close = asyncio.ensure_future(self.sched.close())
+        close = asyncio.ensure_future(fix.sched.close())
         await exhaust_callbacks()
-        status1 = self._status_update(self.nodes[1].taskinfo.task_id.value, 'TASK_KILLED')
+        status1 = fix._status_update(fix.nodes[1].taskinfo.task_id.value, 'TASK_KILLED')
         await exhaust_callbacks()
-        status0 = self._status_update(self.nodes[0].taskinfo.task_id.value, 'TASK_KILLED')
+        status0 = fix._status_update(fix.nodes[0].taskinfo.task_id.value, 'TASK_KILLED')
         # defer is insufficient here, because close() uses run_in_executor to
         # join the driver thread. Wait up to 5 seconds for that to happen.
         await asyncio.wait_for(close, 5)
-        for node in self.physical_graph:
+        for node in fix.physical_graph:
             assert node.state == TaskState.DEAD
         for node in physical_graph2:
             assert node.state == TaskState.DEAD
         # The timing of suppressOffers is undefined, because it depends on the
         # order in which the graphs are killed. However, it must occur
         # after the initial reviveOffers and before stopping the driver.
-        driver_calls = self._driver_calls()
+        driver_calls = fix._driver_calls()
         assert mock.call.suppressOffers({'default'}) in driver_calls
         pos = driver_calls.index(mock.call.suppressOffers({'default'}))
         assert 1 <= pos < len(driver_calls) - 2
         del driver_calls[pos]
         assert [
             mock.call.reviveOffers({'default'}),
-            mock.call.killTask(self.nodes[1].taskinfo.task_id),
+            mock.call.killTask(fix.nodes[1].taskinfo.task_id),
             mock.call.acknowledgeStatusUpdate(status1),
-            mock.call.killTask(self.nodes[0].taskinfo.task_id),
+            mock.call.killTask(fix.nodes[0].taskinfo.task_id),
             mock.call.acknowledgeStatusUpdate(status0),
             mock.call.stop(),
             mock.call.join()
@@ -2433,43 +2425,43 @@ class TestScheduler(asynctest.ClockedTestCase):
         assert launch.done()
         await launch
 
-    async def test_status_unknown_task_id(self):
+    async def test_status_unknown_task_id(self, fix: 'TestScheduler.Fixture') -> None:
         """statusUpdate must correctly handle an unknown task ID.
 
         It must also kill it if it's not already dead.
         """
-        self._status_update('test-01234567', 'TASK_LOST')
-        self._status_update('test-12345678', 'TASK_RUNNING')
+        fix._status_update('test-01234567', 'TASK_LOST')
+        fix._status_update('test-12345678', 'TASK_RUNNING')
         await exhaust_callbacks()
-        self.driver.killTask.assert_called_once_with({'value': 'test-12345678'})
+        fix.driver.killTask.assert_called_once_with({'value': 'test-12345678'})
 
-    async def test_retry_kill(self):
+    async def test_retry_kill(self, fix: 'TestScheduler.Fixture') -> None:
         """Killing a task must be retried after a timeout."""
-        await self._ready_graph()
-        kill = asyncio.ensure_future(self.sched.kill(self.physical_graph, [self.nodes[0]]))
+        await fix._ready_graph()
+        kill = asyncio.ensure_future(fix.sched.kill(fix.physical_graph, [fix.nodes[0]]))
         await exhaust_callbacks()
-        self.driver.killTask.assert_called_once_with(self.nodes[0].taskinfo.task_id)
-        self.driver.killTask.reset_mock()
+        fix.driver.killTask.assert_called_once_with(fix.nodes[0].taskinfo.task_id)
+        fix.driver.killTask.reset_mock()
         # Send a task status update in less than the kill timeout. It must not
         # lead to a retry.
-        await self.advance(1.0)
-        self._status_update(self.task_ids[0], 'TASK_RUNNING')
+        await asyncio.sleep(1.0)
+        fix._status_update(fix.task_ids[0], 'TASK_RUNNING')
         await exhaust_callbacks()
-        self.driver.killTask.assert_not_called()
+        fix.driver.killTask.assert_not_called()
 
         # Give time for reconciliation requests to occur
-        await self.advance(70.0)
-        self.driver.reconcileTasks.assert_called()
-        self._status_update(self.task_ids[0], 'TASK_RUNNING')
+        await asyncio.sleep(70.0)
+        fix.driver.reconcileTasks.assert_called()
+        fix._status_update(fix.task_ids[0], 'TASK_RUNNING')
         await exhaust_callbacks()
-        self.driver.killTask.assert_called_once_with(self.nodes[0].taskinfo.task_id)
+        fix.driver.killTask.assert_called_once_with(fix.nodes[0].taskinfo.task_id)
 
         # Send an update for TASK_KILLING state: must not trigger another attempt
-        self.driver.killTask.reset_mock()
-        self._status_update(self.task_ids[0], 'TASK_KILLING')
+        fix.driver.killTask.reset_mock()
+        fix._status_update(fix.task_ids[0], 'TASK_KILLING')
         await exhaust_callbacks()
-        self.driver.killTask.assert_not_called()
+        fix.driver.killTask.assert_not_called()
 
         # Let it die so that we can clean up the async task
-        self._status_update(self.task_ids[0], 'TASK_FAILED')
+        fix._status_update(fix.task_ids[0], 'TASK_FAILED')
         await kill

--- a/src/katsdpcontroller/test/test_scheduler.py
+++ b/src/katsdpcontroller/test/test_scheduler.py
@@ -5,7 +5,6 @@ import logging
 import uuid
 import asyncio
 import ipaddress
-import unittest
 from unittest import mock
 import time
 from decimal import Decimal
@@ -690,15 +689,13 @@ def _make_status(task_id, state):
     return status
 
 
-class TestAgent(unittest.TestCase):
-    """Tests for :class:`katsdpcontroller.scheduler.Agent`.
+class TestAgent:
+    """Tests for :class:`katsdpcontroller.scheduler.Agent`."""
 
-    This imports from :class:`unittest.TestCase` so that we can use
-    ``assertLogs``, which has not been ported to :mod:`nose.tools` yet."""
     def _make_offer(self, resources, attrs=()):
         return _make_offer(self.framework_id, self.agent_id, self.host, resources, attrs)
 
-    def setUp(self):
+    def setup(self):
         self.agent_id = 'agentid'
         self.host = 'agenthostname'
         self.framework_id = 'framework'
@@ -822,18 +819,20 @@ class TestAgent(unittest.TestCase):
         agent = scheduler.Agent(offers)
         assert agent.resources['disk'].available == 0
 
-    def test_bad_json(self):
+    def test_bad_json(self, caplog):
         """A warning must be printed if an interface description is not valid JSON"""
         offers = [self._make_offer({}, [self.if_attr_bad_json])]
-        with self.assertLogs('katsdpcontroller.scheduler', logging.WARN):
+        with caplog.at_level(logging.WARNING, logger='katsdpcontroller.scheduler'):
             agent = scheduler.Agent(offers)
+        assert 'Could not parse' in caplog.text
         assert agent.interfaces == []
 
-    def test_bad_schema(self):
+    def test_bad_schema(self, caplog):
         """A warning must be printed if an interface description does not conform to the schema"""
         offers = [self._make_offer({}, [self.if_attr_bad_schema])]
-        with self.assertLogs('katsdpcontroller.scheduler', logging.WARN):
+        with caplog.at_level(logging.WARNING, logger='katsdpcontroller.scheduler'):
             agent = scheduler.Agent(offers)
+        assert 'Validation error' in caplog.text
         assert agent.interfaces == []
 
     def test_allocate_not_valid(self):
@@ -1174,7 +1173,7 @@ class TestPhysicalTask:
         assert physical_task.cores == {'core1': 2, 'core2': 4, 'core3': 6}
 
 
-class TestDiagnoseInsufficient(unittest.TestCase):
+class TestDiagnoseInsufficient:
     """Test :class:`katsdpcontroller.scheduler.Scheduler._diagnose_insufficient.
 
     This is split out from TestScheduler to make it easier to set up fixtures.
@@ -1183,7 +1182,7 @@ class TestDiagnoseInsufficient(unittest.TestCase):
         return _make_offer('frameworkid', 'agentid{}'.format(agent_num),
                            'agenthost{}'.format(agent_num), resources, attrs)
 
-    def setUp(self):
+    def setup(self):
         # Create a number of agents, each of which has a large quantity of
         # some resource but not much of others. This makes it easier to
         # control which resources are plentiful in the simulated cluster.

--- a/src/katsdpcontroller/test/test_sensor_proxy.py
+++ b/src/katsdpcontroller/test/test_sensor_proxy.py
@@ -11,7 +11,6 @@ Still TODO:
 import enum
 import asyncio
 import functools
-import unittest
 from unittest import mock
 from typing import Dict, Mapping, Any, Optional
 
@@ -162,8 +161,8 @@ class TestSensorProxyClient(asynctest.TestCase):
         self._check_sensors()
 
 
-class TestPrometheusWatcher(unittest.TestCase):
-    def setUp(self) -> None:
+class TestPrometheusWatcher:
+    def setup(self) -> None:
         # Create a custom registry, to avoid polluting the global one
         self.registry = CollectorRegistry()
         # Custom metric cache, to avoid polluting the global one

--- a/src/katsdpcontroller/test/test_sensor_proxy.py
+++ b/src/katsdpcontroller/test/test_sensor_proxy.py
@@ -3,7 +3,7 @@
 Still TODO:
 
 - tests for Prometheus wrapping
-- test that self.mirror.mass_inform is called
+- test that mirror.mass_inform is called
 - test for the server removing a sensor before we can subscribe to it
 - test for cancellation of the update in various cases
 """
@@ -12,17 +12,16 @@ import enum
 import asyncio
 import functools
 from unittest import mock
-from typing import Dict, Mapping, Any, Optional
+from typing import Dict, Mapping, Any, Optional, AsyncGenerator
 
 import aiokatcp
 from aiokatcp import Sensor, SensorSet, Address
 from prometheus_client import Gauge, Counter, Histogram, CollectorRegistry
 
-import asynctest
+import pytest
 
 from ..sensor_proxy import SensorProxyClient, PrometheusInfo, PrometheusWatcher
 from ..controller import device_server_sockname
-from .utils import timelimit
 
 
 class MyEnum(enum.Enum):
@@ -72,32 +71,41 @@ class FutureObserver:
         self.future.set_result(reading)
 
 
-@timelimit
-class TestSensorProxyClient(asynctest.TestCase):
-    async def setUp(self) -> None:
-        self.mirror = mock.create_autospec(aiokatcp.DeviceServer, instance=True)
-        self.mirror.sensors = aiokatcp.SensorSet()
-        self.server = DummyServer('127.0.0.1', 0)
-        await self.server.start()
-        self.addCleanup(self.server.stop)
-        assert self.server.server is not None
-        assert self.server.server.sockets is not None
-        port = device_server_sockname(self.server)[1]
-        self.client = SensorProxyClient(
-            self.mirror, 'prefix-', renames={'bytes-sensor': 'custom-bytes-sensor'},
-            host='127.0.0.1', port=port)
-        self.addCleanup(self.client.wait_closed)
-        self.addCleanup(self.client.close)
-        await self.client.wait_synced()
+@pytest.mark.timeout(5)
+class TestSensorProxyClient:
+    @pytest.fixture
+    def mirror(self, mocker) -> mock.MagicMock:
+        mirror = mocker.create_autospec(aiokatcp.DeviceServer, instance=True)
+        mirror.sensors = aiokatcp.SensorSet()
+        return mirror
 
-    def _check_sensors(self) -> None:
+    @pytest.fixture
+    async def server(self) -> AsyncGenerator[DummyServer, None]:
+        server = DummyServer('127.0.0.1', 0)
+        await server.start()
+        yield server
+        await server.stop()
+
+    @pytest.fixture(autouse=True)
+    async def client(self, mirror, server: DummyServer) -> AsyncGenerator[SensorProxyClient, None]:
+        port = device_server_sockname(server)[1]
+        client = SensorProxyClient(
+            mirror, 'prefix-', renames={'bytes-sensor': 'custom-bytes-sensor'},
+            host='127.0.0.1', port=port)
+        await client.wait_synced()
+        yield client
+
+        client.close()
+        await client.wait_closed()
+
+    def _check_sensors(self, mirror, server: DummyServer) -> None:
         """Compare the upstream sensors against the mirror"""
-        for sensor in self.server.sensors.values():
+        for sensor in server.sensors.values():
             qualname = 'prefix-' + sensor.name
             if sensor.name == 'bytes-sensor':
                 qualname = 'custom-bytes-sensor'
-            assert qualname in self.mirror.sensors
-            sensor2 = self.mirror.sensors[qualname]
+            assert qualname in mirror.sensors
+            sensor2 = mirror.sensors[qualname]
             assert sensor.description == sensor2.description
             assert sensor.type_name == sensor2.type_name
             assert sensor.units == sensor2.units
@@ -108,57 +116,59 @@ class TestSensorProxyClient(asynctest.TestCase):
             assert sensor.timestamp == sensor2.timestamp
             assert sensor.status == sensor2.status
         # Check that we don't have any we shouldn't
-        for sensor2 in self.mirror.sensors.values():
+        for sensor2 in mirror.sensors.values():
             assert sensor2.name.startswith('prefix-') or sensor2.name == 'custom-bytes-sensor'
             base_name = sensor2.name[7:]
-            assert base_name in self.server.sensors
-        assert 'prefix-bytes-sensor' not in self.mirror.sensors
+            assert base_name in server.sensors
+        assert 'prefix-bytes-sensor' not in mirror.sensors
 
-    async def test_init(self) -> None:
-        self._check_sensors()
+    async def test_init(self, mirror, server: DummyServer) -> None:
+        self._check_sensors(mirror, server)
 
-    async def _set(self, name: str, value: Any, **kwargs) -> None:
+    async def _set(self, mirror, server: DummyServer, name: str, value: Any, **kwargs) -> None:
         """Set a sensor on the server and wait for the mirror to observe it"""
         observer = FutureObserver()
-        self.mirror.sensors['prefix-' + name].attach(observer)
-        self.server.sensors[name].set_value(value, **kwargs)
+        mirror.sensors['prefix-' + name].attach(observer)
+        server.sensors[name].set_value(value, **kwargs)
         await observer.future
-        self.mirror.sensors['prefix-' + name].detach(observer)
+        mirror.sensors['prefix-' + name].detach(observer)
 
-    async def test_set_value(self) -> None:
-        await self._set('int-sensor', 2, timestamp=123456790.0)
-        self._check_sensors()
+    async def test_set_value(self, mirror, server: DummyServer) -> None:
+        await self._set(mirror, server, 'int-sensor', 2, timestamp=123456790.0)
+        self._check_sensors(mirror, server)
 
-    async def test_add_sensor(self) -> None:
-        self.server.sensors.add(Sensor(int, 'another', 'another sensor', '', 234))
+    async def test_add_sensor(self, mirror, server: DummyServer, client: SensorProxyClient) -> None:
+        server.sensors.add(Sensor(int, 'another', 'another sensor', '', 234))
         # Rather than having server send an interface-changed inform, we invoke
         # it directly on the client so that we don't need to worry about timing.
         changed = aiokatcp.Message.inform('interface-changed', b'sensor-list')
-        self.client.handle_inform(changed)
-        await self.client.wait_synced()
-        self._check_sensors()
+        client.handle_inform(changed)
+        await client.wait_synced()
+        self._check_sensors(mirror, server)
 
-    async def test_remove_sensor(self) -> None:
-        del self.server.sensors['int-sensor']
+    async def test_remove_sensor(
+            self, mirror, server: DummyServer, client: SensorProxyClient) -> None:
+        del server.sensors['int-sensor']
         changed = aiokatcp.Message.inform('interface-changed', b'sensor-list')
-        self.client.handle_inform(changed)
-        await self.client.wait_synced()
-        self._check_sensors()
+        client.handle_inform(changed)
+        await client.wait_synced()
+        self._check_sensors(mirror, server)
 
-    async def test_replace_sensor(self) -> None:
-        self.server.sensors.add(Sensor(bool, 'int-sensor', 'Replaced by bool'))
+    async def test_replace_sensor(
+            self, mirror, server: DummyServer, client: SensorProxyClient) -> None:
+        server.sensors.add(Sensor(bool, 'int-sensor', 'Replaced by bool'))
         changed = aiokatcp.Message.inform('interface-changed', b'sensor-list')
-        self.client.handle_inform(changed)
-        await self.client.wait_synced()
-        self._check_sensors()
+        client.handle_inform(changed)
+        await client.wait_synced()
+        self._check_sensors(mirror, server)
 
-    async def test_reconnect(self) -> None:
+    async def test_reconnect(self, mirror, server: DummyServer, client: SensorProxyClient) -> None:
         # Cheat: the client will disconnect if given a #disconnect inform, and
         # we don't actually need to kill the server.
-        self.client.inform_disconnect('Test')
-        await self.client.wait_disconnected()
-        await self.client.wait_synced()
-        self._check_sensors()
+        client.inform_disconnect('Test')
+        await client.wait_disconnected()
+        await client.wait_synced()
+        self._check_sensors(mirror, server)
 
 
 class TestPrometheusWatcher:

--- a/src/katsdpcontroller/test/test_web.py
+++ b/src/katsdpcontroller/test/test_web.py
@@ -7,16 +7,18 @@ import json
 import functools
 import logging
 import signal
+import socket
 from unittest import mock
 from typing import List, Dict, Tuple, Any, Optional
 
 import yarl
 from aiokatcp import Sensor, SensorSet
 from aiohttp.test_utils import TestClient, TestServer
-import asynctest
+from aiohttp.web import Application
+import async_solipsism
+import pytest
 
 from .. import web
-from .utils import create_patch
 
 
 EXTERNAL_URL = yarl.URL('http://proxy.invalid:1234')
@@ -160,173 +162,213 @@ async def dummy_create_subprocess_exec(*args: str) -> DummyHaproxyProcess:
     return DummyHaproxyProcess(*args)
 
 
-class TestWeb(asynctest.ClockedTestCase):
-    haproxy_bind: Optional[Tuple[str, int]] = None
-    maxDiff = None
+def socket_factory(host: str, port: int, family: socket.AddressFamily) -> socket.socket:
+    """Connects aiohttp test_utils to async-solipsism."""
+    return async_solipsism.ListenSocket((host, port if port else 80))
 
-    async def setUp(self) -> None:
-        self.mc_server = mock.MagicMock()
-        self.mc_server.sensors = SensorSet()
-        self.mc_server.orig_sensors = SensorSet()
 
-        self.mc_server.sensors.add(
+class TestWeb:
+    @pytest.fixture
+    def use_haproxy(self) -> bool:
+        return False  # Overridden in TestHaproxyWeb
+
+    @pytest.fixture
+    def haproxy_bind(self, use_haproxy) -> Optional[Tuple[str, int]]:
+        return ('localhost.invalid', 80) if use_haproxy else None
+
+    @pytest.fixture
+    def event_loop(self):
+        loop = async_solipsism.EventLoop()
+        yield loop
+        loop.close()
+
+    @pytest.fixture
+    def mc_server(self, use_haproxy: bool) -> mock.MagicMock:
+        mc_server = mock.MagicMock()
+        mc_server.sensors = SensorSet()
+        mc_server.orig_sensors = SensorSet()
+
+        mc_server.sensors.add(
             Sensor(str, 'products', '', default='["product1", "product2"]',
                    initial_status=Sensor.Status.NOMINAL))
-        self.mc_server.sensors.add(
+        mc_server.sensors.add(
             Sensor(str, 'gui-urls', '', default=json.dumps(ROOT_GUI_URLS),
                    initial_status=Sensor.Status.NOMINAL))
 
-        self.mc_server.orig_sensors.add(
+        mc_server.orig_sensors.add(
             Sensor(str, 'product1.gui-urls', '', default=json.dumps(PRODUCT1_GUI_URLS),
                    initial_status=Sensor.Status.NOMINAL))
-        self.mc_server.orig_sensors.add(
+        mc_server.orig_sensors.add(
             Sensor(str, 'product2.cal.1.gui-urls', '', default=json.dumps(PRODUCT2_CAL_GUI_URLS),
                    initial_status=Sensor.Status.NOMINAL))
-        self.mc_server.orig_sensors.add(
+        mc_server.orig_sensors.add(
             Sensor(str, 'product2.ingest.1.gui-urls', '', default=json.dumps(PRODUCT2_CAL_GUI_URLS),
                    initial_status=Sensor.Status.UNKNOWN))
-        for sensor in self.mc_server.orig_sensors.values():
-            if self.haproxy_bind is not None and sensor.name.endswith('.gui-urls'):
+        for sensor in mc_server.orig_sensors.values():
+            if use_haproxy and sensor.name.endswith('.gui-urls'):
                 new_value = web.rewrite_gui_urls(EXTERNAL_URL, sensor)
                 new_sensor = Sensor(sensor.stype, sensor.name, sensor.description, sensor.units)
                 new_sensor.set_value(new_value, timestamp=sensor.timestamp, status=sensor.status)
-                self.mc_server.sensors.add(new_sensor)
+                mc_server.sensors.add(new_sensor)
             else:
-                self.mc_server.sensors.add(sensor)
+                mc_server.sensors.add(sensor)
+        return mc_server
 
-        self.app = web.make_app(self.mc_server, self.haproxy_bind)
-        self.server = TestServer(self.app)
-        self.client = TestClient(self.server)
-        await self.client.start_server()
-        self.addCleanup(self.client.close)
-        self.mc_server.add_interface_changed_callback.assert_called_once()
-        self.dirty_set = self.mc_server.add_interface_changed_callback.mock_calls[0][1][0]
-        self.dirty_set()
-        await self.advance(1)
+    @pytest.fixture
+    async def app(self, mc_server, haproxy_bind) -> Application:
+        # Declared async to ensure that the pytest-asyncio event loop is
+        # installed before anything tries to get the current event loop.
+        return web.make_app(mc_server, haproxy_bind)
 
-    async def test_get_guis(self) -> None:
-        guis = web._get_guis(self.mc_server)
-        haproxy = self.haproxy_bind is not None
+    @pytest.fixture
+    async def server(self, app: Application) -> TestServer:
+        async with TestServer(app, socket_factory=socket_factory) as server:
+            yield server
+
+    @pytest.fixture
+    async def client(self, server: TestServer) -> TestClient:
+        async with TestClient(server) as client:
+            yield client
+
+    @pytest.fixture(autouse=True)
+    def dirty_set(self, mc_server, client: TestClient) -> None:
+        mc_server.add_interface_changed_callback.assert_called_once()
+        dirty_set = mc_server.add_interface_changed_callback.mock_calls[0][1][0]
+        dirty_set()
+        return dirty_set
+
+    async def test_get_guis(self, mc_server, use_haproxy: bool) -> None:
+        guis = web._get_guis(mc_server)
         expected = {
             "general": ROOT_GUI_URLS,
             "products": {
-                "product1": expected_gui_urls(PRODUCT1_GUI_URLS_OUT, haproxy, True),
-                "product2": expected_gui_urls(PRODUCT2_GUI_URLS_OUT, haproxy, True)
+                "product1": expected_gui_urls(PRODUCT1_GUI_URLS_OUT, use_haproxy, True),
+                "product2": expected_gui_urls(PRODUCT2_GUI_URLS_OUT, use_haproxy, True)
             }
         }
         assert guis == expected
 
-    async def test_get_guis_not_nominal(self) -> None:
+    def test_get_guis_not_nominal(self, mc_server) -> None:
         for name in ['gui-urls', 'product1.gui-urls', 'product2.cal.1.gui-urls']:
-            sensor = self.mc_server.sensors[name]
+            sensor = mc_server.sensors[name]
             sensor.set_value(sensor.value, status=Sensor.Status.ERROR)
-        guis = web._get_guis(self.mc_server)
+        guis = web._get_guis(mc_server)
         expected = {
             "general": [],
             "products": {"product1": [], "product2": []}
         }
         assert guis == expected
 
-    async def test_update_bad_gui_sensor(self) -> None:
-        with self.assertLogs('katsdpcontroller.web', logging.ERROR):
-            self.mc_server.sensors['product1.gui-urls'].value = 'not valid json'
-            await self.advance(1)
+    async def test_update_bad_gui_sensor(self, mc_server, caplog) -> None:
+        with caplog.at_level(logging.ERROR, logger='katsdpcontroller.web'):
+            mc_server.sensors['product1.gui-urls'].value = 'not valid json'
+            await asyncio.sleep(1)
+        assert caplog.text
 
-    async def test_index(self) -> None:
-        async with self.client.get('/') as resp:
+    async def test_index(self, client: TestClient) -> None:
+        async with client.get('/') as resp:
             assert resp.status == 200
             assert resp.headers['Content-type'] == 'text/html; charset=utf-8'
             assert resp.headers['Cache-control'] == 'no-store'
 
-    async def test_favicon(self) -> None:
-        async with self.client.get('/favicon.ico') as resp:
+    async def test_favicon(self, client: TestClient) -> None:
+        async with client.get('/favicon.ico') as resp:
             assert resp.status == 200
             assert resp.headers['Content-type'] == 'image/vnd.microsoft.icon'
 
-    async def test_prometheus(self) -> None:
-        async with self.client.get('/metrics') as resp:
+    async def test_prometheus(self, client: TestClient) -> None:
+        async with client.get('/metrics') as resp:
             assert resp.status == 200
 
-    async def test_rotate(self) -> None:
+    async def test_rotate(self, client: TestClient) -> None:
         # A good test of this probably needs Selenium plus a whole lot of
         # extra infrastructure.
-        async with self.client.get('/rotate?width=500&height=600') as resp:
+        async with client.get('/rotate?width=500&height=600') as resp:
             text = await resp.text()
             assert resp.status == 200
             assert 'width: 500' in text
             assert 'height: 600' in text
 
-    async def test_missing_gui(self) -> None:
+    async def test_missing_gui(self, client: TestClient) -> None:
         for path in ['/gui/product3/service/label', '/gui/product3/service/label/foo']:
-            async with self.client.get(path) as resp:
+            async with client.get(path) as resp:
                 text = await resp.text()
                 assert resp.status == 404
                 assert 'product3' in text
 
-    async def test_websocket(self) -> None:
-        haproxy = self.haproxy_bind is not None
+    async def test_websocket(self, client: TestClient, mc_server,
+                             dirty_set, use_haproxy: bool) -> None:
         expected = {
             "general": ROOT_GUI_URLS,
             "products": {
-                "product1": expected_gui_urls(PRODUCT1_GUI_URLS_OUT, haproxy, False),
-                "product2": expected_gui_urls(PRODUCT2_GUI_URLS_OUT, haproxy, False)
+                "product1": expected_gui_urls(PRODUCT1_GUI_URLS_OUT, use_haproxy, False),
+                "product2": expected_gui_urls(PRODUCT2_GUI_URLS_OUT, use_haproxy, False)
             }
         }
-        async with self.client.ws_connect('/ws') as ws:
+        async with client.ws_connect('/ws') as ws:
             await ws.send_str('guis')
             guis = await ws.receive_json()
             assert guis == expected
             # Updating should trigger an unsolicited update
-            sensor = self.mc_server.sensors['products']
+            sensor = mc_server.sensors['products']
             sensor.value = '["product1"]'
             del expected["products"]["product2"]    # type: ignore
-            self.dirty_set()
-            await self.advance(1)
+            dirty_set()
+            await asyncio.sleep(1)
             guis = await ws.receive_json()
             assert guis == expected
             await ws.close()
 
-    async def test_websocket_close_server(self) -> None:
+    async def test_websocket_close_server(self, client: TestClient, server: TestServer) -> None:
         """Close the server while a websocket is still connected"""
-        async with self.client.ws_connect('/ws'):
-            await self.server.close()
+        async with client.ws_connect('/ws'):
+            await server.close()
 
 
 class TestWebHaproxy(TestWeb):
-    haproxy_bind = ('localhost.invalid', 80)
+    @pytest.fixture
+    def use_haproxy(self) -> bool:
+        return True
 
-    async def setUp(self) -> None:
-        create_patch(self, 'asyncio.create_subprocess_exec',
-                     dummy_create_subprocess_exec)
-        await super().setUp()
-        self.app['updater'].internal_port = 2345
-        await self.advance(1)
+    @pytest.fixture(autouse=True)
+    def mock_subprocess(self, mocker) -> None:
+        mocker.patch('asyncio.create_subprocess_exec', dummy_create_subprocess_exec)
 
-    def test_internal_port(self) -> None:
+    @pytest.fixture(autouse=True)
+    def _set_app_internal_port(self, app) -> None:
+        app['updater'].internal_port = 2345
+        return app
+
+    def test_internal_port(self, app) -> None:
         """Tests the internal_port property getter"""
-        assert self.app['updater'].internal_port == 2345
+        assert app['updater'].internal_port == 2345
 
-    async def test_null_update(self) -> None:
+    async def test_null_update(self, mocker, dirty_set) -> None:
         """Triggered update must not poke haproxy if not required"""
-        with mock.patch.object(DummyHaproxyProcess, 'send_signal') as m:
-            self.dirty_set()
-            await self.advance(1)
-            m.assert_not_called()
+        m = mocker.patch.object(DummyHaproxyProcess, 'send_signal')
+        dirty_set()
+        await asyncio.sleep(1)
+        m.assert_not_called()
 
-    async def test_update(self) -> None:
+    async def test_update(self, app: Application, mc_server) -> None:
         """Sensor update must update haproxy config and reload it"""
-        sensor = self.mc_server.sensors['product1.gui-urls']
+        sensor = mc_server.sensors['product1.gui-urls']
         guis = json.loads(sensor.value)
         guis[0]['title'] = 'Test Title'
         sensor.value = json.dumps(guis).encode()
-        await self.advance(1)
-        assert 'test-title' in self.app['updater']._haproxy._process.config
+        await asyncio.sleep(1)
+        assert 'test-title' in app['updater']._haproxy._process.config
 
-    async def test_haproxy_died(self) -> None:
+    async def test_haproxy_died(self, app: Application, client: TestClient, caplog) -> None:
         """Gracefully handle haproxy dying on its own"""
-        with self.assertLogs('katsdpcontroller.web', logging.WARNING) as cm:
-            self.app['updater']._haproxy._process.died(-9)
-            await self.client.close()
-        assert cm.output == [
-            'WARNING:katsdpcontroller.web:haproxy exited with non-zero exit status -9'
+        with caplog.at_level(logging.WARNING, 'katsdpcontroller.web'):
+            await asyncio.sleep(1)  # Give simulated process a chance to start
+            app['updater']._haproxy._process.died(-9)
+            await client.close()
+        assert caplog.record_tuples == [
+            (
+                'katsdpcontroller.web',
+                logging.WARNING,
+                'haproxy exited with non-zero exit status -9'
+            )
         ]

--- a/src/katsdpcontroller/test/utils.py
+++ b/src/katsdpcontroller/test/utils.py
@@ -427,18 +427,6 @@ class Background(Generic[_T]):
         return self._future.result()
 
 
-async def run_clocked(test_case: asynctest.ClockedTestCase, time: float,
-                      awaitable: Awaitable[_T]) -> _T:
-    """Run a coroutine while advancing the clock on a clocked test case.
-
-    This is useful if the implementation of the `awaitable` sleeps and hence
-    needs the time advanced to make progress.
-    """
-    with Background(awaitable) as cm:
-        await test_case.advance(time)
-    return cm.result
-
-
 def future_return(mock: mock.Mock) -> asyncio.Future:
     """Modify a callable mock so that it blocks on a future then returns it."""
     async def replacement(*args, **kwargs):

--- a/src/katsdpcontroller/test/utils.py
+++ b/src/katsdpcontroller/test/utils.py
@@ -1,14 +1,12 @@
 """Utilities for unit tests"""
 
 import asyncio
-import unittest
 from unittest import mock
 from typing import (List, Tuple, Iterable, Coroutine, Awaitable, Optional,
                     Type, Any, TypeVar, Generic)
 from types import TracebackType
 
 import aiokatcp
-import asynctest
 import pytest
 
 
@@ -288,14 +286,6 @@ EXPECTED_INTERFACE_SENSOR_LIST: List[Tuple[bytes, ...]] = [
     (b'timeplot.sdp_l0.gui-urls', b'', b'string'),
     (b'timeplot.sdp_l0.html_port', b'', b'address')
 ]
-
-
-def create_patch(test_case: unittest.TestCase, *args, **kwargs) -> Any:
-    """Wrap asynctest.patch such that it will be unpatched as part of test case cleanup."""
-    patcher = asynctest.patch(*args, **kwargs)
-    mock_obj = patcher.start()
-    test_case.addCleanup(patcher.stop)
-    return mock_obj
 
 
 async def assert_request_fails(client: aiokatcp.Client, name: str, *args: Any) -> None:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 -c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
 aioresponses==0.7.1
+async-solipsism
 asynctest
 coverage
 open-mock-file==1.0.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,4 @@ open-mock-file==1.0.2
 pytest
 pytest-asyncio
 pytest-cov
+pytest-mock

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 -c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
 aioresponses==0.7.1
-async-solipsism==0.4.0
+async-solipsism==0.5
 coverage
 open-mock-file==1.0.2
 pytest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,12 +1,12 @@
 -c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
 aioresponses==0.7.1
-async-solipsism
+async-solipsism==0.4.0
 asynctest
 coverage
 open-mock-file==1.0.2
 pytest
-pytest-asyncio
+pytest-asyncio==0.18.3
 pytest-cov
-pytest-mock
-pytest-timeout
+pytest-mock==3.7.0
+pytest-timeout==2.1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,6 @@
 
 aioresponses==0.7.1
 async-solipsism==0.4.0
-asynctest
 coverage
 open-mock-file==1.0.2
 pytest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,3 +8,4 @@ pytest
 pytest-asyncio
 pytest-cov
 pytest-mock
+pytest-timeout

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,5 @@ asynctest
 coverage
 open-mock-file==1.0.2
 pytest
+pytest-asyncio
 pytest-cov


### PR DESCRIPTION
asynctest hasn't been updated for years and uses deprecated functionality that is expected to stop working in Python 3.11. I've eliminated unittest.TestCase just so that everything is using the same framework.

This is unfortunately a massive change because pytest doesn't support having fixture functions store data in the test class itself (each fixture gets called with a different instance of the class). One can still store data in the class with a `setup` function, but that is quite limited e.g. it cannot make use of any other pytest fixtures. In a few cases I've gotten around this by creating an inner class called "Fixture" that holds all the state that was previously held in the TestFoo class, to avoid passing a dozen fixtured into every method.

There are still a lot of warnings emitted, which suggests that some cleanup is not happening, but the tests all pass. I plan to clean up warnings in a future PR, but this one is already excessively large.

It depends on https://github.com/ska-sa/katsdpdockerbase/pull/84.