### PR TITLE
Update sensors for narrowband

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -998,14 +998,6 @@ def _make_xbgpu(
             default=stream.n_chans_per_substream,
             initial_status=Sensor.Status.NOMINAL,
         ),
-        Sensor(
-            float,
-            f"{stream.name}.ddc-mix-freq",
-            "F-engine DDC mixer frequency, where used. 0 where n/a",
-            units="Hz",
-            default=0.0,
-            initial_status=Sensor.Status.NOMINAL,
-        ),
         SumSensor(
             sensors,
             f"{stream.name}.xeng-clip-cnt",

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -667,10 +667,10 @@ def _make_fgpu(
             initial_status=Sensor.Status.NOMINAL,
         ),
         Sensor(
-            int,
+            float,
             f"{stream.name}.pfb-group-delay",
             "PFB group delay, specified in number of samples",
-            default=round(pfb_group_delay),  # TODO: change the ICD from int to float?
+            default=pfb_group_delay,
             initial_status=Sensor.Status.NOMINAL,
         ),
         Sensor(

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -592,6 +592,13 @@ def _make_fgpu(
             default=stream.bandwidth,
             initial_status=Sensor.Status.NOMINAL,
         ),
+        Sensor(
+            int,
+            f"{stream.name}.decimation-factor",
+            "The factor by which the bandwidth of the incoming digitiser stream is decimated",
+            default=stream.narrowband.decimation_factor if stream.narrowband else 1,
+            initial_status=Sensor.Status.NOMINAL,
+        ),
         # The timestamps are simply ADC sample counts
         Sensor(
             float,


### PR DESCRIPTION
- Fix value of `pfb-group-delay` sensor, and also allow it to be non-integer (as discussed in MKAIV-731)
- Fix value of `center-freq` sensor
- Add `decimation-factor` sensor and remove `ddc-mix-freq` sensor (as per NGC-913)

Closes NGC-568, NGC-966.
