### PR TITLE
Move fgpu adc-bits sensor to f-engine stream grouping

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -564,7 +564,7 @@ def _make_fgpu(
     stream_sensors = [
         Sensor(
             int,
-            "adc-bits",
+            "{stream.name}.adc-bits",
             "ADC sample bitwidth",
             default=adc_bits,
             initial_status=Sensor.Status.NOMINAL,


### PR DESCRIPTION
This action taken in order to be more consistent with adc-sample-rate.

Closes NGC-920