### PR TITLE
Add .source and .revision sensors for product controllers

### DIFF
--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -775,23 +775,21 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
 
     @staticmethod
     def _serialise_product(product: SingularityProduct) -> dict:
-        data = {
+        # Strip out optional fields with None in them
+        image_data = dict(product.image.__dict__)
+        for key, value in list(image_data.items()):
+            if value is None:
+                del image_data[key]
+        return {
             'config': product.config,
             'run_id': product.run_id,
             'task_id': product.task_id,
+            'image': image_data,
             'host': product.hostname,
             'ports': product.ports,
             'multicast_groups': [str(group) for group in product.multicast_groups],
             'start_time': product.start_time
         }
-        if product.image is not None:
-            # Strip out optional fields with None in them
-            image_data = dict(product.image.__dict__)
-            for key, value in list(image_data.items()):
-                if value is None:
-                    del image_data[key]
-            data['image'] = image_data
-        return data
 
     async def _save_state(self) -> None:
         """Save the current state to Zookeeper"""

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -970,6 +970,31 @@ class Image:
         if self.tag is None and self.digest is None:
             raise TypeError("at least one of tag and digest must be specified")
 
+    @classmethod
+    def from_path(cls: Type['Image'], path: str) -> 'Image':
+        """Construct an Image from a path.
+
+        This is not particularly robust, and does not infer a registry from an
+        incomplete path. It is intended only for use where backwards
+        compatibility is required. In most cases, ImageLookup subclasses are a
+        better choice.
+        """
+        parts = path.split('/', 1)
+        if len(parts) == 1:
+            registry = 'unknown'
+            repo = path
+        else:
+            registry, repo = parts
+        tag = None
+        digest = None
+        if '@' in repo:
+            repo, digest = repo.split('@', 1)
+        elif ':' in repo:
+            repo, tag = repo.split(':', 1)
+        else:
+            tag = 'latest'
+        return cls(registry=registry, repo=repo, tag=tag, digest=digest)
+
     @property
     def path(self) -> str:
         """Get image path that can be passed to Docker."""

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -980,6 +980,22 @@ class Image:
         # Docker doesn't like leading http:// or https://
         return re.sub(r'^https?://', '', result)
 
+    @property
+    def source(self) -> Optional[str]:
+        """Version control source for the image, if available."""
+        for key in ['org.opencontainers.image.source', 'org.label-schema.vcs-url']:
+            if key in self.labels:
+                return self.labels[key]
+        return None
+
+    @property
+    def revision(self) -> Optional[str]:
+        """Version control revision for the image, if available."""
+        for key in ['org.opencontainers.image.revision', 'org.label-schema.vcs-ref']:
+            if key in self.labels:
+                return self.labels[key]
+        return None
+
 
 class ImageLookup(ABC):
     """Abstract base class to get a full image name from a repo and tag."""

--- a/src/katsdpcontroller/schemas/zk_state.json.j2
+++ b/src/katsdpcontroller/schemas/zk_state.json.j2
@@ -67,7 +67,7 @@
                             }
                         },
                         "required": ["registry", "repo"],
-                        "oneOf": [
+                        "anyOf": [
                             {"required": ["tag"]},
                             {"required": ["digest"]}
                         ]

--- a/src/katsdpcontroller/schemas/zk_state.json.j2
+++ b/src/katsdpcontroller/schemas/zk_state.json.j2
@@ -6,7 +6,7 @@
     "properties": {
         "version": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 4,
             "maximum": 5
         }
     }
@@ -37,38 +37,23 @@
                 "type": "object",
                 "additionalProperties": false,
                 "required": [
-{% if version >= 2 %}
                     "start_time",
-{% endif %}
-{% if version >= 3 %}
                     "ports",
-{% else %}
-                    "port",
-{% endif %}
-{% if version >= 4 %}
                     "image",
-{% endif %}
                     "run_id", "task_id", "host", "config", "multicast_groups"
                 ],
                 "properties": {
-{% if version >= 2 %}
                     "start_time": {"type": "number"},
-{% endif %}
-{% if version >= 3 %}
                     "ports": {
                         "type": "object",
                         "required": ["katcp"],
                         "additionalProperties": {"type": "integer", "minimum": 0, "maximum": 65535}
                     },
-{% else %}
-                    "port": {"type": "integer", "minimum": 0, "maximum": 65535},
-{% endif %}
                     "run_id": {"type": "string"},
                     "task_id": {"type": "string"},
 {% if version == 4 %}
                     "image": {"type": "string"},
-{% endif %}
-{% if version >= 5 %}
+{% else %}
                     "image": {
                         "type": "object",
                         "properties": {
@@ -81,7 +66,11 @@
                                 "additionalProperties": {"type": "string"}
                             }
                         },
-                        "required": ["registry", "repo"]
+                        "required": ["registry", "repo"],
+                        "oneOf": [
+                            {"required": ["tag"]},
+                            {"required": ["digest"]}
+                        ]
                     },
 {% endif %}
                     "host": {"type": "string"},

