### PR TITLE
Use fullstops for hierarchical separation in sensor names

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2019, National Research Foundation (SARAO)
+Copyright (c) 2013-2023, National Research Foundation (SARAO)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/src/katsdpcontroller/fake_servers.py
+++ b/src/katsdpcontroller/fake_servers.py
@@ -146,7 +146,7 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
             self.sensors.add(
                 Sensor(
                     int,
-                    f"input{pol}.rx-timestamp",
+                    f"input{pol}.rx.timestamp",
                     "The timestamp (in samples) of the last chunk of data received "
                     "from the digitiser",
                     default=-1,
@@ -156,7 +156,7 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
             self.sensors.add(
                 Sensor(
                     Timestamp,
-                    f"input{pol}.rx-unixtime",
+                    f"input{pol}.rx.unixtime",
                     "The timestamp (in UNIX time) of the last chunk of data received "
                     "from the digitiser",
                     default=Timestamp(-1.0),
@@ -166,7 +166,7 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
             self.sensors.add(
                 Sensor(
                     Timestamp,
-                    f"input{pol}.rx-missing-unixtime",
+                    f"input{pol}.rx.missing-unixtime",
                     "The timestamp (in UNIX time) when missing data was last detected",
                     default=Timestamp(-1.0),
                     initial_status=Sensor.Status.NOMINAL,
@@ -224,7 +224,7 @@ class FakeXbgpuDeviceServer(FakeDeviceServer):
         self.sensors.add(
             Sensor(
                 bool,
-                "synchronised",
+                "rx.synchronised",
                 "For the latest accumulation, was data present from all F-Engines.",
                 default=True,
                 initial_status=Sensor.Status.NOMINAL,
@@ -251,7 +251,7 @@ class FakeXbgpuDeviceServer(FakeDeviceServer):
         self.sensors.add(
             Sensor(
                 int,
-                "input-rx-timestamp",
+                "rx.timestamp",
                 "The timestamp (in samples) of the last chunk of data received from an F-engine",
                 default=-1,
                 initial_status=Sensor.Status.ERROR,
@@ -260,7 +260,7 @@ class FakeXbgpuDeviceServer(FakeDeviceServer):
         self.sensors.add(
             Sensor(
                 Timestamp,
-                "input-rx-unixtime",
+                "rx.unixtime",
                 "The timestamp (in UNIX time) of the last chunk of data received "
                 "from an F-engine",
                 default=Timestamp(-1.0),
@@ -270,7 +270,7 @@ class FakeXbgpuDeviceServer(FakeDeviceServer):
         self.sensors.add(
             Sensor(
                 Timestamp,
-                "input-rx-missing-unixtime",
+                "rx.missing-unixtime",
                 "The timestamp (in UNIX time) when missing data was last detected",
                 default=Timestamp(-1.0),
                 initial_status=Sensor.Status.NOMINAL,

--- a/src/katsdpcontroller/fake_servers.py
+++ b/src/katsdpcontroller/fake_servers.py
@@ -96,7 +96,7 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
             self.sensors.add(
                 Sensor(
                     str,
-                    f"input{pol}-eq",
+                    f"input{pol}.eq",
                     "For this input, the complex, unitless, per-channel digital scaling factors "
                     "implemented prior to requantisation",
                     default="[1.0+0.0j]",
@@ -106,7 +106,7 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
             self.sensors.add(
                 Sensor(
                     str,
-                    f"input{pol}-delay",
+                    f"input{pol}.delay",
                     "The delay settings for this input: (loadmcnt <ADC sample "
                     "count when model was loaded>, delay <in seconds>, "
                     "delay-rate <unit-less or, seconds-per-second>, "
@@ -118,7 +118,7 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
             self.sensors.add(
                 Sensor(
                     int,
-                    f"input{pol}-dig-clip-cnt",
+                    f"input{pol}.dig-clip-cnt",
                     "Number of digitiser samples that are saturated",
                     default=0,
                     initial_status=Sensor.Status.NOMINAL,
@@ -127,7 +127,7 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
             self.sensors.add(
                 Sensor(
                     float,
-                    f"input{pol}-dig-pwr-dbfs",
+                    f"input{pol}.dig-pwr-dbfs",
                     "Digitiser ADC average power",
                     units="dBFS",
                     default=-25.0,
@@ -137,7 +137,7 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
             self.sensors.add(
                 Sensor(
                     int,
-                    f"input{pol}-feng-clip-cnt",
+                    f"input{pol}.feng-clip-cnt",
                     "Number of output samples that are saturated",
                     default=0,
                     initial_status=Sensor.Status.NOMINAL,
@@ -146,7 +146,7 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
             self.sensors.add(
                 Sensor(
                     int,
-                    f"input{pol}-rx-timestamp",
+                    f"input{pol}.rx-timestamp",
                     "The timestamp (in samples) of the last chunk of data received "
                     "from the digitiser",
                     default=-1,
@@ -156,7 +156,7 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
             self.sensors.add(
                 Sensor(
                     Timestamp,
-                    f"input{pol}-rx-unixtime",
+                    f"input{pol}.rx-unixtime",
                     "The timestamp (in UNIX time) of the last chunk of data received "
                     "from the digitiser",
                     default=Timestamp(-1.0),
@@ -166,7 +166,7 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
             self.sensors.add(
                 Sensor(
                     Timestamp,
-                    f"input{pol}-rx-missing-unixtime",
+                    f"input{pol}.rx-missing-unixtime",
                     "The timestamp (in UNIX time) when missing data was last detected",
                     default=Timestamp(-1.0),
                     initial_status=Sensor.Status.NOMINAL,
@@ -191,7 +191,7 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
             delay, delay_rate = (float(x) for x in delay_args.split(","))
             phase, phase_rate = (float(x) for x in phase_args.split(","))
             value = f"({load_time}, {delay}, {delay_rate}, {phase}, {phase_rate})"
-            self.sensors[f"input{i}-delay"].value = value
+            self.sensors[f"input{i}.delay"].value = value
 
     async def request_gain(self, ctx, input: int, *values: str) -> Tuple[str, ...]:
         """Set or query the eq gains."""
@@ -202,7 +202,7 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
                 # Same value for all channels
                 cvalues = cvalues[:1]
             self._gains[input] = cvalues
-            self.sensors[f"input{input}-eq"].value = (
+            self.sensors[f"input{input}.eq"].value = (
                 "[" + ", ".join(_format_complex(gain) for gain in cvalues) + "]"
             )
         return tuple(_format_complex(v) for v in self._gains[input])

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -833,7 +833,7 @@ def _make_fgpu(
                 "rx-unixtime",
                 "rx-missing-unixtime",
             ]:
-                fgpu.sensor_renames[f"input{j}-{name}"] = f"{stream.name}.{label}.{name}"
+                fgpu.sensor_renames[f"input{j}.{name}"] = f"{stream.name}.{label}.{name}"
         # Prepare expected data rates etc
         fgpu.static_gauges["fgpu_expected_input_heaps_per_second"] = sum(
             src.adc_sample_rate / src.samples_per_heap for src in srcs

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -829,9 +829,9 @@ def _make_fgpu(
                 "dig-clip-cnt",
                 "dig-pwr-dbfs",
                 "feng-clip-cnt",
-                "rx-timestamp",
-                "rx-unixtime",
-                "rx-missing-unixtime",
+                "rx.timestamp",
+                "rx.unixtime",
+                "rx.missing-unixtime",
             ]:
                 fgpu.sensor_renames[f"input{j}.{name}"] = f"{stream.name}.{label}.{name}"
         # Prepare expected data rates etc
@@ -986,7 +986,7 @@ def _make_xbgpu(
             sensors,
             f"{stream.name}.xengs-synchronised",
             "For the latest accumulation, was data present from all F-Engines for all X-Engines",
-            name_regex=re.compile(rf"xb\.{re.escape(stream.name)}\.[0-9]+\.synchronised"),
+            name_regex=re.compile(rf"xb\.{re.escape(stream.name)}\.[0-9]+\.rx.synchronised"),
             n_children=stream.n_substreams,
         ),
         data_suspect_sensor,
@@ -1170,11 +1170,11 @@ def _make_xbgpu(
 
         # Rename sensors that are relevant to the stream rather than the process
         for name in [
-            "rx-timestamp",
-            "rx-unixtime",
-            "rx-missing-unixtime",
+            "rx.timestamp",
+            "rx.unixtime",
+            "rx.missing-unixtime",
         ]:
-            xbgpu.sensor_renames[f"input.{name}"] = f"{stream.name}.{i}.{name}"
+            xbgpu.sensor_renames[name] = f"{stream.name}.{i}.{name}"
 
         xbgpu.static_gauges["xbgpu_expected_input_heaps_per_second"] = (
             acv.adc_sample_rate

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -833,7 +833,7 @@ def _make_fgpu(
                 "rx-unixtime",
                 "rx-missing-unixtime",
             ]:
-                fgpu.sensor_renames[f"input{j}-{name}"] = f"{stream.name}-{label}-{name}"
+                fgpu.sensor_renames[f"input{j}-{name}"] = f"{stream.name}.{label}.{name}"
         # Prepare expected data rates etc
         fgpu.static_gauges["fgpu_expected_input_heaps_per_second"] = sum(
             src.adc_sample_rate / src.samples_per_heap for src in srcs

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1168,6 +1168,14 @@ def _make_xbgpu(
         # Link it to the group, so that downstream tasks need only depend on the group.
         g.add_edge(xbgpu_group, xbgpu, depends_ready=True, depends_init=True)
 
+        # Rename sensors that are relevant to the stream rather than the process
+        for name in [
+            "rx-timestamp",
+            "rx-unixtime",
+            "rx-missing-unixtime",
+        ]:
+            xbgpu.sensor_renames[f"input.{name}"] = f"{stream.name}.{i}.{name}"
+
         xbgpu.static_gauges["xbgpu_expected_input_heaps_per_second"] = (
             acv.adc_sample_rate
             / (acv.n_samples_between_spectra * acv.n_spectra_per_heap)

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -830,7 +830,7 @@ def _make_fgpu(
                 "rx-unixtime",
                 "rx-missing-unixtime",
             ]:
-                fgpu.sensor_renames[f"input{j}-{name}"] = f"{stream.name}.{label}.{name}"
+                fgpu.sensor_renames[f"input{j}.{name}"] = f"{stream.name}.{label}.{name}"
         # Prepare expected data rate
         fgpu.static_gauges["fgpu_expected_input_heaps_per_second"] = sum(
             src.adc_sample_rate / src.samples_per_heap for src in srcs

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -153,7 +153,7 @@ class PhysicalMulticast(scheduler.PhysicalExternal):
         stream_name = logical_task.stream_name
         self._endpoint_sensor = Sensor(
             str,
-            f"{stream_name}-destination",
+            f"{stream_name}.destination",
             f"The IP address, range and port to which data for stream {stream_name} is sent",
         )
         subarray_product.add_sensor(self._endpoint_sensor)
@@ -547,7 +547,7 @@ def _make_fgpu(
     # TODO: this list is not complete, and will need to be updated as the ICD evolves.
     data_suspect_sensor = Sensor(
         str,
-        f"{stream.name}-input-data-suspect",
+        f"{stream.name}.input-data-suspect",
         "A bitmask of flags indicating for each input whether the data for "
         "that input should be considered to be garbage. Input order matches "
         "input labels.",
@@ -572,7 +572,7 @@ def _make_fgpu(
         ),
         Sensor(
             float,
-            f"{stream.name}-adc-sample-rate",
+            f"{stream.name}.adc-sample-rate",
             "Sample rate of the ADC",
             "Hz",
             default=stream.adc_sample_rate,
@@ -580,7 +580,7 @@ def _make_fgpu(
         ),
         Sensor(
             float,
-            f"{stream.name}-bandwidth",
+            f"{stream.name}.bandwidth",
             "The analogue bandwidth of the digitised band",
             "Hz",
             default=stream.bandwidth,
@@ -589,7 +589,7 @@ def _make_fgpu(
         # The timestamps are simply ADC sample counts
         Sensor(
             float,
-            f"{stream.name}-scale-factor-timestamp",
+            f"{stream.name}.scale-factor-timestamp",
             "Factor by which to divide instrument timestamps to convert to unix seconds",
             "Hz",
             default=stream.adc_sample_rate,
@@ -597,7 +597,7 @@ def _make_fgpu(
         ),
         Sensor(
             float,
-            f"{stream.name}-sync-time",
+            f"{stream.name}.sync-time",
             "The time at which the digitisers were synchronised. Seconds since the Unix Epoch.",
             "s",
             default=float(sync_time),
@@ -605,28 +605,28 @@ def _make_fgpu(
         ),
         Sensor(
             int,
-            f"{stream.name}-n-ants",
+            f"{stream.name}.n-ants",
             "The number of antennas in the instrument",
             default=len(stream.antennas),
             initial_status=Sensor.Status.NOMINAL,
         ),
         Sensor(
             int,
-            f"{stream.name}-n-inputs",
+            f"{stream.name}.n-inputs",
             "The number of single polarisation inputs to the instrument",
             default=len(stream.src_streams),
             initial_status=Sensor.Status.NOMINAL,
         ),
         Sensor(
             int,
-            f"{stream.name}-n-fengs",
+            f"{stream.name}.n-fengs",
             "The number of F-engines in the instrument",
             default=n_engines,
             initial_status=Sensor.Status.NOMINAL,
         ),
         Sensor(
             int,
-            f"{stream.name}-feng-out-bits-per-sample",
+            f"{stream.name}.feng-out-bits-per-sample",
             "F-engine output bits per sample. Per number, not complex pair. "
             "Real and imaginary parts are both this wide",
             default=stream.bits_per_sample,
@@ -634,35 +634,35 @@ def _make_fgpu(
         ),
         Sensor(
             int,
-            f"{stream.name}-n-chans",
+            f"{stream.name}.n-chans",
             "Number of channels in the output spectrum",
             default=stream.n_chans,
             initial_status=Sensor.Status.NOMINAL,
         ),
         Sensor(
             int,
-            f"{stream.name}-n-chans-per-substream",
+            f"{stream.name}.n-chans-per-substream",
             "Number of channels in each substream for this f-engine stream",
             default=stream.n_chans_per_substream,
             initial_status=Sensor.Status.NOMINAL,
         ),
         Sensor(
             int,
-            f"{stream.name}-n-samples-between-spectra",
+            f"{stream.name}.n-samples-between-spectra",
             "Number of samples between spectra",
             default=stream.n_samples_between_spectra,
             initial_status=Sensor.Status.NOMINAL,
         ),
         Sensor(
             int,
-            f"{stream.name}-pfb-group-delay",
+            f"{stream.name}.pfb-group-delay",
             "PFB group delay, specified in number of samples",
             default=-stream.n_chans * stream.pfb_taps,
             initial_status=Sensor.Status.NOMINAL,
         ),
         Sensor(
             int,
-            f"{stream.name}-spectra-per-heap",
+            f"{stream.name}.spectra-per-heap",
             "Number of spectrum chunks per heap",
             default=stream.n_spectra_per_heap,
             initial_status=Sensor.Status.NOMINAL,
@@ -671,7 +671,7 @@ def _make_fgpu(
         # stream.centre_frequency.
         Sensor(
             float,
-            f"{stream.name}-center-freq",
+            f"{stream.name}.center-freq",
             "The centre frequency of the digitised band",
             default=stream.bandwidth / 2,
             initial_status=Sensor.Status.NOMINAL,
@@ -830,7 +830,7 @@ def _make_fgpu(
                 "rx-unixtime",
                 "rx-missing-unixtime",
             ]:
-                fgpu.sensor_renames[f"input{j}-{name}"] = f"{stream.name}-{label}-{name}"
+                fgpu.sensor_renames[f"input{j}-{name}"] = f"{stream.name}.{label}.{name}"
         # Prepare expected data rate
         fgpu.static_gauges["fgpu_expected_input_heaps_per_second"] = sum(
             src.adc_sample_rate / src.samples_per_heap for src in srcs
@@ -880,7 +880,7 @@ def _make_xbgpu(
     n_accs = round(stream.int_time * acv.adc_sample_rate / acv.n_samples_between_spectra)
     data_suspect_sensor = Sensor(
         str,
-        f"{stream.name}-channel-data-suspect",
+        f"{stream.name}.channel-data-suspect",
         "A bitmask of flags indicating whether each channel should be considered to be garbage.",
         default="0" * stream.n_chans,
         initial_status=Sensor.Status.NOMINAL,
@@ -889,7 +889,7 @@ def _make_xbgpu(
     stream_sensors = [
         Sensor(
             float,
-            f"{stream.name}-sync-time",
+            f"{stream.name}.sync-time",
             "The time at which the digitisers were synchronised. Seconds since the Unix Epoch.",
             "s",
             default=float(sync_time),
@@ -897,7 +897,7 @@ def _make_xbgpu(
         ),
         Sensor(
             float,
-            f"{stream.name}-bandwidth",
+            f"{stream.name}.bandwidth",
             "The analogue bandwidth of the digitised band",
             "Hz",
             default=acv.bandwidth,
@@ -905,21 +905,21 @@ def _make_xbgpu(
         ),
         Sensor(
             int,
-            f"{stream.name}-n-xengs",
+            f"{stream.name}.n-xengs",
             "The number of X-engines in the instrument",
             default=n_engines,
             initial_status=Sensor.Status.NOMINAL,
         ),
         Sensor(
             int,
-            f"{stream.name}-n-accs",
+            f"{stream.name}.n-accs",
             "The number of spectra that are accumulated per X-engine output",
             default=n_accs,
             initial_status=Sensor.Status.NOMINAL,
         ),
         Sensor(
             float,
-            f"{stream.name}-int-time",
+            f"{stream.name}.int-time",
             "The time, in seconds, for which the X-engines accumulate.",
             "s",
             default=stream.int_time,
@@ -927,7 +927,7 @@ def _make_xbgpu(
         ),
         Sensor(
             int,
-            f"{stream.name}-xeng-out-bits-per-sample",
+            f"{stream.name}.xeng-out-bits-per-sample",
             "X-engine output bits per sample. Per number, not complex pair- "
             "Real and imaginary parts are both this wide",
             default=stream.bits_per_sample,
@@ -935,7 +935,7 @@ def _make_xbgpu(
         ),
         Sensor(
             str,
-            f"{stream.name}-bls-ordering",
+            f"{stream.name}.bls-ordering",
             "A string showing the output ordering of baseline data "
             "produced by the X-engines in this instrument, as a list "
             "of correlation pairs given by input label.",
@@ -944,28 +944,28 @@ def _make_xbgpu(
         ),
         Sensor(
             int,
-            f"{stream.name}-n-bls",
+            f"{stream.name}.n-bls",
             "The number of baselines produced by this correlator instrument.",
             default=stream.n_baselines,
             initial_status=Sensor.Status.NOMINAL,
         ),
         Sensor(
             int,
-            f"{stream.name}-n-chans",
+            f"{stream.name}.n-chans",
             "The number of frequency channels in an integration",
             default=stream.n_chans,
             initial_status=Sensor.Status.NOMINAL,
         ),
         Sensor(
             int,
-            f"{stream.name}-n-chans-per-substream",
+            f"{stream.name}.n-chans-per-substream",
             "Number of channels in each substream for this x-engine stream",
             default=stream.n_chans_per_substream,
             initial_status=Sensor.Status.NOMINAL,
         ),
         Sensor(
             float,
-            f"{stream.name}-ddc-mix-freq",
+            f"{stream.name}.ddc-mix-freq",
             "F-engine DDC mixer frequency, where used. 0 where n/a",
             units="Hz",
             default=0.0,
@@ -973,14 +973,14 @@ def _make_xbgpu(
         ),
         SumSensor(
             sensors,
-            f"{stream.name}-xeng-clip-cnt",
+            f"{stream.name}.xeng-clip-cnt",
             "Number of visibilities that saturated",
             name_regex=re.compile(rf"xb\.{re.escape(stream.name)}\.[0-9]+\.xeng-clip-cnt"),
             n_children=stream.n_substreams,
         ),
         SyncSensor(
             sensors,
-            f"{stream.name}-xengs-synchronised",
+            f"{stream.name}.xengs-synchronised",
             "For the latest accumulation, was data present from all F-Engines for all X-Engines",
             name_regex=re.compile(rf"xb\.{re.escape(stream.name)}\.[0-9]+\.synchronised"),
             n_children=stream.n_substreams,

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -583,7 +583,7 @@ class TestControllerInterface(BaseTestController):
         )
         assert reply == [b"1.0+2.0j"]
         await assert_sensor_value(
-            client, "gpucbf_antenna_channelised_voltage-gpucbf_m901h-eq", "[1.0+2.0j]"
+            client, "gpucbf_antenna_channelised_voltage.gpucbf_m901h.eq", "[1.0+2.0j]"
         )
         await client.request("product-deconfigure")
 
@@ -597,7 +597,7 @@ class TestControllerInterface(BaseTestController):
         assert reply == gains
         await assert_sensor_value(
             client,
-            "gpucbf_antenna_channelised_voltage-gpucbf_m901h-eq",
+            "gpucbf_antenna_channelised_voltage.gpucbf_m901h.eq",
             "[" + ", ".join(g.decode() for g in gains) + "]",
         )
         await client.request("product-deconfigure")
@@ -608,7 +608,7 @@ class TestControllerInterface(BaseTestController):
         await client.request("gain-all", "gpucbf_antenna_channelised_voltage", "1.0+2.0j")
         for name in ["gpucbf_m900v", "gpucbf_m900h", "gpucbf_m901v", "gpucbf_m901h"]:
             await assert_sensor_value(
-                client, f"gpucbf_antenna_channelised_voltage-{name}-eq", "[1.0+2.0j]"
+                client, f"gpucbf_antenna_channelised_voltage.{name}.eq", "[1.0+2.0j]"
             )
         await client.request("product-deconfigure")
 
@@ -620,7 +620,7 @@ class TestControllerInterface(BaseTestController):
         for name in ["gpucbf_m900v", "gpucbf_m900h", "gpucbf_m901v", "gpucbf_m901h"]:
             await assert_sensor_value(
                 client,
-                f"gpucbf_antenna_channelised_voltage-{name}-eq",
+                f"gpucbf_antenna_channelised_voltage.{name}.eq",
                 "[" + ", ".join(g.decode() for g in gains) + "]",
             )
         await client.request("product-deconfigure")
@@ -631,7 +631,7 @@ class TestControllerInterface(BaseTestController):
         await client.request("gain-all", "gpucbf_antenna_channelised_voltage", "default")
         for name in ["gpucbf_m900v", "gpucbf_m900h", "gpucbf_m901v", "gpucbf_m901h"]:
             await assert_sensor_value(
-                client, f"gpucbf_antenna_channelised_voltage-{name}-eq", "[1.0+0.0j]"
+                client, f"gpucbf_antenna_channelised_voltage.{name}.eq", "[1.0+0.0j]"
             )
         await client.request("product-deconfigure")
 
@@ -640,7 +640,7 @@ class TestControllerInterface(BaseTestController):
         await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
         await assert_sensor_value(
             client,
-            "gpucbf_antenna_channelised_voltage-sync-time",
+            "gpucbf_antenna_channelised_voltage.sync-time",
             123456789.0,  # Just to detect any change in sync time logic in generator.py
         )
         await client.request(
@@ -654,22 +654,22 @@ class TestControllerInterface(BaseTestController):
         )
         await assert_sensor_value(
             client,
-            "gpucbf_antenna_channelised_voltage-gpucbf_m900v-delay",
+            "gpucbf_antenna_channelised_voltage.gpucbf_m900v.delay",
             "(4280000000, 0.5, 0.0, 0.0, 0.0)",
         )
         await assert_sensor_value(
             client,
-            "gpucbf_antenna_channelised_voltage-gpucbf_m900h-delay",
+            "gpucbf_antenna_channelised_voltage.gpucbf_m900h.delay",
             "(4280000000, 0.0, 0.125, 0.0, 0.0)",
         )
         await assert_sensor_value(
             client,
-            "gpucbf_antenna_channelised_voltage-gpucbf_m901v-delay",
+            "gpucbf_antenna_channelised_voltage.gpucbf_m901v.delay",
             "(4280000000, 0.0, 0.0, 0.25, 0.0)",
         )
         await assert_sensor_value(
             client,
-            "gpucbf_antenna_channelised_voltage-gpucbf_m901h-delay",
+            "gpucbf_antenna_channelised_voltage.gpucbf_m901h.delay",
             "(4280000000, 0.0, 0.0, 0.0, 1.0)",
         )
         await client.request("product-deconfigure")
@@ -677,14 +677,14 @@ class TestControllerInterface(BaseTestController):
     async def test_input_data_suspect(self, client: aiokatcp.Client, server: DeviceServer) -> None:
         await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
         await assert_sensor_value(
-            client, "gpucbf_antenna_channelised_voltage-input-data-suspect", b"0000"
+            client, "gpucbf_antenna_channelised_voltage.input-data-suspect", b"0000"
         )
         # Kill off one of the tasks
         assert server.product is not None  # Keeps mypy happy
         server.product._nodes["f.gpucbf_antenna_channelised_voltage.1"].kill(None)
         await assert_sensor_value(
             client,
-            "gpucbf_antenna_channelised_voltage-input-data-suspect",
+            "gpucbf_antenna_channelised_voltage.input-data-suspect",
             b"0011",
             status=Sensor.Status.WARN,
         )
@@ -692,7 +692,7 @@ class TestControllerInterface(BaseTestController):
         server.product._nodes["f.gpucbf_antenna_channelised_voltage.0"].kill(None)
         await assert_sensor_value(
             client,
-            "gpucbf_antenna_channelised_voltage-input-data-suspect",
+            "gpucbf_antenna_channelised_voltage.input-data-suspect",
             b"1111",
             status=Sensor.Status.ERROR,
         )
@@ -702,14 +702,14 @@ class TestControllerInterface(BaseTestController):
     ) -> None:
         await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
         await assert_sensor_value(
-            client, "gpucbf_baseline_correlation_products-channel-data-suspect", b"0" * 4096
+            client, "gpucbf_baseline_correlation_products.channel-data-suspect", b"0" * 4096
         )
         # Kill off one of the tasks
         assert server.product is not None
         server.product._nodes["xb.gpucbf_baseline_correlation_products.1"].kill(None)
         await assert_sensor_value(
             client,
-            "gpucbf_baseline_correlation_products-channel-data-suspect",
+            "gpucbf_baseline_correlation_products.channel-data-suspect",
             b"0" * 1024 + b"1" * 1024 + b"0" * 2048,
             status=Sensor.Status.WARN,
         )
@@ -1189,30 +1189,30 @@ class TestController(BaseTestController):
         n_xengs = 4  # Update if sizing logic changes
         # antenna-channelised-voltage sensors
         await assert_sensor_value(
-            client, "gpucbf_antenna_channelised_voltage-adc-sample-rate", 1712e6
+            client, "gpucbf_antenna_channelised_voltage.adc-sample-rate", 1712e6
         )
-        await assert_sensor_value(client, "gpucbf_antenna_channelised_voltage-bandwidth", 856e6)
+        await assert_sensor_value(client, "gpucbf_antenna_channelised_voltage.bandwidth", 856e6)
         await assert_sensor_value(
-            client, "gpucbf_antenna_channelised_voltage-scale-factor-timestamp", 1712e6
+            client, "gpucbf_antenna_channelised_voltage.scale-factor-timestamp", 1712e6
         )
-        await assert_sensor_value(client, "gpucbf_antenna_channelised_voltage-n-ants", 2)
-        await assert_sensor_value(client, "gpucbf_antenna_channelised_voltage-n-inputs", 4)
-        await assert_sensor_value(client, "gpucbf_antenna_channelised_voltage-n-fengs", 2)
+        await assert_sensor_value(client, "gpucbf_antenna_channelised_voltage.n-ants", 2)
+        await assert_sensor_value(client, "gpucbf_antenna_channelised_voltage.n-inputs", 4)
+        await assert_sensor_value(client, "gpucbf_antenna_channelised_voltage.n-fengs", 2)
         await assert_sensor_value(
-            client, "gpucbf_antenna_channelised_voltage-feng-out-bits-per-sample", 8
+            client, "gpucbf_antenna_channelised_voltage.feng-out-bits-per-sample", 8
         )
-        await assert_sensor_value(client, "gpucbf_antenna_channelised_voltage-n-chans", 4096)
+        await assert_sensor_value(client, "gpucbf_antenna_channelised_voltage.n-chans", 4096)
         await assert_sensor_value(
-            client, "gpucbf_antenna_channelised_voltage-n-chans-per-substream", 4096 // n_xengs
+            client, "gpucbf_antenna_channelised_voltage.n-chans-per-substream", 4096 // n_xengs
         )
 
         # baseline-correlation-products sensors
-        await assert_sensor_value(client, "gpucbf_baseline_correlation_products-n-accs", 408 * 256)
+        await assert_sensor_value(client, "gpucbf_baseline_correlation_products.n-accs", 408 * 256)
         await assert_sensor_value(
-            client, "gpucbf_baseline_correlation_products-int-time", 408 * 256 * 4096 / 856e6
+            client, "gpucbf_baseline_correlation_products.int-time", 408 * 256 * 4096 / 856e6
         )
         await assert_sensor_value(
-            client, "gpucbf_baseline_correlation_products-xeng-out-bits-per-sample", 32
+            client, "gpucbf_baseline_correlation_products.xeng-out-bits-per-sample", 32
         )
         expected_bls_ordering = (
             "[('gpucbf_m900v', 'gpucbf_m900v'), "
@@ -1229,18 +1229,18 @@ class TestController(BaseTestController):
             "('gpucbf_m901h', 'gpucbf_m901h')]"
         )
         await assert_sensor_value(
-            client, "gpucbf_baseline_correlation_products-bls-ordering", expected_bls_ordering
+            client, "gpucbf_baseline_correlation_products.bls-ordering", expected_bls_ordering
         )
-        await assert_sensor_value(client, "gpucbf_baseline_correlation_products-n-bls", 12)
-        await assert_sensor_value(client, "gpucbf_baseline_correlation_products-n-chans", 4096)
+        await assert_sensor_value(client, "gpucbf_baseline_correlation_products.n-bls", 12)
+        await assert_sensor_value(client, "gpucbf_baseline_correlation_products.n-chans", 4096)
         await assert_sensor_value(
-            client, "gpucbf_baseline_correlation_products-n-chans-per-substream", 4096 // n_xengs
+            client, "gpucbf_baseline_correlation_products.n-chans-per-substream", 4096 // n_xengs
         )
         # Test a multicast stream destination sensor
         stream_name = "gpucbf_baseline_correlation_products"
         node = product._nodes[f"multicast.{stream_name}"]
         await assert_sensor_value(
-            client, f"{stream_name}-destination", str(Endpoint(node.host, node.ports["spead"]))
+            client, f"{stream_name}.destination", str(Endpoint(node.host, node.ports["spead"]))
         )
 
     async def test_product_configure_telstate_fail(

--- a/test/utils.py
+++ b/test/utils.py
@@ -295,8 +295,8 @@ EXPECTED_INTERFACE_SENSOR_LIST: List[Tuple[bytes, ...]] = [
     (b"cal.1.capture-block-state", b"", b"string"),
     (b"cal.1.gui-urls", b"", b"string"),
     (b"capture-block-state", b"", b"string"),
-    (b"gpucbf_antenna_channelised_voltage-bandwidth", b"Hz", b"float"),
-    (b"gpucbf_m900h-destination", b"", b"string"),
+    (b"gpucbf_antenna_channelised_voltage.bandwidth", b"Hz", b"float"),
+    (b"gpucbf_m900h.destination", b"", b"string"),
     (b"gui-urls", b"", b"string"),
     (b"ingest.sdp_l0.1.capture-active", b"", b"boolean"),
     (


### PR DESCRIPTION
This change affects the product controller. Previously, hyphens were
used basically everywhere.

The CBF ICD with CAM requires that the KATCP guidelines (i.e. using a
fullstop to separate hierarchical levels), which is what prompted this
change.

Note: there are some not-exclusively-CBF sensors that are affected here.
I'm not sure whether or how much this will affect SDP.

Addresses NGC-854.