### PR TITLE
Pass log messages to master controller clients

### DIFF
--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -1033,7 +1033,7 @@ class DeviceServer(aiokatcp.DeviceServer):
         self.orig_sensors = SensorSet()
         for sensor in self.sensors.values():
             self.orig_sensors.add(sensor)
-        # Send all logs sent over katcp connection to clients
+        # Send all logs over katcp connection to clients
         logging.getLogger().addHandler(self.LogHandler(self))
 
     async def start(self) -> None:

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -1033,6 +1033,8 @@ class DeviceServer(aiokatcp.DeviceServer):
         self.orig_sensors = SensorSet()
         for sensor in self.sensors.values():
             self.orig_sensors.add(sensor)
+        # Send all logs sent over katcp connection to clients
+        logging.getLogger().addHandler(self.LogHandler(self))
 
     async def start(self) -> None:
         await self._manager.start()


### PR DESCRIPTION
CAM have indicated they're happy with the functionality (NGC-715 / MT-3187), so this just needs a rubber stamp.