### PR TITLE
Fix delay/gain setting with multiple streams per engine

### DIFF
--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -144,10 +144,11 @@ class KatcpTransition:
 
 
 class ProductLogicalTask(scheduler.LogicalTask):
-    def __init__(self, name, streams=()):
+    def __init__(self, name, streams=(), index=None):
         super().__init__(name)
         self.task_type = name.split(".", 1)[0]
         self.streams = list(streams)
+        self.index = index
         self.stream_names = frozenset(stream.name for stream in streams)
         self.physical_factory = ProductPhysicalTask
         self.fake_katcp_server_cls: Type[FakeDeviceServer] = FakeDeviceServer


### PR DESCRIPTION
Previously there was a hard-coded assumption that the engine handling a stream was named f.<stream>.<index>, but that doesn't hold when an F-engine handles multiple streams.

Resolve it by associating an `index` field with each ProductLogicalTask so that `find_nodes` can find the appropriate nodes for a stream.

Closes NGC-992