### PR TITLE
remove wildcard for dash requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     aiokatcp>=1.6.0
     aiozk
     async_timeout
-    dash>=1.18.*
+    dash>=1.18
     dash-core-components
     dash-html-components
     dash-table


### PR DESCRIPTION
Wildcards accompanying inclusive ordered comparison operators (https://peps.python.org/pep-0440/#inclusive-ordered-comparison) are not defined in the PEP 440 specification (also see https://discuss.python.org/t/pep-440-wildcard-usage-in-comparison-clause/10045/4).

I've merely gone around the problem by removing the wildcard in the requirements.txt entry for dash, in order to get katsdpcontroller branches to build again.