### PR TITLE
Implement capture-list for CBF

### DIFF
--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -1233,7 +1233,7 @@ class SubarrayProduct:
                 node.transmit_state = TransmitState.UP if start else TransmitState.DOWN
 
     def capture_list(self) -> Sequence[generator.PhysicalMulticast]:
-        """Return all :class:`.PhysicalMulticast` nodes that has known stream state."""
+        """Return all :class:`.PhysicalMulticast` nodes that have known stream state."""
         return [
             node for node in self.physical_graph
             if (isinstance(node, generator.PhysicalMulticast)


### PR DESCRIPTION
To implement it, each PhysicalMulticast object has an enum to indicate
whether it is up, down, or unknown. Unknown streams won't appear in
capture-list.

It only lists gpucbf streams, because reporting the up/down status
requires tracking whether streams are up or down, and I didn't feel like
trying to do that for all the assorted SDP streams. It's not part of the
SDP ICD, so there is no need to do that.

Closes NGC-716.
