### PR TITLE
Add .source and .revision sensors for tasks

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -287,7 +287,7 @@ class IngestTask(ProductPhysicalTask):
         if image_path is None:
             gpu = self.agent.gpus[self.allocation.gpus[0].index]
             gpu_name = normalise_gpu_name(gpu.name)
-            image_path = await resolver.image_resolver('katsdpingest_' + gpu_name)
+            image_path = (await resolver.image_resolver('katsdpingest_' + gpu_name)).path
             if gpu != defaults.INGEST_GPU_NAME:
                 logger.info('Develop mode: using %s for ingest', image_path)
         await super().resolve(resolver, graph, image_path)

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -281,16 +281,16 @@ class TelstateTask(ProductPhysicalTask):
 
 
 class IngestTask(ProductPhysicalTask):
-    async def resolve(self, resolver, graph, image_path=None):
+    async def resolve(self, resolver, graph, image=None):
         # In develop mode, the GPU can be anything, and we need to pick a
         # matching image.
-        if image_path is None:
+        if image is None:
             gpu = self.agent.gpus[self.allocation.gpus[0].index]
             gpu_name = normalise_gpu_name(gpu.name)
-            image_path = (await resolver.image_resolver('katsdpingest_' + gpu_name)).path
+            image = await resolver.image_resolver('katsdpingest_' + gpu_name)
             if gpu != defaults.INGEST_GPU_NAME:
-                logger.info('Develop mode: using %s for ingest', image_path)
-        await super().resolve(resolver, graph, image_path)
+                logger.info('Develop mode: using %s for ingest', image.path)
+        await super().resolve(resolver, graph, image)
 
 
 def _mb(value):

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -902,7 +902,7 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
         success = False
         task_id: Optional[str] = None
         try:
-            image = await image_resolver('katsdpcontroller')
+            image = (await image_resolver('katsdpcontroller')).path
             product.image = image
             request_id = await self._ensure_request(name)
             await self._ensure_deploy(name, image)
@@ -1202,7 +1202,28 @@ class DeviceServer(aiokatcp.DeviceServer):
         str
             Full image name
         """
-        return await self._image_lookup(repo, tag)
+        return (await self._image_lookup(repo, tag)).path
+
+    @time_request
+    async def request_image_lookup_v2(self, ctx, repo: str, tag: str) -> str:
+        """Look up information about an image.
+
+        This should only be used by product controllers.
+
+        Parameters
+        ----------
+        repo : str
+            Image repository name
+        tag : str
+            Docker image tag
+
+        Returns
+        -------
+        str
+            JSON serialisation of scheduler.Image class
+        """
+        image = await self._image_lookup(repo, tag)
+        return json.dumps(image.__dict__)
 
     @time_request
     async def request_set_config_override(self, ctx, name: str, override_dict_json: str) -> str:

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -220,12 +220,14 @@ class KatcpImageLookup(scheduler.ImageLookup):
     Tunnelling the lookup avoids the need for the product controller to
     have the right CA certificates and credentials for the Docker registry.
     """
+
     def __init__(self, conn: aiokatcp.Client) -> None:
         self._conn = conn
 
-    async def __call__(self, repo: str, tag: str) -> str:
-        reply, informs = await self._conn.request('image-lookup', repo, tag)
-        return reply[0].decode()
+    async def __call__(self, repo: str, tag: str) -> scheduler.Image:
+        reply, informs = await self._conn.request('image-lookup-v2', repo, tag)
+        data = json.loads(aiokatcp.decode(str, reply[0]))
+        return scheduler.Image(**data)
 
 
 class Resolver(scheduler.Resolver):

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -225,6 +225,7 @@ from abc import abstractmethod, ABC
 from contextlib import AsyncExitStack
 import random
 import typing
+from dataclasses import dataclass, field
 # Note: don't include Dict here, because it conflicts with addict.Dict.
 from typing import (
     AsyncContextManager, List, Tuple, Optional, Mapping, Union, ClassVar, Type)
