### PR TITLE
Control autotune matching behavior in ingest tasks

### DIFF
--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -32,3 +32,5 @@ GPUCBF_SPECTRA_PER_HEAP = 256
 XBGPU_MAX_SRC_DATA_RATE = 5.45e9
 #: Number of polyphase filter-bank taps for gpucbf F-engines
 PFB_TAPS = 16
+#: Autotune fallback behaviour: "nearest" or "exact"
+KATSDPSIGPROC_TUNE_MATCH = "nearest"

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -117,8 +117,6 @@ OBJ_DATA_VOL = scheduler.VolumeRequest("obj_data", "/var/kat/data", "RW")
 CONFIG_VOL = scheduler.VolumeRequest("config", "/var/kat/config", "RW")
 #: Number of components in a complex number
 COMPLEX = 2
-#: Autotune fallback behaviour
-KATSDPSIGPROC_TUNE_MATCH = defaults.KATSDPSIGPROC_TUNE_MATCH
 
 logger = logging.getLogger(__name__)
 
@@ -309,19 +307,11 @@ class TelstateTask(ProductPhysicalTask):
 
 class IngestTask(ProductPhysicalTask):
     async def resolve(self, resolver, graph, image=None):
-        # In develop.any_gpu mode, the GPU can be anything, and we need to pick a
-        # matching image.
         if image is None:
             gpu = self.agent.gpus[self.allocation.gpus[0].index]
-            gpu_name = normalise_gpu_name(gpu.name)
-            image = await resolver.image_resolver("katsdpingest_" + gpu_name)
-            if gpu != defaults.INGEST_GPU_NAME:
-                logger.info("Develop.any_gpu mode: using %s for ingest", image.path)
+            image = await resolver.image_resolver("katsdpingest_" + normalise_gpu_name(gpu.name))
+            logger.info("Using %s for ingest", image.path)
         await super().resolve(resolver, graph, image)
-        parameters = self.taskinfo.container.docker.setdefault("parameters", [])
-        parameters.append(
-            {"key": "env", "value": f"KATSDPSIGPROC_TUNE_MATCH={KATSDPSIGPROC_TUNE_MATCH}"}
-        )
 
 
 def _mb(value):
@@ -1661,6 +1651,9 @@ def _make_ingest(
         else:
             ingest.command = ["capambel", "-c", "cap_net_raw+p", "--", "ingest.py"]
             ingest.capabilities.append("NET_RAW")
+        ingest.taskinfo.command.environment.setdefault("variables", []).extend(
+            [{"name": "KATSDPSIGPROC_TUNE_MATCH", "value": defaults.KATSDPSIGPROC_TUNE_MATCH}]
+        )
         ingest.ports = ["port", "aiomonitor_port", "aioconsole_port"]
         ingest.wait_ports = ["port"]
         ingest.gpus = [scheduler.GPURequest()]


### PR DESCRIPTION
This commit sets the KATSDPSIGPROC_TUNE_MATCH environment variable inside ingest containers before launching. This controls the behaviour of the autotuning machinery when an exact match for the GPU device is not found. Setting the variable to "nearest" causes the nearest match to be used, if any exists, while setting it to "exact" forces autotuning for all but exact matches.