### PR TITLE
Add xbgpu aggregate sync sensor

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -209,11 +209,15 @@ class SumSensor(SimpleAggregateSensor[int]):
 
 
 class SyncSensor(SimpleAggregateSensor[bool]):
-    """Aggregate which takes the logical AND of its children.
+    """Aggregate which tracks if its children are synchronised.
 
-    The status computes as ERROR if any of the child readings are False
-    or absent.
-    TODO: Update the comment to indicate the updated logic.
+    In this case,
+    - a 'synchronised' child has a reading of (True, NOMINAL), and
+    - an 'unsynchronised' child has a reading of (False, ERROR).
+
+    This aggregate sensor does not make provision for a FAILURE status
+    as this functionality is considered covered in a dedicated Device
+    Status sensor.
     """
 
     def __init__(

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -216,7 +216,7 @@ class SyncSensor(SimpleAggregateSensor[bool]):
     """
 
     def __init__(
-        self, target: SensorSet, sensor_type: Type[_T],
+        self, target: SensorSet, sensor_type: Type[bool],
         name: str, description: str, units: str = "",
         *,
         auto_strategy: Optional["SensorSampler.Strategy"] = None,
@@ -228,7 +228,7 @@ class SyncSensor(SimpleAggregateSensor[bool]):
         self.name_regex = name_regex
         self.children = children
         self._known = 0
-        self.synchronised = None
+        self.synchronised = False
         self.curr_values: List[bool] = []
 
         super().__init__(

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -255,9 +255,7 @@ class SyncSensor(SimpleAggregateSensor[bool]):
         return False
 
     def aggregate_compute(self) -> Tuple[Sensor.Status, bool]:
-        # Add the sensor to the list and update the value according to
-        # reading.value
-        # Update the aggregated sync-status?
+        self.curr_values.clear()
 
         # Also, the target passed in is for *all* sensors
         # - Use the name_regex to get the ones we need

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -213,6 +213,7 @@ class SyncSensor(SimpleAggregateSensor[bool]):
 
     The status computes as ERROR if any of the child readings are False
     or absent.
+    TODO: Update the comment to indicate the updated logic.
     """
 
     def __init__(
@@ -244,6 +245,8 @@ class SyncSensor(SimpleAggregateSensor[bool]):
         if reading.status.valid_value():
             if reading.value is True:
                 self._total_in_sync += 1
+            else:
+                self._total_in_sync -= 1
             self._known += 1
             return True
         return False
@@ -260,10 +263,10 @@ class SyncSensor(SimpleAggregateSensor[bool]):
     def aggregate_compute(self) -> Tuple[Sensor.Status, bool]:
         if self._known != self.children:
             return (Sensor.Status.ERROR, False)
+        # TODO: Maybe change this to MOD?
         synchronised = self._total_in_sync == self.children
         status = Sensor.Status.NOMINAL if synchronised else Sensor.Status.ERROR
         # Need to zero the _total_in_sync count before the tally is done again
-        self._total_in_sync = 0
         return (status, synchronised)
 
 

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -211,8 +211,8 @@ class SumSensor(SimpleAggregateSensor[int]):
 class SyncSensor(SimpleAggregateSensor[bool]):
     """Aggregate which takes the logical AND of its children.
 
-    It also tracks which child readings are False/out-of-sync, and sets the
-    state to FAILURE if they are all False/out-of-sync.
+    The status computes as ERROR if any of the child readings are False, and
+    FAILURE if they aren't all present.
     """
 
     def __init__(

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -753,12 +753,12 @@ def _make_xbgpu(
                default=stream.n_chans_per_substream, initial_status=Sensor.Status.NOMINAL),
         SumSensor(sensors, int, f"{stream.name}-xeng-clip-cnt",
                   "Number of visibilities that saturated",
-                  name_regex=re.compile(rf"xb\.{stream.name}\.[0-9]+\.xeng-clip-cnt"),
+                  name_regex=re.compile(rf"xb\.{re.escape(stream.name)}\.[0-9]+\.xeng-clip-cnt"),
                   children=stream.n_substreams),
         SyncSensor(sensors, bool, f"{stream.name}-xengs-synchronised",
                    "For the latest accumulation, was data present from all F-Engines \
                    for all X-Engines",
-                   name_regex=re.compile(rf"xb\.{stream.name}\.[0-9]+\.synchronised"),
+                   name_regex=re.compile(rf"xb\.{re.escape(stream.name)}\.[0-9]+\.synchronised"),
                    children=stream.n_substreams)
     ]
     for ss in stream_sensors:

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -209,7 +209,7 @@ class SumSensor(SimpleAggregateSensor[int]):
 
 
 class SyncSensor(SimpleAggregateSensor[bool]):
-    """Aggregate which tracks if its children are synchronised.
+    """Aggregate which tracks whether its children are synchronised.
 
     In this case,
     - a 'synchronised' child has a reading of (True, NOMINAL), and
@@ -754,8 +754,8 @@ def _make_xbgpu(
                   name_regex=re.compile(rf"xb\.{re.escape(stream.name)}\.[0-9]+\.xeng-clip-cnt"),
                   children=stream.n_substreams),
         SyncSensor(sensors, bool, f"{stream.name}-xengs-synchronised",
-                   "For the latest accumulation, was data present from all F-Engines \
-                   for all X-Engines",
+                   "For the latest accumulation, was data present from all F-Engines "
+                   "for all X-Engines",
                    name_regex=re.compile(rf"xb\.{re.escape(stream.name)}\.[0-9]+\.synchronised"),
                    children=stream.n_substreams)
     ]

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -214,10 +214,6 @@ class SyncSensor(SimpleAggregateSensor[bool]):
     In this case,
     - a 'synchronised' child has a reading of (True, NOMINAL), and
     - an 'unsynchronised' child has a reading of (False, ERROR).
-
-    This aggregate sensor does not make provision for a FAILURE status
-    as this functionality is considered covered in a dedicated Device
-    Status sensor.
     """
 
     def __init__(


### PR DESCRIPTION
Considering all X-engines should have their `synchronised` sensors
go to `False` when an F-engine goes missing, perhaps I should change
the calculation of the aggregated `synchronised` to ensure all are `False`?
(To be more explicit from a readability POV.)

Either way, I've run through the various ways of correlator degradation to
ensure the status does move through the values accordingly:
* SyncSensor goes to `ERROR` when X-engines are showing `False`,
* ~~SyncSensor goes to `FAILURE` when an X-engine disappears.~~ As per the discussion below, this case was removed.

Resolves: NGC-665.