### PR TITLE
dig-rms-dbfs is now an engine-level sensor

### DIFF
--- a/src/katsdpcontroller/fake_servers.py
+++ b/src/katsdpcontroller/fake_servers.py
@@ -129,16 +129,6 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
                 )
                 self.sensors.add(
                     Sensor(
-                        float,
-                        f"{output}.input{pol}.dig-rms-dbfs",
-                        "Digitiser ADC average power",
-                        units="dBFS",
-                        default=-25.0,
-                        initial_status=Sensor.Status.NOMINAL,
-                    )
-                )
-                self.sensors.add(
-                    Sensor(
                         int,
                         f"{output}.input{pol}.feng-clip-cnt",
                         "Number of output samples that are saturated",
@@ -152,6 +142,16 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
                     f"input{pol}.dig-clip-cnt",
                     "Number of digitiser samples that are saturated",
                     default=0,
+                    initial_status=Sensor.Status.NOMINAL,
+                )
+            )
+            self.sensors.add(
+                Sensor(
+                    float,
+                    f"input{pol}.dig-rms-dbfs",
+                    "Digitiser ADC average power",
+                    units="dBFS",
+                    default=-25.0,
                     initial_status=Sensor.Status.NOMINAL,
                 )
             )

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -874,6 +874,7 @@ def _make_fgpu(
         for j, label in enumerate(input_labels):
             for name in [
                 "dig-clip-cnt",
+                "dig-rms-dbfs",
                 "rx.timestamp",
                 "rx.unixtime",
                 "rx.missing-unixtime",
@@ -886,7 +887,6 @@ def _make_fgpu(
                 for name in [
                     "eq",
                     "delay",
-                    "dig-rms-dbfs",
                     "feng-clip-cnt",
                 ]:
                     fgpu.sensor_renames[


### PR DESCRIPTION
Replicate it to each of the corresponding streams (NGC-924).