### PR TITLE
Add hyphen to allowed characters in stream-name

### DIFF
--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -2074,7 +2074,7 @@ def _upgrade(config):
         config["version"] = "3.0"
 
     # Upgrade to latest 3.x
-    config["version"] = schemas.PRODUCT_CONFIG.versions[-1]
+    config["version"] = str(schemas.PRODUCT_CONFIG.versions[-1])
 
     _validate(config)  # Should never fail if the input was valid
     return config

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -2074,7 +2074,7 @@ def _upgrade(config):
         config["version"] = "3.0"
 
     # Upgrade to latest 3.x
-    config["version"] = "3.3"
+    config["version"] = schemas.PRODUCT_CONFIG.versions[-1]
 
     _validate(config)  # Should never fail if the input was valid
     return config

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -2074,7 +2074,7 @@ def _upgrade(config):
         config["version"] = "3.0"
 
     # Upgrade to latest 3.x
-    config["version"] = str(schemas.PRODUCT_CONFIG.versions[-1])
+    config["version"] = str(max(schemas.PRODUCT_CONFIG.versions))
 
     _validate(config)  # Should never fail if the input was valid
     return config

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -9,7 +9,7 @@
     "definitions": {
         "stream_name": {
             "type": "string",
-            "pattern": "^[A-Za-z0-9_]+$"
+            "pattern": "^[A-Za-z0-9_\-]+$"
         },
         "stream_type": {
             "type": "string",

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -4,16 +4,13 @@
 
 {% macro validate(version) %}
 {% set input_additional = "false" if version >= "3.0" else "true" %}
+{% set stream_name_pattern = "^[-A-Za-z0-9_]+$" if version >= "3.4" else "^[A-Za-z0-9_]+$" %}
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "stream_name": {
             "type": "string",
-{% if version >= "3.4" %}
-            "pattern": "^[-A-Za-z0-9_]+$"
-{% else %}
-            "pattern": "^[A-Za-z0-9_]+$"
-{% endif %}
+            "pattern": "{{ stream_name_pattern }}"
         },
         "stream_type": {
             "type": "string",
@@ -108,11 +105,7 @@
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
-{% if version >= "3.4" %}
-                "^[-A-Za-z0-9_]+$": {
-{% else %}
-                "^[A-Za-z0-9_]+$": {
-{% endif %}
+                "{{ stream_name_pattern }}": {
                     "type": "object",
                     "required": ["type", "url"],
                     "properties": {
@@ -269,11 +262,7 @@
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
-{% if version >= "3.4" %}
-                "^[-A-Za-z0-9_]+$": {
-{% else %}
-                "^[A-Za-z0-9_]+$": {
-{% endif %}
+                "{{ stream_name_pattern }}": {
                     "type": "object",
                     "required": ["type"],
                     "properties": {

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -1,5 +1,5 @@
 {% macro versions() %}
-["2.4", "2.5", "2.6", "3.0", "3.1", "3.2", "3.3"]
+["2.4", "2.5", "2.6", "3.0", "3.1", "3.2", "3.3", "3.4"]
 {% endmacro %}
 
 {% macro validate(version) %}
@@ -9,7 +9,11 @@
     "definitions": {
         "stream_name": {
             "type": "string",
+{% if version >= "3.4" %}
             "pattern": "^[-A-Za-z0-9_]+$"
+{% else %}
+            "pattern": "^[A-Za-z0-9_]+$"
+{% endif %}
         },
         "stream_type": {
             "type": "string",

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -9,7 +9,7 @@
     "definitions": {
         "stream_name": {
             "type": "string",
-            "pattern": "^[A-Za-z0-9_\-]+$"
+            "pattern": r"^[A-Za-z0-9_\-]+$"
         },
         "stream_type": {
             "type": "string",

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -4,7 +4,7 @@
 
 {% macro validate(version) %}
 {% set input_additional = "false" if version >= "3.0" else "true" %}
-{% set stream_name_pattern = "^[-A-Za-z0-9_]+$" if version >= "3.4" else "^[A-Za-z0-9_]+$" %}
+{% set stream_name_pattern = "^[A-Za-z0-9_-]+$" if version >= "3.4" else "^[A-Za-z0-9_]+$" %}
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -9,7 +9,7 @@
     "definitions": {
         "stream_name": {
             "type": "string",
-            "pattern": r"^[A-Za-z0-9_\-]+$"
+            "pattern": "^[-A-Za-z0-9_]+$"
         },
         "stream_type": {
             "type": "string",

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -108,7 +108,11 @@
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
+{% if version >= "3.4" %}
+                "^[-A-Za-z0-9_]+$": {
+{% else %}
                 "^[A-Za-z0-9_]+$": {
+{% endif %}
                     "type": "object",
                     "required": ["type", "url"],
                     "properties": {
@@ -265,7 +269,11 @@
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
+{% if version >= "3.4" %}
+                "^[-A-Za-z0-9_]+$": {
+{% else %}
                 "^[A-Za-z0-9_]+$": {
+{% endif %}
                     "type": "object",
                     "required": ["type"],
                     "properties": {

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -1367,7 +1367,7 @@ class TestSpectralImageStream:
 @pytest.fixture
 def config() -> Dict[str, Any]:
     return {
-        "version": "3.3",
+        "version": "3.4",
         "inputs": {
             "camdata": {"type": "cam.http", "url": "http://10.8.67.235/api/client/1"},
             "i0_antenna_channelised_voltage": {
@@ -1529,7 +1529,7 @@ def config_v2() -> Dict[str, Any]:
 @pytest.fixture
 def config_sim() -> Dict[str, Any]:
     return {
-        "version": "3.3",
+        "version": "3.4",
         "outputs": {
             "acv": {
                 "type": "sim.cbf.antenna_channelised_voltage",


### PR DESCRIPTION
CAM would like to be able to call CBF streams things like `antenna-channelised-voltage`, rather than
`antenna_channelised_voltage`. I think this commit should enable it.

(Possibly) closes NGC-914.