--- a/src/katsdpcontroller/schemas/zk_state.json.j2
+++ b/src/katsdpcontroller/schemas/zk_state.json.j2
@@ -7,7 +7,7 @@
         "version": {
             "type": "integer",
             "minimum": 1,
-            "maximum": 4
+            "maximum": 5
         }
     }
 }
@@ -65,8 +65,24 @@
 {% endif %}
                     "run_id": {"type": "string"},
                     "task_id": {"type": "string"},
-{% if version >= 4 %}
+{% if version == 4 %}
                     "image": {"type": "string"},
+{% endif %}
+{% if version >= 5 %}
+                    "image": {
+                        "type": "object",
+                        "properties": {
+                            "registry": {"type": "string"},
+                            "repo": {"type": "string"},
+                            "tag": {"type": "string"},
+                            "digest": {"type": "string"},
+                            "labels": {
+                                "type": "object",
+                                "additionalProperties": {"type": "string"}
+                            }
+                        },
+                        "required": ["registry", "repo"]
+                    },
 {% endif %}
                     "host": {"type": "string"},
                     "config": {"type": "object"},

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -719,15 +719,10 @@ class ProductPhysicalTask(ConfigMixin, ProductPhysicalTaskMixin, scheduler.Physi
 
         # Fill in values for version sensors
         self._version_sensor.value = self.taskinfo.container.docker.image
-        # org.label-schema is the deprecated version
-        for key in ['org.opencontainers.image.source', 'org.label-schema.vcs-url']:
-            if key in self.image.labels:
-                self._source_sensor.value = self.image.labels[key]
-                break
-        for key in ['org.opencontainers.image.revision', 'org.label-schema.vcs-ref']:
-            if key in self.image.labels:
-                self._revision_sensor.value = self.image.labels[key]
-                break
+        if self.image.source is not None:
+            self._source_sensor.value = self.image.source
+        if self.image.revision is not None:
+            self._revision_sensor.value = self.image.revision
 
     def set_status(self, status):
         # Ensure we only count once, even in corner cases like a lost task

--- a/test/test_master_controller.py
+++ b/test/test_master_controller.py
@@ -356,8 +356,9 @@ class TestSingularityProductManager:
         assert product.ports['aiomonitor'] == 12347
         assert product.ports['aioconsole'] == 12348
         assert product.ports['dashboard'] == 12349
-        assert product.image == 'registry.invalid:5000/katsdpcontroller:a_tag'
-        assert fix.server.sensors['foo.version'].value == product.image
+        assert product.image is not None
+        assert product.image.path == 'registry.invalid:5000/katsdpcontroller:a_tag'
+        assert fix.server.sensors['foo.version'].value == product.image.path
         client_mock.assert_called_with('192.0.2.0', 12345)
 
         await fix.manager.product_active(product)

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -359,6 +359,18 @@ class TestImage:
         with pytest.raises(TypeError):
             scheduler.Image(registry="registry.invalid", repo="foo")
 
+    @pytest.mark.parametrize(
+        'path,expected',
+        [
+            ('unqualified', 'unknown/unqualified:latest'),
+            ('registry.invalid/repo:tag', 'registry.invalid/repo:tag'),
+            ('registry.invalid/repo@sha256:deadbeef', 'registry.invalid/repo@sha256:deadbeef'),
+            ('registry.invalid/nested/repo/name', 'registry.invalid/nested/repo/name:latest')
+        ]
+    )
+    def test_from_path(self, path: str, expected: str) -> None:
+        assert scheduler.Image.from_path(path).path == expected
+
 
 class TestSimpleImageLookup:
     async def test(self) -> None:


### PR DESCRIPTION
To support this, the Zookeeper schema for persisting product controller information over MC restarts is updated to version 5, holding a JSON representation of the Image class. Support for versions 1-3 is removed to simplify the code (they're ancient and not needed since there are no running product controllers using them). If a v4 product controller is loaded when the MC starts up, it uses a somewhat hacky approach to synthesize an Image object (Image.from_path method).

Closes NGC-841.

- [x] Re-test the final modifications in the lab once the link to site is working again