### PR TITLE
SPR1-2376: Let dsim set sub_band telstate entry

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -457,6 +457,7 @@ def _make_dsim(
     telstate_data = {"observer": streams[0].antenna.description}
     for key, value in telstate_data.items():
         init_telstate[(streams[0].antenna.name, key)] = value
+    init_telstate[("sub", "band")] = streams[0].band
 
     # Generate a unique name. The caller groups streams by
     # (antenna.name, adc_sample_rate), so that is guaranteed to be unique.


### PR DESCRIPTION
In the absence of CAM we need to set certain telstate keys as part of product configuration. One is `sub_band`, needed by cal to start up. The CBF simulator stream ("sim.cbf") already initialises `sub_band`, so do the same for the lab test setup of the GPU correlator ("gpucbf").

Dsim is a good place to put this because
  - it knows the band,
  - it already pre-populates `mxxx_observer` in the absence of CAM, and
  - it is typically not needed if CAM is around.

This change allows cal to start up in the lab.