@@ -955,10 +956,36 @@ def _strip_scheme(image: str) -> str:
     return re.sub(r'^https?://', '', image)
 
 
+@dataclass
+class Image:
+    """Information about a (fully resolved) container image."""
+
+    registry: str
+    repo: str
+    tag: Optional[str] = None
+    digest: Optional[str] = None
+    labels: typing.Dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.tag is None and self.digest is None:
+            raise TypeError("at least one of tag and digest must be specified")
+
+    @property
+    def path(self) -> str:
+        """Get image path that can be passed to Docker."""
+        if self.digest is not None:
+            result = f"{self.registry}/{self.repo}@{self.digest}"
+        else:
+            result = f"{self.registry}/{self.repo}:{self.tag}"
+        # Docker doesn't like leading http:// or https://
+        return re.sub(r'^https?://', '', result)
+
+
 class ImageLookup(ABC):
     """Abstract base class to get a full image name from a repo and tag."""
+
     @abstractmethod
-    async def __call__(self, repo: str, tag: str) -> str: pass
+    async def __call__(self, repo: str, tag: str) -> Image: pass
 
 
 class _RegistryImageLookup(ImageLookup):
@@ -983,9 +1010,9 @@ class _RegistryImageLookup(ImageLookup):
 class SimpleImageLookup(_RegistryImageLookup):
     """Resolver that simply concatenates registry, repo and tag."""
 
-    async def __call__(self, repo: str, tag: str) -> str:
+    async def __call__(self, repo: str, tag: str) -> Image:
         registry, repo = self._split_repo_name(repo)
-        return _strip_scheme(f'{registry}/{repo}:{tag}')
+        return Image(registry=registry, repo=repo, tag=tag)
 
 
 class HTTPImageLookup(_RegistryImageLookup):
@@ -996,16 +1023,22 @@ class HTTPImageLookup(_RegistryImageLookup):
         self._authconfig = docker.auth.load_config()
 
     @staticmethod
