### PR TITLE
Merge fgpu streams

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -870,18 +870,18 @@ def _make_fgpu(
         g.add_edge(fgpu_group, fgpu, depends_ready=True, depends_init=True)
 
         # Rename sensors that are relevant to the stream rather than the process
-        for stream in streams:
-            for j, label in enumerate(input_labels):
-                for name in [
-                    "dig-clip-cnt",
-                    "rx.timestamp",
-                    "rx.unixtime",
-                    "rx.missing-unixtime",
-                ]:
-                    # TODO[nb]: this will only rename to the last stream. We
-                    # need to extend the renaming mechanism to support
-                    # cloning.
-                    fgpu.sensor_renames[f"input{j}.{name}"] = f"{stream.name}.{label}.{name}"
+        for j, label in enumerate(input_labels):
+            for name in [
+                "dig-clip-cnt",
+                "rx.timestamp",
+                "rx.unixtime",
+                "rx.missing-unixtime",
+            ]:
+                # These engine-level sensors get replicated to all the corresponding streams
+                fgpu.sensor_renames[f"input{j}.{name}"] = [
+                    f"{stream.name}.{label}.{name}" for stream in streams
+                ]
+            for stream in streams:
                 for name in [
                     "eq",
                     "delay",

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -577,10 +577,11 @@ def _make_fgpu(
         data_suspect_sensors.append(data_suspect_sensor)
 
         if stream.narrowband is not None:
-            pfb_group_delay = (
-                -(stream.n_chans * stream.pfb_taps - 1) / 2 * (stream.narrowband.decimation_factor * 2)
-            )
+            subsampling = stream.narrowband.decimation_factor * 2
+            # Complex-to-complex PFB
+            pfb_group_delay = -(stream.n_chans * stream.pfb_taps - 1) / 2 * subsampling
         else:
+            # Real-to-complex PFB
             pfb_group_delay = -(2 * stream.n_chans * stream.pfb_taps - 1) / 2
 
         stream_sensors = [

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -593,10 +593,7 @@ class GpucbfNarrowbandConfig:
 
 
 class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase):
-    """Real antenna-channelised-voltage stream (GPU correlator).
-
-    It currently only supports wideband.
-    """
+    """Real antenna-channelised-voltage stream (GPU correlator)."""
 
     stream_type: ClassVar[str] = "gpucbf.antenna_channelised_voltage"
     _valid_src_types: ClassVar[_ValidTypes] = {


### PR DESCRIPTION
When multiple gpucbf.antenna_channelised_voltage streams have the same
input configuration (just different outputs), run them in the same
engines.

This partially addresses NGC-916. There are a few outstanding issues:
- Resource usage may need adjustment (it will use more memory, for
  example).
- A few sensors need to be replicated across streams, which will require
  some rework of the sensor renaming apparatus.