### PR TITLE
Add fake fgpu rx.device-status sensor

### DIFF
--- a/src/katsdpcontroller/fake_servers.py
+++ b/src/katsdpcontroller/fake_servers.py
@@ -2,6 +2,7 @@
 
 import json
 import numbers
+from enum import Enum
 from typing import Dict, Optional, Tuple
 
 import numpy as np
@@ -15,6 +16,14 @@ def _format_complex(value: numbers.Complex) -> str:
     This is copied from katgpucbf.
     """
     return f"{value.real}{value.imag:+}j"
+
+
+class DeviceStatus(Enum):
+    """Discrete `device-status` readings."""
+
+    OK = 1
+    DEGRADED = 2
+    FAIL = 3
 
 
 class FakeFgpuDeviceServer(FakeDeviceServer):
@@ -107,6 +116,16 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
                     initial_status=Sensor.Status.NOMINAL
                 )
             )
+
+        self.sensors.add(
+            Sensor(
+                DeviceStatus,
+                "rx.device-status",
+                "The F-engine is receiving a good, clean digitiser stream",
+                default=DeviceStatus.DEGRADED,
+                initial_status=Sensor.Status.WARN,
+            )
+        )
 
     async def request_delays(self, ctx, start_time: Timestamp, *delays: str) -> None:
         """Add a new first-order polynomial to the delay and fringe correction model."""

--- a/src/katsdpcontroller/fake_servers.py
+++ b/src/katsdpcontroller/fake_servers.py
@@ -123,7 +123,7 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
                 "rx.device-status",
                 "The F-engine is receiving a good, clean digitiser stream",
                 default=DeviceStatus.DEGRADED,
-                initial_status=Sensor.Status.WARN,
+                initial_status=Sensor.Status.WARN
             )
         )
 


### PR DESCRIPTION
I find myself wondering whether the DeviceStatus enum is useful enough to actually be moved into aiokatcp instead.

Closes NGC-847.