### PR TITLE
Adding parsing for product-configure 3.3

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -532,6 +532,9 @@ def _make_fgpu(
     stream: product_config.GpucbfAntennaChannelisedVoltageStream,
     sync_time: int,
 ) -> scheduler.LogicalNode:
+    if stream.narrowband is not None:
+        raise NotImplementedError("narrowband support isn't implemented yet")
+
     ibv = not configuration.options.develop.disable_ibv
     n_engines = len(stream.src_streams) // 2
     fgpu_group = LogicalGroup(f"fgpu.{stream.name}")

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -1,5 +1,5 @@
 {% macro versions() %}
-["2.4", "2.5", "2.6", "3.0", "3.1", "3.2"]
+["2.4", "2.5", "2.6", "3.0", "3.1", "3.2", "3.3"]
 {% endmacro %}
 
 {% macro validate(version) %}
@@ -560,6 +560,17 @@
                                         "uniqueItems": true
                                     },
                                     "w_cutoff": {"$ref": "#/definitions/positive_number", "default": 1.0},
+{% if version >= "3.3" %}
+                                    "narrowband": {
+                                        "type": "object",
+                                        "properties": {
+                                            "decimation_factor": {"$ref": "#/definitions/positive_integer"},
+                                            "centre_frequency": {"$ref": "#/definitions/positive_number"}
+                                        },
+                                        "additionalProperties": false,
+                                        "required": ["decimation_factor", "centre_frequency"]
+                                    },
+{% endif %}
                                     "command_line_extra": {
                                         "type": "array",
                                         "items": {"type": "string"}

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -396,6 +396,16 @@ class TestGpucbfAntennaChanneliseVoltageStream:
         }
 
     @pytest.fixture
+    def narrowband_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "narrowband": {
+                "centre_frequency": 200e6,
+                "decimation_factor": 8,
+            },
+            **config,
+        }
+
+    @pytest.fixture
     def src_streams(self, config: Dict[str, Any]) -> List[DigBasebandVoltageStreamBase]:
         # Use a real digitiser for one of them, to test mixing
         return [
@@ -425,6 +435,32 @@ class TestGpucbfAntennaChanneliseVoltageStream:
         assert acv.sources(1) == tuple(src_streams[2:4])
         assert acv.data_rate(1.0, 0) == 27392e6 * 2
         assert acv.input_labels == config["src_streams"]
+        assert acv.w_cutoff == 1.0  # Default value
+        assert acv.command_line_extra == []
+
+    def test_from_config_narrowband(
+        self, narrowband_config: Dict[str, Any], src_streams: List[DigBasebandVoltageStreamBase]
+    ) -> None:
+        acv = GpucbfAntennaChannelisedVoltageStream.from_config(
+            Options(), "narrow1_acv", narrowband_config, src_streams, {}
+        )
+        assert acv.name == "narrow1_acv"
+        assert acv.antennas == ["m000", "m002"]
+        assert acv.band == src_streams[0].band
+        assert acv.n_chans == narrowband_config["n_chans"]
+        assert acv.bandwidth == src_streams[0].adc_sample_rate / 2 / 8
+        assert acv.centre_frequency == 1056e6
+        assert acv.adc_sample_rate == src_streams[0].adc_sample_rate
+        assert (
+            acv.n_samples_between_spectra
+            == 2
+            * narrowband_config["n_chans"]
+            * narrowband_config["narrowband"]["decimation_factor"]
+        )
+        assert acv.sources(0) == tuple(src_streams[0:2])
+        assert acv.sources(1) == tuple(src_streams[2:4])
+        assert acv.data_rate(1.0, 0) == 27392e6 * 2 / 8
+        assert acv.input_labels == narrowband_config["src_streams"]
         assert acv.w_cutoff == 1.0  # Default value
         assert acv.command_line_extra == []
 
@@ -528,6 +564,17 @@ class TestGpucbfAntennaChanneliseVoltageStream:
             Options(), "wide1_acv", config, src_streams, {}
         )
         assert acv.command_line_extra == config["command_line_extra"]
+
+    def test_narrowband_bad_centre_frequency(
+        self, narrowband_config: Dict[str, Any], src_streams: List[DigBasebandVoltageStreamBase]
+    ) -> None:
+        narrowband_config["narrowband"]["centre_frequency"] = 50e6
+        with pytest.raises(
+            ValueError, match=r"50000000.0 is outside the range \[53500000\.0, 802500000\.0\]"
+        ):
+            GpucbfAntennaChannelisedVoltageStream.from_config(
+                Options(), "narrow1_acv", narrowband_config, src_streams, {}
+            )
 
 
 class TestSimAntennaChannelisedVoltageStream:
@@ -1320,7 +1367,7 @@ class TestSpectralImageStream:
 @pytest.fixture
 def config() -> Dict[str, Any]:
     return {
-        "version": "3.2",
+        "version": "3.3",
         "inputs": {
             "camdata": {"type": "cam.http", "url": "http://10.8.67.235/api/client/1"},
             "i0_antenna_channelised_voltage": {
@@ -1482,7 +1529,7 @@ def config_v2() -> Dict[str, Any]:
 @pytest.fixture
 def config_sim() -> Dict[str, Any]:
     return {
-        "version": "3.2",
+        "version": "3.3",
         "outputs": {
             "acv": {
                 "type": "sim.cbf.antenna_channelised_voltage",

--- a/test/utils.py
+++ b/test/utils.py
@@ -24,7 +24,7 @@ _T = TypeVar("_T")
 # The "gpucbf" correlator components are not connected up to any SDP components.
 # They're there just as a smoke test for generator.py.
 CONFIG = """{
-    "version": "3.2",
+    "version": "3.3",
     "outputs": {
         "gpucbf_m900v": {
             "type": "sim.dig.baseband_voltage",


### PR DESCRIPTION
It parses a GpucbfNarrowbandConfig object, but doesn't actually do
anything with it (and trying to instantiate a correlator will raise a NotImplemented Error).

See the suggested edits in https://docs.google.com/document/d/15ZIyuBf4Vk4ESIEdKsQxdSBoLEwh85eyKeDJouLRAZY/edit# for the schema update.

Closes NGC-565.