### PR TITLE
Bump flask, dash, werkzeug to newer versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
--c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+-d https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
 addict==2.1.1
 aiohttp
-aiohttp-jinja2==1.4.2
+aiohttp-jinja2==1.5.1
 aiokatcp
 aiozk==0.14.0
 async-timeout
-click==7.0                 # via Flask
+blinker==1.6.2             # via flask
+click==8.1.3               # via flask
 dash==1.20.0
 dash_core_components==1.16.0
 dash_dangerously_set_inner_html==0.0.2
@@ -15,17 +16,19 @@ dash_table==4.11.3
 decorator
 docker-pycreds==0.3.0      # via docker
 docker==3.4.1
-flask==1.1.1               # via dash
+flask==2.3.2               # via dash
 flask-compress==1.4.0      # via dash
 hiredis                    # speeds up katsdptelstate
 http-parser==0.9.0         # via pymesos
+importlib-metadata==6.6.0  # via flask
 ipython-genutils==0.2.0    # via nbformat
-itsdangerous==1.1.0        # via flask
-jinja2
+itsdangerous==2.1.2        # via flask
+jinja2==3.1.2              # override old version in katsdpdockerbase
 jsonschema
 jupyter-core==4.11.2       # via nbformat
 katportalclient
 kazoo==2.8.0
+markupsafe==2.1.2          # via jinja2, werkzeug - override old version in katsdpdockerbase
 monotonic==1.5             # via prometheus_async
 nbformat==4.4.0            # via plotly
 netifaces
@@ -41,10 +44,11 @@ retrying==1.3.3            # via plotly
 rfc3987==1.3.7
 traitlets==4.3.2           # via nbformat
 websocket-client==0.45.0   # via docker
-werkzeug==0.15.5           # via flask
+werkzeug==2.3.3            # via flask
 wrapt==1.10.11             # via prometheus_async
 www-authenticate==0.9.2
 yarl
+zipp==3.15.0               # via importlib-metadata
 
 katpoint @ git+https://github.com/ska-sa/katpoint
 katdal @ git+https://github.com/ska-sa/katdal

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,41 +8,36 @@ aiozk==0.14.0
 async-timeout
 blinker==1.6.2             # via flask
 click==8.1.3               # via flask
-dash==1.20.0
-dash_core_components==1.16.0
+dash==2.9.3
+dash_core_components==2.0.0
 dash_dangerously_set_inner_html==0.0.2
-dash_html_components==1.1.3
-dash_table==4.11.3
+dash_html_components==2.0.0
+dash_table==5.0.0
 decorator
 docker-pycreds==0.3.0      # via docker
 docker==3.4.1
 flask==2.3.2               # via dash
-flask-compress==1.4.0      # via dash
 hiredis                    # speeds up katsdptelstate
 http-parser==0.9.0         # via pymesos
 importlib-metadata==6.6.0  # via flask
-ipython-genutils==0.2.0    # via nbformat
 itsdangerous==2.1.2        # via flask
 jinja2==3.1.2              # override old version in katsdpdockerbase
 jsonschema
-jupyter-core==4.11.2       # via nbformat
 katportalclient
 kazoo==2.8.0
 markupsafe==2.1.2          # via jinja2, werkzeug - override old version in katsdpdockerbase
 monotonic==1.5             # via prometheus_async
-nbformat==4.4.0            # via plotly
 netifaces
 networkx==2.0
 numpy
 packaging
-plotly==4.0.0              # via dash
+plotly==5.14.1             # via dash
 prometheus_async==18.1.0
 prometheus_client==0.3.1
 pydot==1.4.2
 pymesos==0.3.6
-retrying==1.3.3            # via plotly
 rfc3987==1.3.7
-traitlets==4.3.2           # via nbformat
+tenacity==8.2.2            # via plotly
 websocket-client==0.45.0   # via docker
 werkzeug==2.3.3            # via flask
 wrapt==1.10.11             # via prometheus_async


### PR DESCRIPTION
This started out as bumping flask and werkzeug to keep dependabot happy (security advisories), but required updating a bunch of other packages in the stack due to incompatibilities. The good news is that it got rid of the dependency on ipython. The bad news is that it required overriding some package versions from dockerbase because I don't want to deal with the fallout of updating dockerbase and breaking half the downstream packages.

Relates to SPR1-2783.