### PR TITLE
SPR1-2376: Don't dump RDB files if not archiving

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -2502,9 +2502,13 @@ def build_logical_graph(
                 need_telstate = True
     if need_telstate:
         telstate: Optional[scheduler.LogicalNode] = _make_telstate(g, configuration)
-        meta_writer: Optional[scheduler.LogicalNode] = _make_meta_writer(g, configuration)
     else:
         telstate = None
+    # XXX Technically meta_writer expects archived streams of type sdp.vis,
+    # so this check is necessary but not sufficient (to skip RDB files in the lab)
+    if need_telstate and archived_streams:
+        meta_writer: Optional[scheduler.LogicalNode] = _make_meta_writer(g, configuration)
+    else:
         meta_writer = None
 
     # Count large allocations in telstate, which affects memory usage of


### PR DESCRIPTION
While the meta_writer's `write_meta` KATCP request is quite flexible in terms of stream input, it is only ever called with the default setting, which looks for archived `sdp.vis` streams. The resulting stream names are appended to the CBID to form corresponding RDB filenames.

When testing in the lab, we frequently disable archiving streams to save disk space. The side effect is that meta_writer crashes with "No stream specified, and cannot determine available streams from telstate." This happens right at the end of the observation so it's not that critical, but it leaves a bad taste in the mouth.

Avoid this crash by disabling RDB dumps if there are no archived streams. This is necessary but not sufficient, but should at least get rid of the typical lab crashes.