### PR TITLE
Add fake time synchronisation sensors for CBF servers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     addict!=2.0.*,!=2.4.0
     aiohttp~=3.5
     aiohttp-jinja2
-    aiokatcp>=1.2.0
+    aiokatcp>=1.6.0
     aiozk
     async_timeout
     dash>=1.18.*


### PR DESCRIPTION
Since this required bumping aiokatcp to 1.6.0 (for the ClockState enum), use its DeviceStatus enum instead of an in-house one.