### PR TITLE
Update sandbox dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   hooks:
     - id: black
 - repo: https://github.com/PyCQA/isort
-  rev: "5.10.1"
+  rev: "5.12.0"
   hooks:
     - id: isort
 - repo: https://github.com/PyCQA/flake8

--- a/sandbox/.gitignore
+++ b/sandbox/.gitignore
@@ -1,1 +1,3 @@
 sdp_image_tag
+etc/mesos-agent/attributes
+etc/mesos-agent/resources

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -62,7 +62,7 @@ virtual environment, are:
 pip install -e .
 pip install docker
 cd sandbox
-docker-compose up -d registry
+docker compose up -d registry
 ./update-local-registry.py
 ```
 
@@ -90,7 +90,7 @@ which will be faster since it will avoid building a number of images.
    amount of memory or CPU that Mesos thinks it has so that you can simulate
    larger arrays (at the risk of gobbling up all the RAM in your machine!)
 
-2. Run `docker-compose up -d`. Use `docker-compose ps` to check that the
+2. Run `docker compose up -d`. Use `docker compose ps` to check that the
    processes are all starting up.
 
 3. After the system has been left to settle for a bit, run `./elk-setup.sh`.
@@ -108,7 +108,7 @@ which will be faster since it will avoid building a number of images.
 
 5. Sometimes Singularity doesn't realise that it should be the master if it is
    started too soon after Zookeeper. To be on the safe side, run
-   `docker-compose restart singularity` to get it going.
+   `docker compose restart singularity` to get it going.
 
 ## Preparing an image tag
 

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -120,6 +120,7 @@ services:
     environment:
       - discovery.type=single-node
       - network.host=127.0.0.1
+      - ES_JAVA_OPTS=-Xmx2g -Xms2g
     volumes:
       - elasticsearch_data:/usr/share/elasticsearch/data
 

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -9,7 +9,7 @@ services:
 
   mesos-master:
     network_mode: host
-    image: mesos/mesos-centos:1.9.x
+    image: avhost/mesos-mini:1.11.0-0.2.0-1
     depends_on:
       - exhibitor
     environment:
@@ -28,7 +28,7 @@ services:
   mesos-agent:
     network_mode: host
     pid: host
-    image: mesos/mesos-centos:1.9.x
+    image: avhost/mesos-mini:1.11.0-0.2.0-1
     depends_on:
       - exhibitor
     environment:
@@ -36,7 +36,7 @@ services:
       MESOS_HOSTNAME: 127.0.0.1
       MESOS_PORT: 5051
       MESOS_MASTER: zk://127.0.0.1:2181/mesos
-      MESOS_CONTAINERIZERS: docker,mesos
+      MESOS_CONTAINERIZERS: docker
       MESOS_DOCKER_CONFIG: file:///etc/mesos/config.json
       MESOS_EXECUTOR_REGISTRATION_TIMEOUT: 5mins
       MESOS_WORK_DIR: /var/tmp/mesos
@@ -45,8 +45,8 @@ services:
       - "${HOME}/.docker/config.json:/etc/mesos/config.json:ro"
       - /var/run/docker.sock:/var/run/docker.sock
       - /sys:/sys
-      - /usr/bin/docker:/usr/local/bin/docker
       - ./etc/mesos-agent:/etc/mesos-agent:ro
+      - ./etc/default/mesos-agent:/etc/default/mesos-agent:ro
       # /var/tmp/mesos needs to be the same on the host and the container,
       # because mesos-agent writes to the sandbox and then tells the host
       # Docker to bind-mount it into the newly started container.

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -9,7 +9,7 @@ services:
 
   mesos-master:
     network_mode: host
-    image: mesos/mesos-centos:1.8.x
+    image: mesos/mesos-centos:1.9.x
     depends_on:
       - exhibitor
     environment:
@@ -28,7 +28,7 @@ services:
   mesos-agent:
     network_mode: host
     pid: host
-    image: mesos/mesos-centos:1.8.x
+    image: mesos/mesos-centos:1.9.x
     depends_on:
       - exhibitor
     environment:
@@ -59,7 +59,7 @@ services:
 
   singularity:
     network_mode: host
-    image: hubspot/singularityservice:1.2.0
+    image: hubspot/singularityservice:1.4.0
     depends_on:
       - mesos-master
       - exhibitor
@@ -68,7 +68,7 @@ services:
 
   minio:
     network_mode: host
-    image: minio/minio:RELEASE.2020-06-12T00-06-19Z
+    image: minio/minio:RELEASE.2023-02-27T18-10-45Z
     command: server --address 127.0.0.1:9000 /data
     volumes:
       - ./minio-data:/data
@@ -89,7 +89,7 @@ services:
 
   grafana:
     network_mode: host
-    image: grafana/grafana:6.5.2
+    image: grafana/grafana:9.4.1
     depends_on:
       - prometheus
     environment:
@@ -105,7 +105,7 @@ services:
 
   logstash:
     network_mode: host
-    image: docker.elastic.co/logstash/logstash-oss:7.3.1
+    image: docker.elastic.co/logstash/logstash:7.17.9
     command: logstash -w 1 -f /etc/logstash.conf --http.host 127.0.0.1
     environment:
       - LS_HEAP_SIZE=2048m
@@ -116,7 +116,7 @@ services:
 
   elasticsearch:
     network_mode: host
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.3.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.9
     environment:
       - discovery.type=single-node
       - network.host=127.0.0.1
@@ -136,7 +136,7 @@ services:
 
   consul:
     network_mode: host
-    image: consul:1.7.3
+    image: consul:1.15.0
     command: consul agent -dev -bind=127.0.0.1 -client=127.0.0.1 -config-dir=/etc/consul.d
     volumes:
       - ./etc/consul.d:/etc/consul.d:ro
@@ -148,7 +148,7 @@ services:
       - "127.0.0.1:9118:8080"
 
   registry:
-    image: registry:2.7.1
+    image: registry:2.8.1
     ports:
       - "127.0.0.1:5000:5000"
     volumes:

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -2,8 +2,8 @@
 
 version: "2.3"
 services:
-  exhibitor:
-    image: netflixoss/exhibitor:1.5.2
+  zookeeper:
+    image: zookeeper:3.8.1
     ports:
       - "127.0.0.1:2181:2181"
 
@@ -11,7 +11,7 @@ services:
     network_mode: host
     image: avhost/mesos-mini:1.11.0-0.2.0-1
     depends_on:
-      - exhibitor
+      - zookeeper
     environment:
       MESOS_IP: 127.0.0.1
       MESOS_HOSTNAME: 127.0.0.1
@@ -30,7 +30,7 @@ services:
     pid: host
     image: avhost/mesos-mini:1.11.0-0.2.0-1
     depends_on:
-      - exhibitor
+      - zookeeper
     environment:
       MESOS_IP: 127.0.0.1
       MESOS_HOSTNAME: 127.0.0.1
@@ -62,7 +62,7 @@ services:
     image: hubspot/singularityservice:1.4.0
     depends_on:
       - mesos-master
-      - exhibitor
+      - zookeeper
     volumes:
       - ./etc/singularity/singularity.yaml:/etc/singularity/singularity.yaml:ro
 

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -73,8 +73,8 @@ services:
     volumes:
       - ./minio-data:/data
     environment:
-      MINIO_ACCESS_KEY: minioaccesskey
-      MINIO_SECRET_KEY: miniosecretkey
+      MINIO_ROOT_USER: minioaccesskey
+      MINIO_ROOT_PASSWORD: miniosecretkey
 
   prometheus:
     network_mode: host

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -9,7 +9,7 @@ services:
 
   mesos-master:
     network_mode: host
-    image: avhost/mesos-mini:1.11.0-0.2.0-1
+    image: quay.io/ska-sa/mesos
     depends_on:
       - zookeeper
     environment:
@@ -28,7 +28,7 @@ services:
   mesos-agent:
     network_mode: host
     pid: host
-    image: avhost/mesos-mini:1.11.0-0.2.0-1
+    image: quay.io/ska-sa/mesos
     depends_on:
       - zookeeper
     environment:

--- a/sandbox/etc/elk/Dockerfile.kibana-logtrail
+++ b/sandbox/etc/elk/Dockerfile.kibana-logtrail
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/kibana/kibana-oss:7.3.1
+FROM docker.elastic.co/kibana/kibana-oss:7.9.2
 
-RUN ./bin/kibana-plugin install https://github.com/sivasamyk/logtrail/releases/download/v0.1.31/logtrail-7.3.1-0.1.31.zip
+RUN ./bin/kibana-plugin install https://github.com/sivasamyk/logtrail/releases/download/v0.1.31/logtrail-7.9.2-0.1.31.zip

--- a/sandbox/etc/mesos-agent/.gitignore
+++ b/sandbox/etc/mesos-agent/.gitignore
@@ -1,2 +1,0 @@
-/attributes
-/resources

--- a/sandbox/grafana-setup.sh
+++ b/sandbox/grafana-setup.sh
@@ -4,5 +4,5 @@ set -e -u
 trap 'echo Failed' ERR
 
 echo 'Installing plotly plugin'
-docker-compose exec grafana grafana-cli plugins install natel-plotly-panel 0.0.6
-docker-compose restart grafana
+docker compose exec grafana grafana-cli plugins install natel-plotly-panel 0.0.6
+docker compose restart grafana

--- a/sandbox/update-local-registry.py
+++ b/sandbox/update-local-registry.py
@@ -50,7 +50,7 @@ IMAGE_INFO = {
     "katsdpingest": ImageInfo(action=Action.BUILD),
     "katsdpimager": ImageInfo(action=Action.BUILD),
     "katcbfsim": ImageInfo(action=Action.BUILD),
-    "katgpucbf": ImageInfo(action=Action.BUILD),
+    "katgpucbf": ImageInfo(action=Action.BUILD, branch="main"),
 }
 
 


### PR DESCRIPTION
Bring all the dependencies in the sandbox up to more recent versions, which should reduce the number of security issues. Thanks to the Mesos update, this now works on an Ubuntu 22.04 host.

I mostly just went for the latest version, but I left the Elastic stack at 7.x (and Kibana at an older 7.x) because Logtrail doesn't support newer versions. Apparently Elastic might have something built-in in newer versions, but that's probably a whole extra kettle of fish to deal with.