### PR TITLE
Add product-configure-versions request

### DIFF
--- a/test/test_master_controller.py
+++ b/test/test_master_controller.py
@@ -74,6 +74,7 @@ EXPECTED_REQUEST_LIST = [
     "product-deconfigure",
     "product-reconfigure",
     "product-list",
+    "product-configure-versions",
     "set-config-override",
     "sdp-shutdown",
     "capture-done",


### PR DESCRIPTION
This reports the product configure schema versions that are supported, assuming that nothing in the config dict overrides the choice of product controller.

Closes NGC-906 (although the ICD will still need to be updated).