-    async def _get_digest(
+    async def _get_image(
             session: aiohttp.ClientSession,
-            url: str,
+            registry: str,
+            repo: str,
+            tag: str,
             ssl_context: Optional[ssl.SSLContext],
-            auth_header: Optional[str]) -> str:
-        """Make a single attempt to get the digest.
+            auth_header: Optional[str]) -> Image:
+        """Make a single attempt to get the image information.
 
         This fails if there is an authorization error, leaving the caller to
         obtain a token and try again.
         """
+        if '://' not in registry:
+            # If no scheme is specified, assume https
+            registry = 'https://' + registry
+        manifest_url = '{}/v2/{}/manifests/{}'.format(registry, repo, tag)
         headers = {aiohttp.hdrs.ACCEPT: 'application/vnd.docker.distribution.manifest.v2+json'}
         if auth_header:
             headers[aiohttp.hdrs.AUTHORIZATION] = auth_header
@@ -1013,13 +1046,30 @@ class HTTPImageLookup(_RegistryImageLookup):
             # Use a lowish timeout, so that we don't wedge the entire launch if
             # there is a connection problem.
             async with session.head(
-                    url, timeout=15, ssl_context=ssl_context, headers=headers) as response:
+                    manifest_url, timeout=15, ssl_context=ssl_context, headers=headers) as response:
                 response.raise_for_status()
-                return response.headers['Docker-Content-Digest']
+                digest = response.headers['Docker-Content-Digest']
         except (aiohttp.client.ClientError, asyncio.TimeoutError) as error:
-            raise ImageError('Failed to get digest from {}: {}'.format(url, error)) from error
+            raise ImageError(f'Failed to get digest from {manifest_url}: {error}') from error
         except KeyError:
-            raise ImageError('Docker-Content-Digest header not found for {}'.format(url))
+            raise ImageError(f'Docker-Content-Digest header not found for {manifest_url}')
+
+        image_url = '{}/v2/{}/blobs/{}'.format(registry, repo, digest)
+        headers[aiohttp.hdrs.ACCEPT] = 'application/vnd.docker.container.image.v1+json'
+        try:
+            async with session.get(
+                    image_url, timeout=15, ssl_context=ssl_context, headers=headers) as response:
+                response.raise_for_status()
+                # Docker registry returns Content-Type of
+                # application/octet-stream. Passing content_type=None
+                # here suppresses the content-type check.
+                response_json = await response.json(content_type=None)
+            labels = response_json.get('config', {}).get('Labels', {})
+            if not isinstance(labels, dict):
+                labels = {}
+        except (aiohttp.client.ClientError, asyncio.TimeoutError) as error:
+            raise ImageError('Failed to get labels from {}: {}'.format(image_url, error)) from error
+        return Image(registry=registry, repo=repo, tag=tag, digest=digest, labels=labels)
 
     async def _get_token(
             self,
@@ -1043,7 +1093,7 @@ class HTTPImageLookup(_RegistryImageLookup):
         except (aiohttp.ClientError, asyncio.TimeoutError, KeyError, ValueError) as error:
             raise ImageError(f'Failed to get authentication token from {realm}: {error}') from error
 
-    async def __call__(self, repo: str, tag: str) -> str:
+    async def __call__(self, repo: str, tag: str) -> Image:
         # TODO: see if it's possible to do some connection pooling
         # here. That probably requires the caller to initiate a
         # Session and close it when done.
@@ -1055,10 +1105,6 @@ class HTTPImageLookup(_RegistryImageLookup):
         else:
             auth = aiohttp.BasicAuth(authdata['username'], authdata['password'])
 
-        url = '{}/v2/{}/manifests/{}'.format(registry, repo, tag)
-        if not url.startswith('http'):
-            # If no scheme is specified, assume https
-            url = 'https://' + url
         cafile = '/etc/ssl/certs/ca-certificates.crt'
         ssl_context: Optional[ssl.SSLContext]
         if os.path.exists(cafile):
@@ -1068,7 +1114,8 @@ class HTTPImageLookup(_RegistryImageLookup):
         async with aiohttp.ClientSession() as session:
             try:
                 auth_header = auth.encode() if auth else None
-                digest = await self._get_digest(session, url, ssl_context, auth_header)
+                image = await self._get_image(
+                    session, registry, repo, tag, ssl_context, auth_header)
             except ImageError as error:
                 cause = error.__cause__
                 # If it's an authorization error, see if we can get a bearer token
@@ -1087,11 +1134,11 @@ class HTTPImageLookup(_RegistryImageLookup):
                     # trust it, and don't bother checking the realm for CSRF.
                     token = await self._get_token(session, realm, service, scope, auth)
                     auth_header = f'Bearer {token}'
-                    digest = await self._get_digest(session, url, ssl_context, auth_header)
+                    image = await self._get_image(
+                        session, registry, repo, tag, ssl_context, auth_header)
                 else:
                     raise
-
-        return _strip_scheme(f'{registry}/{repo}@{digest}')
+        return image
 
 
 class ImageResolver:
@@ -1117,7 +1164,7 @@ class ImageResolver:
         self._lookup = lookup
         self._tag_file = tag_file
         self._overrides: typing.Dict[str, str] = {}
-        self._cache: typing.Dict[str, str] = {}
+        self._cache: typing.Dict[str, Image] = {}
         if tag is not None:
             self._tag = tag
             self._tag_file = None
@@ -1145,7 +1192,7 @@ class ImageResolver:
     def override(self, name: str, path: str):
         self._overrides[name] = path
 
-    async def __call__(self, name: str) -> str:
+    async def __call__(self, name: str) -> Image:
         if name in self._overrides:
             name = self._overrides[name]
         if name in self._cache:
@@ -2325,7 +2372,7 @@ class PhysicalTask(PhysicalNode):
             taskinfo.command.value = command[0]
             taskinfo.command.arguments = command[1:]
         if image_path is None:
-            image_path = await resolver.image_resolver(self.logical_node.image)
+            image_path = (await resolver.image_resolver(self.logical_node.image)).path
         taskinfo.container.docker.image = image_path
         taskinfo.agent_id.value = self.agent_id
         taskinfo.resources = []

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -4004,7 +4004,7 @@ __all__ = [
     'GroupInsufficientGPUResourcesError',
     'GroupInsufficientInterfaceResourcesError',
     'InterfaceRequest', 'GPURequest',
-    'ImageLookup', 'SimpleImageLookup', 'HTTPImageLookup',
+    'Image', 'ImageLookup', 'SimpleImageLookup', 'HTTPImageLookup',
     'ImageResolver', 'TaskIDAllocator', 'Resolver',
     'Agent', 'AgentGPU', 'AgentInterface',
     'SchedulerBase', 'Scheduler', 'instantiate']

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -183,8 +183,8 @@ class ConfigMixin:
     def _graph_config(self, resolver, graph):
         return graph.nodes[self].get('config', lambda task_, resolver_: {})(self, resolver)
 
-    async def resolve(self, resolver, graph, image_path=None):
-        await super().resolve(resolver, graph, image_path)
+    async def resolve(self, resolver, graph, image=None):
+        await super().resolve(resolver, graph, image)
         if not self.logical_node.katsdpservices_config:
             if self._graph_config(resolver, graph):
                 logger.warning('Graph node %s has explicit config but katsdpservices_config=False',
@@ -490,8 +490,8 @@ class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
             self._disconnect()
             super().kill(driver, **kwargs)
 
-    async def resolve(self, resolver, graph, image_path=None):
-        await super().resolve(resolver, graph, image_path)
+    async def resolve(self, resolver, graph, image=None):
+        await super().resolve(resolver, graph, image)
 
         self.gui_urls = gui_urls = []
         for entry in self.logical_node.gui_urls:
@@ -658,8 +658,8 @@ class ProductPhysicalTask(ConfigMixin, ProductPhysicalTaskMixin, scheduler.Physi
             asyncio.get_event_loop().create_task(service.deregister())
         super()._disconnect()
 
-    async def resolve(self, resolver, graph, image_path=None):
-        await super().resolve(resolver, graph, image_path)
+    async def resolve(self, resolver, graph, image=None):
+        await super().resolve(resolver, graph, image)
 
         # Provide info about which container this is for logspout to collect.
         labels = {
@@ -756,8 +756,8 @@ class ProductFakePhysicalTask(ProductPhysicalTaskMixin, scheduler.FakePhysicalTa
         ProductPhysicalTaskMixin.__init__(
             self, logical_task, sdp_controller, subarray_product, capture_block_id)
 
-    async def resolve(self, resolver, graph, image_path=None):
-        await super().resolve(resolver, graph, image_path)
+    async def resolve(self, resolver, graph, image=None):
+        await super().resolve(resolver, graph, image)
         if self.logical_node.metadata_katcp_sensors:
             # Notify about the sensors added by the mixin constructor. This is
             # done here rather than in the constructor because

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -704,6 +704,23 @@ class ProductPhysicalTask(ConfigMixin, ProductPhysicalTaskMixin, scheduler.Physi
                 Sensor(str, self.name + '.version', "Image of executing container.", "",
                        default=self.taskinfo.container.docker.image,
                        initial_status=Sensor.Status.NOMINAL))
+            source_sensor = Sensor(
+                str, self.name + '.source', 'Version control source for the container', ''
+            )
+            revision_sensor = Sensor(
+                str, self.name + '.revision', 'Version control revision for the container', ''
+            )
+            # org.label-schema is the deprecated version
+            for key in ['org.opencontainers.image.source', 'org.label-schema.vcs-url']:
+                if key in self.image.labels:
+                    source_sensor.value = self.image.labels[key]
+                    break
+            for key in ['org.opencontainers.image.revision', 'org.label-schema.vcs-ref']:
+                if key in self.image.labels:
+                    revision_sensor.value = self.image.labels[key]
+                    break
+            self._add_sensor(source_sensor)
+            self._add_sensor(revision_sensor)
             self.sdp_controller.mass_inform('interface-changed', 'sensor-list')
 
     def set_status(self, status):

--- a/test/test_master_controller.py
+++ b/test/test_master_controller.py
@@ -66,6 +66,7 @@ EXPECTED_REQUEST_LIST = [
     # Internal commands
     'get-multicast-groups',
     'image-lookup',
+    'image-lookup-v2',
     # Standard katcp commands
     'client-list', 'halt', 'help', 'log-level', 'sensor-list',
     'sensor-sampling', 'sensor-value', 'watchdog', 'version-list'

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -402,8 +402,9 @@ class TestHTTPImageLookup:
 
     def _prepare_image(self, rmock, url, digest, **kwargs) -> None:
         url = URL(url)
-        # Response headers are modelled on some actual registry responses
-        rmock.head(
+        # Response headers are modelled on some actual registry responses, but
+        # payloads are stripped down to the essentials needed by the test.
+        rmock.get(
             url,
             content_type='application/vnd.docker.distribution.manifest.v2+json',
             headers={
@@ -414,9 +415,15 @@ class TestHTTPImageLookup:
                 'X-Content-Type-Options': 'nosniff',
                 'Date': 'Thu, 26 Jan 2017 11:31:22 GMT'
             },
+            payload={
+                'config': {
+                    'mediaType': 'application/vnd.docker.container.image.v1+json',
+                    'digest': 'sha256:cafebeef'
+                }
+            },
             **kwargs
         )
-        blob_url = url.parent.parent / f"blobs/{digest}"
+        blob_url = url.parent.parent / "blobs/sha256:cafebeef"
         # Payload is a very cut down version with just the bits needed
         rmock.get(
             blob_url,
@@ -442,7 +449,7 @@ class TestHTTPImageLookup:
 
     def _prepare_image_auth_required(self, rmock, url, realm, scope, **kwargs) -> None:
         # Response headers are loosely based on Harbor 1.8
-        rmock.head(
+        rmock.get(
             url,
             status=401,
             content_type='application/json; charset=utf-8',
@@ -454,6 +461,7 @@ class TestHTTPImageLookup:
                     f'scope="{scope}"'
                 )
             },
+            payload={},
             **kwargs)
 
     @staticmethod

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -1969,9 +1969,9 @@ class TestScheduler:
         This is a regression test for SR-1093.
         """
         class SlowResolve(scheduler.PhysicalTask):
-            async def resolve(self, resolver, graph, image_path=None):
+            async def resolve(self, resolver, graph, image=None):
                 await asyncio.sleep(30)
-                await super().resolve(resolver, graph, image_path=None)
+                await super().resolve(resolver, graph, image=None)
 
         for node in fix.logical_graph.nodes():
             if node.name == 'node0':
@@ -2112,7 +2112,7 @@ class TestScheduler:
             await launch
 
     async def test_launch_resolve_raises(self, fix: 'TestScheduler.Fixture') -> None:
-        async def resolve_raise(resolver, graph, image_path=None):
+        async def resolve_raise(resolver, graph, image=None):
             raise ValueError('Testing')
 
         fix.nodes[0].resolve = resolve_raise

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -424,7 +424,6 @@ class TestHTTPImageLookup:
             **kwargs
         )
         blob_url = url.parent.parent / "blobs/sha256:cafebeef"
-        # Payload is a very cut down version with just the bits needed
         rmock.get(
             blob_url,
             content_type='application/octet-stream',


### PR DESCRIPTION
The data for these are taken from Docker labels that Jenkins (both SDP and CBF) provides when it builds the images. To handle this, the ImageLookup framework needed to be reworked to return an object describing the image rather than just a string.

There is also some rework of the `.host` and `.version` sensors to make them behave more uniformly relative to the `.state` and `.mesos-state` sensors.

When in interface mode, these sensors will exist, but will have unknown values since there are no Docker images involved.

This does not yet provide these sensors for product controllers. That will need some rework in the master controller Zookeeper schema.