### PR TITLE
Prefix ingest command with capambel

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1647,7 +1647,8 @@ def _make_ingest(
             ingest.physical_factory = IngestTask
         ingest.fake_katcp_server_cls = FakeIngestDeviceServer
         ingest.image = "katsdpingest_" + normalise_gpu_name(defaults.INGEST_GPU_NAME)
-        ingest.command = ["ingest.py"]
+        ingest.command = ["capambel", "-c", "cap_net_raw+p", "-v", "--", "ingest.py"]
+        ingest.capabilities.append("NET_RAW")
         ingest.ports = ["port", "aiomonitor_port", "aioconsole_port"]
         ingest.wait_ports = ["port"]
         ingest.gpus = [scheduler.GPURequest()]

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1650,8 +1650,11 @@ def _make_ingest(
             ingest.physical_factory = IngestTask
         ingest.fake_katcp_server_cls = FakeIngestDeviceServer
         ingest.image = "katsdpingest_" + normalise_gpu_name(defaults.INGEST_GPU_NAME)
-        ingest.command = ["capambel", "-c", "cap_net_raw+p", "-v", "--", "ingest.py"]
-        ingest.capabilities.append("NET_RAW")
+        if develop.disable_ibv:
+            ingest.command = ["ingest.py"] 
+        else:
+            ingest.command = ["capambel", "-c", "cap_net_raw+p", "--", "ingest.py"]
+            ingest.capabilities.append("NET_RAW")
         ingest.ports = ["port", "aiomonitor_port", "aioconsole_port"]
         ingest.wait_ports = ["port"]
         ingest.gpus = [scheduler.GPURequest()]


### PR DESCRIPTION
This change is motivated by a change in the docker daemon and the way linux capabilities are handled. 

CAP_NET_RAW capability is transferred to ingest by `capambel.c`