### PR TITLE
Make some fgpu sensors output-specific

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -831,16 +831,21 @@ def _make_fgpu(
         # Rename sensors that are relevant to the stream rather than the process
         for j, label in enumerate(input_labels):
             for name in [
-                "eq",
-                "delay",
                 "dig-clip-cnt",
-                "dig-pwr-dbfs",
-                "feng-clip-cnt",
                 "rx.timestamp",
                 "rx.unixtime",
                 "rx.missing-unixtime",
             ]:
                 fgpu.sensor_renames[f"input{j}.{name}"] = f"{stream.name}.{label}.{name}"
+            for name in [
+                "eq",
+                "delay",
+                "dig-pwr-dbfs",
+                "feng-clip-cnt",
+            ]:
+                fgpu.sensor_renames[
+                    f"{stream.name}.input{j}.{name}"
+                ] = f"{stream.name}.{label}.{name}"
         # Prepare expected data rates etc
         fgpu.static_gauges["fgpu_expected_input_heaps_per_second"] = sum(
             src.adc_sample_rate / src.samples_per_heap for src in srcs

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -806,6 +806,21 @@ class FakeDeviceServer(aiokatcp.DeviceServer):
         position = self.logical_task.command.index(argument_name)
         return value_type(self.logical_task.command[position + 1])
 
+    def get_command_arguments(
+        self, value_type: Callable[[str], _T], argument_name: str
+    ) -> List[_T]:
+        """Return the values pass to the fake device as CLI parameters.
+
+        This is similar to :meth:`get_command_argument` (with the same
+        limitations), but supports arguments that can be passed multiple times,
+        returning a list of the values.
+        """
+        ret = []
+        for i, arg in enumerate(self.logical_task.command):
+            if arg == argument_name:
+                ret.append(value_type(self.logical_task.command[i + 1]))
+        return ret
+
 
 @asynccontextmanager
 async def wrap_katcp_server(

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -809,7 +809,7 @@ class FakeDeviceServer(aiokatcp.DeviceServer):
     def get_command_arguments(
         self, value_type: Callable[[str], _T], argument_name: str
     ) -> List[_T]:
-        """Return the values pass to the fake device as CLI parameters.
+        """Return the values passed to the fake device as CLI parameters.
 
         This is similar to :meth:`get_command_argument` (with the same
         limitations), but supports arguments that can be passed multiple times,


### PR DESCRIPTION
Sensors eq, gain, feng-clip-cnt and dig-pwr-dbfs are now prefixed with the stream name in fgpu (requires a matching update to fgpu).

This matches https://github.com/ska-sa/katgpucbf/pull/542. See NGC-569.