### PR TITLE
Remove use of deprecated pkg_resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ flask==2.3.2               # via dash
 hiredis                    # speeds up katsdptelstate
 http-parser==0.9.0         # via pymesos
 importlib-metadata==6.6.0  # via flask
+importlib-resources==5.12.0
 itsdangerous==2.1.2        # via flask
 jinja2==3.1.2              # override old version in katsdpdockerbase
 jsonschema

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     dash-dangerously-set-inner-html
     decorator
     docker
+    importlib-resources
     jinja2
     jsonschema>=3.0   # Version 3 implements Draft 7
     katdal
@@ -54,7 +55,7 @@ python_requires = >=3.8
 scripts =
     scripts/sdp_master_controller.py
     scripts/sdp_product_controller.py
-zip_safe = False
+zip_safe = False  # Need importlib.resources.files to return a real path
 
 [options.packages.find]
 where = src

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -232,9 +232,9 @@ from typing import AsyncContextManager, ClassVar, List, Mapping, Optional, Tuple
 
 import aiohttp.web
 import docker
+import importlib_resources
 import jsonschema
 import networkx
-import pkg_resources
 import pymesos
 import www_authenticate
 from addict import Dict
@@ -3112,9 +3112,7 @@ class SchedulerBase:
         app = aiohttp.web.Application()
         app["katsdpcontroller_scheduler"] = self
         app.router.add_get("/tasks/{id}/wait_start", wait_start_handler)
-        app.router.add_static(
-            "/static", pkg_resources.resource_filename("katsdpcontroller", "static")
-        )
+        app.router.add_static("/static", importlib_resources.files("katsdpcontroller") / "static")
         self.app = app
         if runner_kwargs is None:
             runner_kwargs = {}

--- a/src/katsdpcontroller/schemas/__init__.py
+++ b/src/katsdpcontroller/schemas/__init__.py
@@ -1,11 +1,10 @@
 """Makes packaged JSON schemas available."""
 
-import codecs
 import json
 
+import importlib_resources
 import jinja2
 import jsonschema
-import pkg_resources
 from packaging.version import Version
 
 _env = jinja2.Environment(loader=jinja2.PackageLoader(__name__, "."))
@@ -86,10 +85,10 @@ class MultiVersionValidator:
         validator.validate(doc)
 
 
-for name in pkg_resources.resource_listdir(__name__, "."):
+for entry in importlib_resources.files(__name__).iterdir():
+    name = entry.name
     if name.endswith(".json"):
-        with codecs.getreader("utf-8")(pkg_resources.resource_stream(__name__, name)) as reader:
-            schema = json.load(reader)
+        schema = json.loads(entry.read_text())
         globals()[name[:-5].upper()] = _make_validator(schema)
     elif name.endswith(".json.j2"):
         globals()[name[:-8].upper()] = MultiVersionValidator(name)

--- a/src/katsdpcontroller/web.py
+++ b/src/katsdpcontroller/web.py
@@ -24,8 +24,8 @@ import weakref
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import aiohttp_jinja2
+import importlib_resources
 import jinja2
-import pkg_resources
 import yarl
 from aiohttp import WSMsgType, web
 from aiokatcp import Reading, Sensor
@@ -356,7 +356,7 @@ def make_app(
             web.get("/rotate", _rotate_handler),
             web.post("/gui/{product}/{path:.*}/_dash-update-component", _block_dashboard),
             web.route("*", "/gui/{product}/{service}/{gui}{path:.*}", _missing_gui_handler),
-            web.static("/static", pkg_resources.resource_filename("katsdpcontroller", "static")),
+            web.static("/static", importlib_resources.files("katsdpcontroller") / "static"),
         ]
     )
     aiohttp_jinja2.setup(


### PR DESCRIPTION
Use importlib_resources instead (can eventually be replaced by stdlib importlib.resources once Python 3.8 support is no longer needed).

See NGC-977.