### PR TITLE
Make list of product-schema versions accessible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ nbformat==4.4.0            # via plotly
 netifaces
 networkx==2.0
 numpy
+packaging
 plotly==4.0.0              # via dash
 prometheus_async==18.1.0
 prometheus_client==0.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     netifaces
     networkx>=2.0
     numpy
+    packaging
     prometheus_async
     prometheus_client>=0.3.0,<0.4.0   # 0.4.0 forces _total suffix
     pydot             # For networkx.drawing.nx_pydot

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -7,7 +7,6 @@ import logging
 import math
 import re
 from abc import ABC, abstractmethod
-from distutils.version import StrictVersion
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -31,6 +30,7 @@ import katportalclient
 import networkx
 import yarl
 from katsdptelstate.endpoint import endpoint_list_parser
+from packaging.version import Version
 
 from . import defaults, schemas
 
@@ -1850,7 +1850,7 @@ def _validate(config):
         if semantic constraints are violated
     """
     schemas.PRODUCT_CONFIG.validate(config)
-    version = StrictVersion(config["version"])
+    version = Version(config["version"])
     inputs = config.get("inputs", {})
     outputs = config.get("outputs", {})
     for name, stream in itertools.chain(inputs.items(), outputs.items()):
@@ -1900,7 +1900,7 @@ def _validate(config):
                     raise ValueError("sdp.cal output type no longer supports models")
 
             if output["type"] == "sdp.flags":
-                if version < "3.0":
+                if version < Version("3.0"):
                     calibration = output["calibration"][0]
                     if calibration not in outputs:
                         raise ValueError(f"calibration ({calibration}) does not exist")
@@ -1986,7 +1986,7 @@ def _upgrade(config):
     config.setdefault("inputs", {})
     config.setdefault("outputs", {})
     # Update to 3.0
-    if config["version"] < StrictVersion("3.0"):
+    if Version(config["version"]) < Version("3.0"):
         # Transfer only recognised stream types and parameters from inputs
         orig_inputs = config["inputs"]
         config["inputs"] = {}

--- a/src/katsdpcontroller/schemas/__init__.py
+++ b/src/katsdpcontroller/schemas/__init__.py
@@ -2,13 +2,18 @@
 
 import codecs
 import json
-from distutils.version import StrictVersion
 
 import jinja2
 import jsonschema
 import pkg_resources
+from packaging.version import Version
 
 _env = jinja2.Environment(loader=jinja2.PackageLoader(__name__, "."))
+
+
+def _normalise_version(version):
+    """Coerce strings to ComparableVersion."""
+    return ComparableVersion(version) if isinstance(version, str) else version
 
 
 def _make_validator(schema):
@@ -18,32 +23,60 @@ def _make_validator(schema):
     return validator_cls(schema, format_checker=jsonschema.FormatChecker())
 
 
+class ComparableVersion(Version):
+    """Version that can be compared to versions represented as strings."""
+
+    def __lt__(self, other) -> bool:
+        return super().__lt__(_normalise_version(other))
+
+    def __gt__(self, other) -> bool:
+        return super().__gt__(_normalise_version(other))
+
+    def __le__(self, other) -> bool:
+        return super().__le__(_normalise_version(other))
+
+    def __ge__(self, other) -> bool:
+        return super().__ge__(_normalise_version(other))
+
+    def __eq__(self, other) -> bool:
+        return super().__eq__(_normalise_version(other))
+
+    def __ne__(self, other) -> bool:
+        return super().__ne__(_normalise_version(other))
+
+
 class MultiVersionValidator:
     """Validation wrapper that supports a versioned schema.
 
     The schema must have a top-level `version` key. It is defined by a Jinja2
     template that contains two macros:
 
-    - ``validate_version()`` returns a mini version of the schema that only
-      validates the version.
+    - ``versions()`` returns a JSON list of supported versions.
     - ``validate(version)`` returns a schema for the given version.
 
-    If the version is a string, then it is converted to a
-    :class:`~distutils.version.StrictVersion` before being passed to
-    `validate`. The template can thus compare it against strings and get
-    sensible version ordering.
+    Versions can be strings or integers, and strings are converted to
+    :class:`ComparableVersion` before being passed to `validate`. The template
+    can thus compare the version against strings and get sensible version
+    ordering.
     """
 
     def __init__(self, name):
         self._template = _env.get_template(name)
-        # Load the mini-schema that just validates the version
-        schema = json.loads(self._template.module.validate_version())
+        # Create the mini-schema that just validates the version
+        versions = json.loads(self._template.module.versions())
+        assert isinstance(versions, list)
+        schema = {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": ["version"],
+            "properties": {"version": {"enum": versions}},
+        }
         self._version_validator = _make_validator(schema)
+        self.versions = [_normalise_version(v) for v in versions]
 
     @staticmethod
     def _get_version(doc):
-        version = doc["version"]
-        return StrictVersion(version) if isinstance(version, str) else version
+        return _normalise_version(doc["version"])
 
     def validate(self, doc):
         self._version_validator.validate(doc)

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -1,15 +1,5 @@
-{% macro validate_version() %}
-{
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "required": ["version"],
-    "properties": {
-        "version": {
-            "type": "string",
-            "enum": ["2.4", "2.5", "2.6", "3.0", "3.1", "3.2"]
-        }
-    }
-}
+{% macro versions() %}
+["2.4", "2.5", "2.6", "3.0", "3.1", "3.2"]
 {% endmacro %}
 
 {% macro validate(version) %}

--- a/src/katsdpcontroller/schemas/zk_state.json.j2
+++ b/src/katsdpcontroller/schemas/zk_state.json.j2
@@ -1,16 +1,5 @@
-{% macro validate_version() %}
-{
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "required": ["version"],
-    "properties": {
-        "version": {
-            "type": "integer",
-            "minimum": 4,
-            "maximum": 5
-        }
-    }
-}
+{% macro versions() %}
+[4, 5]
 {% endmacro %}
 
 {% macro validate(version) %}


### PR DESCRIPTION
It's only accessible internally for now, but could eventually be used to support NGC-906. Additionally, distutils (which is deprecated) is replaced by packaging.version. Because packaging.version.Version doesn't automatically implement comparisons to stringified versions the way distutils.version.StrictVersion did, I had to write a ComparableVersion wrapper.

Instead of individual schema files defining a validate_version schema, they simply list the versions they support, and the validation schema is generated. This also allows each schema object to report its versions e.g. PRODUCT_CONFIG.versions. As noted, this facility isn't wired up to anything yet.