### PR TITLE
Eliminate warnings from pytest

### DIFF
--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -481,7 +481,7 @@ class InternalProductManager(ProductManagerBase[InternalProduct]):
             '127.0.0.1', 0, mc_client, name, sched, self._args.batch_role,
             True, self._args.localhost, self._image_resolver_factory,
             s3_config={}, shutdown_delay=0)
-        product = InternalProduct(name, config, asyncio.Task.current_task(), server)
+        product = InternalProduct(name, config, asyncio.current_task(), server)
         self._add_product(product)
         await product.server.start()
         host, port = device_server_sockname(product.server)
@@ -872,7 +872,7 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
             f'zk://{self._args.zk}/mesos'
         ])
 
-        product = SingularityProduct(name, config, asyncio.Task.current_task())
+        product = SingularityProduct(name, config, asyncio.current_task())
         self._add_product(product)
         success = False
         task_id: Optional[str] = None

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -1486,6 +1486,14 @@ class DeviceServer(aiokatcp.DeviceServer):
         await self.master_controller.wait_closed()
         await self.sched.close()
 
+    async def join(self) -> None:
+        await super().join()
+        # Ensure that the connection is closed even if start() did not
+        # complete (in which case on_stop might not run). This could happen
+        # if cancelled while waiting to connect to the master controller.
+        self.master_controller.close()
+        await self.master_controller.wait_closed()
+
     async def configure_product(self, name: str, configuration: Configuration,
                                 config_dict: dict) -> None:
         """Configure a subarray product in response to a request.

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -1484,6 +1484,7 @@ class DeviceServer(aiokatcp.DeviceServer):
                 logger.warning('Failed to deconfigure product %s during shutdown', exc_info=True)
         self.master_controller.close()
         await self.master_controller.wait_closed()
+        await self.sched.close()
 
     async def configure_product(self, name: str, configuration: Configuration,
                                 config_dict: dict) -> None:

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -2807,6 +2807,8 @@ class TaskStats:
 
 
 async def _cleanup_task(task):
+    if not task:
+        return
     task.cancel()
     try:
         await task

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -366,7 +366,7 @@ async def poll_ports(host, ports):
                     await loop.sock_connect(sock, (sockaddr[0], port))
                 except OSError as error:
                     logger.debug('Port %d on %s not ready: %s', port, host, error)
-                    await asyncio.sleep(1, loop=loop)
+                    await asyncio.sleep(1)
                 else:
                     break
         logger.debug('Port %d on %s ready', port, host)

--- a/src/katsdpcontroller/schemas/__init__.py
+++ b/src/katsdpcontroller/schemas/__init__.py
@@ -56,8 +56,8 @@ class MultiVersionValidator(object):
 
 for name in pkg_resources.resource_listdir(__name__, '.'):
     if name.endswith('.json'):
-        reader = codecs.getreader('utf-8')(pkg_resources.resource_stream(__name__, name))
-        schema = json.load(reader)
+        with codecs.getreader('utf-8')(pkg_resources.resource_stream(__name__, name)) as reader:
+            schema = json.load(reader)
         globals()[name[:-5].upper()] = _make_validator(schema)
     elif name.endswith('.json.j2'):
         globals()[name[:-8].upper()] = MultiVersionValidator(name)


### PR DESCRIPTION
This eliminates the warnings on my machine. I think Jenkins is still likely to show some warnings because katsdpdockerbase is pinning older versions of things. It's mostly DeprecationWarning, ResourceWarning, and warnings from asyncio about tasks that never get killed - see individual commits for explanations.