### PR TITLE
Add w_cutoff option for gpucbf.antenna_channelised_voltage streams

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -570,6 +570,7 @@ def _make_fgpu(
             '--channels', str(stream.n_chans),
             '--sync-epoch', str(sync_time),
             '--taps', str(stream.pfb_taps),
+            '--w-cutoff', str(stream.w_cutoff),
             '--katcp-port', '{ports[port]}',
             '--prometheus-port', '{ports[prometheus]}',
             '--aiomonitor',

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -502,6 +502,7 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
             src_streams: Sequence[Stream], *,
             n_chans: int,
             input_labels: Optional[Iterable[str]] = None,
+            w_cutoff: float = 1.0,
             command_line_extra: Iterable[str] = ()) -> None:
         if n_chans < 1 or (n_chans & (n_chans - 1)) != 0:
             raise ValueError('n_chans is not a power of 2')
@@ -557,6 +558,7 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
         self.n_substreams = n_substreams
         self.bits_per_sample = 8
         self.pfb_taps = defaults.PFB_TAPS
+        self.w_cutoff = w_cutoff
         self.command_line_extra = list(command_line_extra)
 
     @property
@@ -597,6 +599,7 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
             name, src_streams,
             n_chans=config['n_chans'],
             input_labels=config.get('input_labels'),
+            w_cutoff=config.get('w_cutoff', 1.0),
             command_line_extra=config.get('command_line_extra', [])
         )
 

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -569,6 +569,7 @@
                                         "items": {"$ref": "#/definitions/stream_name"},
                                         "uniqueItems": true
                                     },
+                                    "w_cutoff": {"$ref": "#/definitions/positive_number", "default": 1.0},
                                     "command_line_extra": {
                                         "type": "array",
                                         "items": {"type": "string"}

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -404,6 +404,7 @@ class TestGpucbfAntennaChanneliseVoltageStream:
         assert acv.sources(1) == tuple(self.src_streams[2:4])
         assert acv.data_rate(1.0, 0) == 27392e6 * 2
         assert acv.input_labels == self.config['src_streams']
+        assert acv.w_cutoff == 1.0  # Default value
         assert acv.command_line_extra == []
 
     def test_n_chans_not_power_of_two(self) -> None:
@@ -472,6 +473,13 @@ class TestGpucbfAntennaChanneliseVoltageStream:
             GpucbfAntennaChannelisedVoltageStream.from_config(
                 Options(), 'wide1_acv', self.config, self.src_streams, {}
             )
+
+    def test_w_cutoff(self) -> None:
+        self.config['w_cutoff'] = 0.9
+        acv = GpucbfAntennaChannelisedVoltageStream.from_config(
+            Options(), 'wide1_acv', self.config, self.src_streams, {}
+        )
+        assert acv.w_cutoff == 0.9
 
     def test_command_line_extra(self) -> None:
         self.config['command_line_extra'] = ['--extra-arg']


### PR DESCRIPTION
It's passed directly to fgpu as `--w-cutoff` (still to be implemented).