### PR TITLE
Add host and version sensors for product controllers

### DIFF
--- a/src/katsdpcontroller/schemas/zk_state.json.j2
+++ b/src/katsdpcontroller/schemas/zk_state.json.j2
@@ -7,7 +7,7 @@
         "version": {
             "type": "integer",
             "minimum": 1,
-            "maximum": 3
+            "maximum": 4
         }
     }
 }
@@ -45,6 +45,9 @@
 {% else %}
                     "port",
 {% endif %}
+{% if version >= 4 %}
+                    "image",
+{% endif %}
                     "run_id", "task_id", "host", "config", "multicast_groups"
                 ],
                 "properties": {
@@ -62,6 +65,9 @@
 {% endif %}
                     "run_id": {"type": "string"},
                     "task_id": {"type": "string"},
+{% if version >= 4 %}
+                    "image": {"type": "string"},
+{% endif %}
                     "host": {"type": "string"},
                     "config": {"type": "object"},
                     "multicast_groups": {

--- a/test/test_master_controller.py
+++ b/test/test_master_controller.py
@@ -48,7 +48,8 @@ EXPECTED_SENSOR_LIST: List[Tuple[bytes, ...]] = [
 
 # Sensors created per-product by the master controller
 EXPECTED_PRODUCT_SENSOR_LIST: List[Tuple[bytes, ...]] = [
-    (b'katcp-address', b'', b'address')
+    (b'katcp-address', b'', b'address'),
+    (b'host', b'', b'string'),
 ]
 
 EXPECTED_REQUEST_LIST = [
@@ -766,6 +767,8 @@ class TestDeviceServer:
         product = server._manager.products['product']
         await assert_sensor_value(
             client, 'product.katcp-address', f'127.0.0.1:{product.ports["katcp"]}')
+        await assert_sensor_value(
+            client, 'product.host', '127.0.0.1')
 
         # Change the product's device-status to FAIL and check that the top-level sensor
         # is updated.

--- a/test/test_master_controller.py
+++ b/test/test_master_controller.py
@@ -354,6 +354,8 @@ class TestSingularityProductManager:
         assert product.ports['aiomonitor'] == 12347
         assert product.ports['aioconsole'] == 12348
         assert product.ports['dashboard'] == 12349
+        assert product.image == 'registry.invalid:5000/katsdpcontroller:a_tag'
+        assert fix.server.sensors['foo.version'].value == product.image
         client_mock.assert_called_with('192.0.2.0', 12345)
 
         await fix.manager.product_active(product)
@@ -462,6 +464,7 @@ class TestSingularityProductManager:
         assert product.task_state == product2.task_state
         assert product.run_id == product2.run_id
         assert product.task_id == product2.task_id
+        assert product.image == product2.image
         assert product.multicast_groups == product2.multicast_groups
         assert product.host == product2.host
         assert product.ports == product2.ports


### PR DESCRIPTION
Add master controller sensors for each product:
- `<product>.host` contains the hostname as a DNS name (as opposed to `<product>.katcp-address`, which by virtue of being the katcp "address" type must use an IP address). It's also persisted in Zookeeper as a hostname rather than an IP address now.
- `<product>.version` contains the Docker image.

These relate to NGC-689.