### PR TITLE
Make things work with async_timeout 4.0

### DIFF
--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -369,7 +369,7 @@ class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
         self.logger.info("Issuing request %s %s to node %s (timeout %gs)",
                          req, args, self.name, timeout)
         try:
-            with async_timeout.timeout(timeout):
+            async with async_timeout.timeout(timeout):
                 await self.katcp_connection.wait_connected()
                 reply, informs = await self.katcp_connection.request(req, *args)
             self.logger.info("Request %s %s to node %s successful", req, args, self.name)

--- a/src/katsdpcontroller/test/utils.py
+++ b/src/katsdpcontroller/test/utils.py
@@ -474,7 +474,7 @@ def timelimit(limit=5.0):
             @functools.wraps(arg)
             async def wrapper(self, *args, **kwargs):
                 try:
-                    async with async_timeout.timeout(limit, loop=self.loop) as cm:
+                    async with async_timeout.timeout(limit) as cm:
                         await arg(self, *args, **kwargs)
                 except asyncio.TimeoutError:
                     if not cm.expired:


### PR DESCRIPTION
The tests broke because an explicit loop argument was being used. There
was also one place that it was being used with the synchronous context
manager, which is deprecated.

This will be superseded by #599, but that's a large PR and may take some
time to land, and in the meantime the master branch is not building.
