### PR TITLE
Improve diagnosis when there are not enough resources

### DIFF
--- a/src/katsdpcontroller/diagnose_insufficient.py
+++ b/src/katsdpcontroller/diagnose_insufficient.py
@@ -469,6 +469,10 @@ def diagnose_insufficient(
         # Non-tasks aren't relevant, so filter them out.
         tasks = [node for node in nodes if isinstance(node, PhysicalTask)]
 
+        # First use a weak filter. This avoids an error saying that a task
+        # require more than zero of a resource of which zero was available,
+        # if the actual problem is that the task has some device requirement
+        # that no agent fulfills.
         _diagnose_insufficient_filter(
             agents, tasks, lambda agent, task: task.logical_node.valid_agent(agent)
         )

--- a/src/katsdpcontroller/diagnose_insufficient.py
+++ b/src/katsdpcontroller/diagnose_insufficient.py
@@ -103,7 +103,7 @@ class InsufficientResource:
 
 @dataclass
 class InsufficientRequester:
-    """A requester that need too much of a resource in :exc:`InsufficientResourcesError`."""
+    """A requester that needs too much of a resource in :exc:`InsufficientResourcesError`."""
 
     task: PhysicalTask
 
@@ -241,7 +241,7 @@ def _global_graphs(
     tasks: Sequence[PhysicalTask],
     agent_filter: Callable[[Agent, PhysicalTask], bool],
 ) -> Iterable[networkx.DiGraph]:
-    # Global resources
+    """Construct flow graphs for each global resource."""
     for r, rcls in scheduler.GLOBAL_RESOURCES.items():
         g = networkx.DiGraph(
             resource_class=rcls, resource=InsufficientResource(r, ResourceGroup.GLOBAL)
@@ -282,6 +282,7 @@ def _gpu_graphs(
     tasks: Sequence[PhysicalTask],
     agent_filter: Callable[[Agent, PhysicalTask], bool],
 ) -> Iterable[networkx.DiGraph]:
+    """Construct flow graphs for each per-GPU resource."""
     for r, rcls in scheduler.GPU_RESOURCES.items():
         g = networkx.DiGraph(
             resource_class=rcls, resource=InsufficientResource(r, ResourceGroup.GPU)
@@ -312,6 +313,10 @@ def _interface_graphs(
     tasks: Sequence[PhysicalTask],
     agent_filter: Callable[[Agent, PhysicalTask], bool],
 ) -> Iterable[networkx.DiGraph]:
+    """Construct flow graphs for each interface resource.
+
+    A separate graph is generated for each network name.
+    """
     # Start by identifying the networks
     networks = set()
     for task in tasks:
@@ -470,7 +475,7 @@ def diagnose_insufficient(
         tasks = [node for node in nodes if isinstance(node, PhysicalTask)]
 
         # First use a weak filter. This avoids an error saying that a task
-        # require more than zero of a resource of which zero was available,
+        # requires more than zero of a resource of which zero was available,
         # if the actual problem is that the task has some device requirement
         # that no agent fulfills.
         _diagnose_insufficient_filter(

--- a/src/katsdpcontroller/diagnose_insufficient.py
+++ b/src/katsdpcontroller/diagnose_insufficient.py
@@ -302,7 +302,7 @@ def _gpu_graphs(
                     for task in tasks:
                         if agent_filter(agent, task):
                             for req in task.logical_node.gpus:
-                                if req.matches(gpu, None):  # TODO: NUMA awareness
+                                if req.matches(gpu, None):  # TODO: NUMA awareness?
                                     g.add_edge(req, gpu)  # Infinity capacity
         yield g
 
@@ -349,7 +349,7 @@ def _interface_graphs(
                     for task in tasks:
                         if agent_filter(agent, task):
                             for req in task.logical_node.interfaces:
-                                if req.matches(interface, None):  # TODO: NUMA awareness
+                                if req.matches(interface, None):  # TODO: NUMA awareness?
                                     g = gs[req.network]
                                     g.add_edge(req, interface)  # Infinity capacity
         yield from gs.values()
@@ -421,7 +421,7 @@ def _diagnose_insufficient_filter(
     graphs.extend(_global_graphs(agents, tasks, agent_filter))
     graphs.extend(_gpu_graphs(agents, tasks, agent_filter))
     graphs.extend(_interface_graphs(agents, tasks, agent_filter))
-    # TODO: volumes? Not sure if they're needed
+    # volumes don't have resources, so nothing is needed for them here
 
     for g in graphs:
         _check_singletons(g)

--- a/src/katsdpcontroller/diagnose_insufficient.py
+++ b/src/katsdpcontroller/diagnose_insufficient.py
@@ -1,0 +1,392 @@
+import decimal
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import Enum
+from typing import Callable, List, Optional, Tuple, Union
+
+import networkx
+
+from . import scheduler
+from .scheduler import DECIMAL_CONTEXT, Agent, InsufficientResourcesError, PhysicalTask
+
+
+class ResourceGroup(Enum):
+    GLOBAL = 0
+    GPU = 1
+    INTERFACE = 2
+
+
+@dataclass
+class InsufficientResource:
+    """A resource that is unsatisfiable in :class:`InsufficientResourcesError`."""
+
+    resource: str  # Name of the resource
+    resource_group: ResourceGroup
+    network: Optional[str] = None  # Network name, if this is an INTERFACE resource
+
+    def __str__(self) -> str:
+        if self.resource_group == ResourceGroup.GLOBAL:
+            return self.resource
+        elif self.resource_group == ResourceGroup.GPU:
+            return f"GPU {self.resource}"
+        else:
+            ret = f"interface {self.resource}"
+            if self.network is not None:
+                ret += " on network " + self.network
+            return ret
+
+
+@dataclass
+class InsufficientRequester:
+    """A requester that need too much of a resource in :class:`InsufficientResourcesError`."""
+
+    task: PhysicalTask
+
+    def __str__(self) -> str:
+        return self.task.name
+
+
+@dataclass
+class InsufficientRequesterGPU(InsufficientRequester):
+    request_index: int
+
+    def __str__(self) -> str:
+        return f"{self.task.name} (GPU request #{self.request_index})"
+
+
+@dataclass
+class InsufficientRequesterInterface(InsufficientRequester):
+    request: scheduler.InterfaceRequest
+
+    def __str__(self) -> str:
+        return f"{self.task.name} (network {self.request.network})"
+
+
+@dataclass
+class InsufficientRequesterVolume(InsufficientRequester):
+    request: scheduler.VolumeRequest
+
+    def __str__(self) -> str:
+        return f"{self.task.name} (volume {self.request.name})"
+
+
+class TaskNoAgentError(InsufficientResourcesError):
+    """No agent was suitable for a task.
+
+    Where possible, a sub-class is used to indicate a more specific error.
+    """
+
+    def __init__(self, task: PhysicalTask) -> None:
+        super().__init__()
+        self.task = task
+
+    def __str__(self):
+        return f"No agent was found suitable for {self.task.name}"
+
+
+class TaskInsufficientResourcesError(TaskNoAgentError):
+    """A task required more of some resource than was available on any agent."""
+
+    def __init__(
+        self,
+        requester: InsufficientRequester,
+        resource: InsufficientResource,
+        needed: Union[int, Decimal],
+        available: Union[int, Decimal],
+    ) -> None:
+        super().__init__(requester.task)
+        self.requester = requester
+        self.resource = resource
+        self.needed = needed
+        self.available = available
+
+    def __str__(self):
+        return (
+            f"Not enough {self.resource} for {self.requester} on any agent "
+            f"({self.needed} > {self.available})"
+        )
+
+
+class TaskNoDeviceError(TaskNoAgentError):
+    """A task required a device that was not present on any agent."""
+
+    def __init__(self, requester: InsufficientRequester) -> None:
+        super().__init__(requester.task)
+        self.requester = requester
+
+    def __str__(self):
+        return f"{self.requester} could not be satisfied by any agent"
+
+
+class GroupInsufficientResourcesError(InsufficientResourcesError):
+    """A group of tasks collectively required more of some resource than available.
+
+    If `requesters_desc` is provided, it is a human-readable summary of the
+    requesters. If set to None, a description is generated.
+    """
+
+    def __init__(
+        self,
+        requesters: List[InsufficientRequester],
+        requesters_desc: Optional[str],
+        resource: InsufficientResource,
+        needed: Union[int, Decimal],
+        available: Union[int, Decimal],
+    ) -> None:
+        super().__init__()
+        self.requesters = requesters
+        if requesters_desc is None:
+            self.requesters_desc = ", ".join(str(r) for r in requesters)
+        else:
+            self.requesters_desc = requesters_desc
+        self.resource = resource
+        self.needed = needed
+        self.available = available
+
+    def __str__(self):
+        return (
+            f"Insufficient {self.resource} to launch {self.requesters_desc} "
+            f"({self.needed} > {self.available})"
+        )
+
+
+def _subset_resources(
+    g: networkx.DiGraph, task_filter: Callable[[PhysicalTask], bool]
+) -> Tuple[list, Union[int, Decimal], Union[int, Decimal]]:
+    """Measure the required and available resources for a subset of graph nodes.
+
+    Returns
+    -------
+    lhs
+        The graph nodes corresponding to the task filter
+    needed
+        The resources required by the nodes in `lhs`
+    available
+        The resources available on all the nodes reachable from `lhs`
+    """
+    lhs = [node for node in g.successors("src") if task_filter(g.nodes[node]["requester"].task)]
+    needed = sum(capacity for _, _, capacity in g.in_edges(lhs, data="capacity"))
+    rhs = set(n for _, n in g.out_edges(lhs, data=False))
+    available = sum(capacity for _, _, capacity in g.out_edges(rhs, data="capacity"))
+    return lhs, needed, available
+
+
+def _diagnose_insufficient_filter(
+    agents: List[Agent],
+    tasks: List[PhysicalTask],
+    agent_filter: Callable[[Agent, PhysicalTask], bool],
+) -> None:
+    """Implement :meth:`_diagnose_insufficient` with a specific edge filter.
+
+    This either raises a subclass of :class:`InsufficientResourcesError`,
+    or it returns if it couldn't identify a bottleneck. The `agent_filter`
+    determines whether a task may be placed on a particular agent.
+
+    The caller is responsible for setting DECIMAL_CONTEXT and excluding
+    non-tasks from the nodes.
+    """
+    graphs = []
+    # Global resources
+    for r, rcls in scheduler.GLOBAL_RESOURCES.items():
+        g = networkx.DiGraph(
+            resource_class=rcls, resource=InsufficientResource(r, ResourceGroup.GLOBAL)
+        )
+        graphs.append(g)
+        g.add_nodes_from(["src", "sink"])
+        for task in tasks:
+            logical_task = task.logical_node
+            need = logical_task.requests[r].amount
+            if need > rcls.ZERO:
+                g.add_node(task, requester=InsufficientRequester(task))
+                g.add_edge("src", task, capacity=need)
+
+        if r == "cores":
+            numas = [(agent, i) for agent in agents for i in range(len(agent.numa_cores))]
+            for numa in numas:
+                agent, numa_idx = numa
+                have = agent.numa_cores[numa_idx].available
+                if have > rcls.ZERO:
+                    g.add_node(numa)
+                    g.add_edge(numa, "sink", capacity=have)
+                    for task in tasks:
+                        if agent_filter(agent, task):  # TODO: use a numa_filter?
+                            g.add_edge(task, numa)
+        else:
+            for agent in agents:
+                have = agent.resources[r].available
+                if have > rcls.ZERO:
+                    g.add_node(agent)
+                    g.add_edge(agent, "sink", capacity=have)
+                    for task in tasks:
+                        if agent_filter(agent, task):
+                            g.add_edge(task, agent)  # Infinity capacity
+
+    # GPU resources
+    for r, rcls in scheduler.GPU_RESOURCES.items():
+        g = networkx.DiGraph(
+            resource_class=rcls, resource=InsufficientResource(r, ResourceGroup.GPU)
+        )
+        graphs.append(g)
+        g.add_nodes_from(["src", "sink"])
+        for task in tasks:
+            for i, req in enumerate(task.logical_node.gpus):
+                need = req.requests[r].amount
+                if need > rcls.ZERO:
+                    g.add_node(req, requester=InsufficientRequesterGPU(task, i))
+                    g.add_edge("src", req, capacity=need)
+        for agent in agents:
+            for gpu in agent.gpus:
+                have = gpu.resources[r].available
+                if have > rcls.ZERO:
+                    g.add_node(gpu)
+                    g.add_edge(gpu, "sink", capacity=have)
+                    for task in tasks:
+                        if agent_filter(agent, task):
+                            for req in task.logical_node.gpus:
+                                if req.matches(gpu, None):  # TODO: NUMA awareness
+                                    g.add_edge(req, gpu)  # Infinity capacity
+
+    # Network resources
+    # Start by identifying the networks
+    networks = set()
+    for task in tasks:
+        for req in task.logical_node.interfaces:
+            networks.add(req.network)
+    for agent in agents:
+        for interface in agent.interfaces:
+            for network in interface.networks:
+                networks.add(network)
+
+    for r, rcls in scheduler.INTERFACE_RESOURCES.items():
+        gs = {}
+        for network in networks:
+            g = networkx.DiGraph(
+                resource_class=rcls,
+                resource=InsufficientResource(r, ResourceGroup.INTERFACE, network=network),
+            )
+            graphs.append(g)
+            g.add_nodes_from(["src", "sink"])
+            gs[network] = g
+        for task in tasks:
+            for req in task.logical_node.interfaces:
+                need = req.requests[r].amount
+                if need > rcls.ZERO:
+                    g = gs[req.network]
+                    g.add_node(req, requester=InsufficientRequesterInterface(task, req))
+                    g.add_edge("src", req, capacity=need)
+        for agent in agents:
+            for interface in agent.interfaces:
+                have = interface.resources[r].available
+                if have > rcls.ZERO:
+                    for network in interface.networks:
+                        g = gs[network]
+                        g.add_node(interface)
+                        g.add_edge(interface, "sink", capacity=have)
+                    for task in tasks:
+                        if agent_filter(agent, task):
+                            for req in task.logical_node.interfaces:
+                                if req.matches(interface, None):  # TODO: NUMA awareness
+                                    g = gs[req.network]
+                                    g.add_edge(req, interface)  # Infinity capacity
+
+    # TODO: volumes
+
+    # First check if there is a singleton that cannot be allocated anywhere.
+    for g in graphs:
+        resource = g.graph["resource"]
+        rcls = g.graph["resource_class"]
+        for (_, lhs, need) in g.out_edges("src", data="capacity"):
+            have_max = rcls.ZERO
+            for (_, rhs) in g.out_edges(lhs, data=False):
+                have_max = max(have_max, g.edges[rhs, "sink"]["capacity"])
+            if need > have_max:
+                requester = g.nodes[lhs]["requester"]
+                raise TaskInsufficientResourcesError(requester, resource, need, have_max)
+
+    # Next, consider some fixed sets
+    sets = []
+    subsystems = {task.logical_node.subsystem for task in tasks}
+    subsystems.discard(None)  # Only want specific subsystems
+    for subsystem in sorted(subsystems):  # Sort just for reproducibility
+        sets.append(
+            (f"all {subsystem} tasks", lambda task: task.logical_node.subsystem == subsystem)
+        )
+    sets.append(("all tasks", lambda task: True))
+    for set_name, set_filter in sets:
+        for g in graphs:
+            lhs, need, have = _subset_resources(g, set_filter)
+            if need > have:
+                resource = g.graph["resource"]
+                requesters = [g.nodes[item]["requester"] for item in lhs]
+                raise GroupInsufficientResourcesError(requesters, set_name, resource, need, have)
+
+    # Now try to find a set of tasks that cannot be allocated, using the
+    # maxflow-mincut theorem.
+    for g in graphs:
+        total_need = sum(capacity for (_, _, capacity) in g.out_edges("src", data="capacity"))
+        cut_value, partition = networkx.minimum_cut(g, "src", "sink")
+        if cut_value < total_need:
+            # Maximum flow couldn't satisfy all the requirements. The
+            # tasks in the src side of the partition are unsatisfiable.
+            bad = [item for item in g.successors("src") if item in partition[0]]
+            need = sum(capacity for (_, _, capacity) in g.in_edges(bad, data="capacity"))
+            have = need - (total_need - cut_value)
+            resource = g.graph["resource"]
+            requesters = [g.nodes[item]["requester"] for item in bad]
+            raise GroupInsufficientResourcesError(requesters, None, resource, need, have)
+
+
+def diagnose_insufficient(agents, nodes):
+    """Try to determine *why* offers are insufficient.
+
+    This function does not return, instead raising an instance of
+    :exc:`InsufficientResourcesError` or a subclass.
+
+    Parameters
+    ----------
+    agents : list
+        :class:`Agent`s from which allocation was attempted
+    nodes : list
+        :class:`PhysicalNode`s for which allocation failed. This may
+        include non-tasks, which will be ignored.
+    """
+    with decimal.localcontext(DECIMAL_CONTEXT):
+        # Non-tasks aren't relevant, so filter them out.
+        tasks = [node for node in nodes if isinstance(node, PhysicalTask)]
+
+        _diagnose_insufficient_filter(
+            agents, tasks, lambda agent, task: task.logical_node.valid_agent(agent)
+        )
+        # Check for a task that doesn't fit anywhere
+        for task in tasks:
+            logical_task = task.logical_node
+            if not any(agent.can_allocate(logical_task) for agent in agents):
+                # Check if there is an interface/volume/GPU request that
+                # doesn't match anywhere.
+                for request in logical_task.interfaces:
+                    if not any(
+                        request.matches(interface, None)
+                        for agent in agents
+                        for interface in agent.interfaces
+                    ):
+                        raise TaskNoDeviceError(InsufficientRequesterInterface(task, request))
+                for request in logical_task.volumes:
+                    if not any(
+                        request.matches(volume, None)
+                        for agent in agents
+                        for volume in agent.volumes
+                    ):
+                        raise TaskNoDeviceError(InsufficientRequesterVolume(task, request))
+                for i, request in enumerate(logical_task.gpus):
+                    if not any(
+                        request.matches(gpu, None) for agent in agents for gpu in agent.gpus
+                    ):
+                        raise TaskNoDeviceError(InsufficientRequesterGPU(task, i))
+                raise TaskNoAgentError(task)
+
+        # Try the mincut algorithm again, but now with a stronger filter
+        _diagnose_insufficient_filter(
+            agents, tasks, lambda agent, task: agent.can_allocate(task.logical_node)
+        )
+        # Not a simple error e.g. due to packing problems
+        raise InsufficientResourcesError("Insufficient resources to launch all tasks")

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -228,17 +228,7 @@ from decimal import Decimal
 from enum import Enum
 
 # Note: don't include Dict here, because it conflicts with addict.Dict.
-from typing import (
-    AsyncContextManager,
-    Callable,
-    ClassVar,
-    List,
-    Mapping,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import AsyncContextManager, ClassVar, List, Mapping, Optional, Tuple, Type, Union
 
 import aiohttp.web
 import docker
@@ -1394,66 +1384,6 @@ class Resolver:
         self.http_url = http_url
 
 
-class ResourceGroup(Enum):
-    GLOBAL = 0
-    GPU = 1
-    INTERFACE = 2
-
-
-@dataclass
-class InsufficientResource:
-    """A resource that is unsatisfiable in :class:`InsufficientResourcesError`."""
-
-    resource: str  # Name of the resource
-    resource_group: ResourceGroup
-    network: Optional[str] = None  # Network name, if this is an INTERFACE resource
-
-    def __str__(self) -> str:
-        if self.resource_group == ResourceGroup.GLOBAL:
-            return self.resource
-        elif self.resource_group == ResourceGroup.GPU:
-            return f"GPU {self.resource}"
-        else:
-            ret = f"interface {self.resource}"
-            if self.network is not None:
-                ret += " on network " + self.network
-            return ret
-
-
-@dataclass
-class InsufficientRequester:
-    """A requester that need too much of a resource in :class:`InsufficientResourcesError`."""
-
-    task: "PhysicalTask"
-
-    def __str__(self) -> str:
-        return self.task.name
-
-
-@dataclass
-class InsufficientRequesterGPU(InsufficientRequester):
-    request_index: int
-
-    def __str__(self) -> str:
-        return f"{self.task.name} (GPU request #{self.request_index})"
-
-
-@dataclass
-class InsufficientRequesterInterface(InsufficientRequester):
-    request: InterfaceRequest
-
-    def __str__(self) -> str:
-        return f"{self.task.name} (network {self.request.network})"
-
-
-@dataclass
-class InsufficientRequesterVolume(InsufficientRequester):
-    request: VolumeRequest
-
-    def __str__(self) -> str:
-        return f"{self.task.name} (volume {self.request.name})"
-
-
 class InsufficientResourcesError(RuntimeError):
     """There are insufficient resources to launch a task or tasks.
 
@@ -1462,86 +1392,6 @@ class InsufficientResourcesError(RuntimeError):
     """
 
     pass
-
-
-class TaskNoAgentError(InsufficientResourcesError):
-    """No agent was suitable for a task.
-
-    Where possible, a sub-class is used to indicate a more specific error.
-    """
-
-    def __init__(self, task: "PhysicalTask") -> None:
-        super().__init__()
-        self.task = task
-
-    def __str__(self):
-        return f"No agent was found suitable for {self.task.name}"
-
-
-class TaskInsufficientResourcesError(TaskNoAgentError):
-    """A task required more of some resource than was available on any agent."""
-
-    def __init__(
-        self,
-        requester: InsufficientRequester,
-        resource: InsufficientResource,
-        needed: Union[int, Decimal],
-        available: Union[int, Decimal],
-    ) -> None:
-        super().__init__(requester.task)
-        self.requester = requester
-        self.resource = resource
-        self.needed = needed
-        self.available = available
-
-    def __str__(self):
-        return (
-            f"Not enough {self.resource} for {self.requester} on any agent "
-            f"({self.needed} > {self.available})"
-        )
-
-
-class TaskNoDeviceError(TaskNoAgentError):
-    """A task required a device that was not present on any agent."""
-
-    def __init__(self, requester: InsufficientRequester) -> None:
-        super().__init__(requester.task)
-        self.requester = requester
-
-    def __str__(self):
-        return f"{self.requester} could not be satisfied by any agent"
-
-
-class GroupInsufficientResourcesError(InsufficientResourcesError):
-    """A group of tasks collectively required more of some resource than available.
-
-    If `requesters_desc` is provided, it is a human-readable summary of the
-    requesters. If set to None, a description is generated.
-    """
-
-    def __init__(
-        self,
-        requesters: List[InsufficientRequester],
-        requesters_desc: Optional[str],
-        resource: InsufficientResource,
-        needed: Union[int, Decimal],
-        available: Union[int, Decimal],
-    ) -> None:
-        super().__init__()
-        self.requesters = requesters
-        if requesters_desc is None:
-            self.requesters_desc = ", ".join(str(r) for r in requesters)
-        else:
-            self.requesters_desc = requesters_desc
-        self.resource = resource
-        self.needed = needed
-        self.available = available
-
-    def __str__(self):
-        return (
-            f"Insufficient {self.resource} to launch {self.requesters_desc} "
-            f"({self.needed} > {self.available})"
-        )
 
 
 class QueueBusyError(InsufficientResourcesError):
@@ -3171,242 +3021,6 @@ class SchedulerBase:
             # crash).
             pass
 
-    @classmethod
-    def _diagnose_check_subset(
-        cls, g: networkx.DiGraph, task_filter: Callable[["PhysicalTask"], bool]
-    ) -> Tuple[list, Union[int, Decimal], Union[int, Decimal]]:
-        """Measure the required and available resources for a subset of graph nodes.
-
-        Returns
-        -------
-        lhs
-            The graph nodes corresponding to the task filter
-        needed
-            The resources required by the nodes in `lhs`
-        available
-            The resources available on all the nodes reachable from `lhs`
-        """
-        lhs = [node for node in g.successors("src") if task_filter(g.nodes[node]["requester"].task)]
-        needed = sum(capacity for _, _, capacity in g.in_edges(lhs, data="capacity"))
-        rhs = set(n for _, n in g.out_edges(lhs, data=False))
-        available = sum(capacity for _, _, capacity in g.out_edges(rhs, data="capacity"))
-        return lhs, needed, available
-
-    @classmethod
-    def _diagnose_insufficient_filter(cls, agents, tasks, agent_filter):
-        """Implement :meth:`_diagnose_insufficient` with a specific edge filter.
-
-        The caller is responsible for setting DECIMAL_CONTEXT and excluding
-        non-tasks from the nodes.
-        """
-        graphs = []
-        # Global resources
-        for r, rcls in GLOBAL_RESOURCES.items():
-            g = networkx.DiGraph(
-                resource_class=rcls, resource=InsufficientResource(r, ResourceGroup.GLOBAL)
-            )
-            graphs.append(g)
-            g.add_nodes_from(["src", "sink"])
-            for task in tasks:
-                logical_task = task.logical_node
-                need = logical_task.requests[r].amount
-                if need > rcls.ZERO:
-                    g.add_node(task, requester=InsufficientRequester(task))
-                    g.add_edge("src", task, capacity=need)
-
-            if r == "cores":
-                numas = [(agent, i) for agent in agents for i in range(len(agent.numa_cores))]
-                for numa in numas:
-                    agent, numa_idx = numa
-                    have = agent.numa_cores[numa_idx].available
-                    if have > rcls.ZERO:
-                        g.add_node(numa)
-                        g.add_edge(numa, "sink", capacity=have)
-                        for task in tasks:
-                            if agent_filter(agent, task):  # TODO: use a numa_filter?
-                                g.add_edge(task, numa)
-            else:
-                for agent in agents:
-                    have = agent.resources[r].available
-                    if have > rcls.ZERO:
-                        g.add_node(agent)
-                        g.add_edge(agent, "sink", capacity=have)
-                        for task in tasks:
-                            if agent_filter(agent, task):
-                                g.add_edge(task, agent)  # Infinity capacity
-
-        # GPU resources
-        for r, rcls in GPU_RESOURCES.items():
-            g = networkx.DiGraph(
-                resource_class=rcls, resource=InsufficientResource(r, ResourceGroup.GPU)
-            )
-            graphs.append(g)
-            g.add_nodes_from(["src", "sink"])
-            for task in tasks:
-                for i, req in enumerate(task.logical_node.gpus):
-                    need = req.requests[r].amount
-                    if need > rcls.ZERO:
-                        g.add_node(req, requester=InsufficientRequesterGPU(task, i))
-                        g.add_edge("src", req, capacity=need)
-            for agent in agents:
-                for gpu in agent.gpus:
-                    have = gpu.resources[r].available
-                    if have > rcls.ZERO:
-                        g.add_node(gpu)
-                        g.add_edge(gpu, "sink", capacity=have)
-                        for task in tasks:
-                            if agent_filter(agent, task):
-                                for req in task.logical_node.gpus:
-                                    if req.matches(gpu, None):  # TODO: NUMA awareness
-                                        g.add_edge(req, gpu)  # Infinity capacity
-
-        # Network resources
-        # Start by identifying the networks
-        networks = set()
-        for task in tasks:
-            for req in task.logical_node.interfaces:
-                networks.add(req.network)
-        for agent in agents:
-            for interface in agent.interfaces:
-                for network in interface.networks:
-                    networks.add(network)
-
-        for r, rcls in INTERFACE_RESOURCES.items():
-            gs = {}
-            for network in networks:
-                g = networkx.DiGraph(
-                    resource_class=rcls,
-                    resource=InsufficientResource(r, ResourceGroup.INTERFACE, network=network),
-                )
-                graphs.append(g)
-                g.add_nodes_from(["src", "sink"])
-                gs[network] = g
-            for task in tasks:
-                for req in task.logical_node.interfaces:
-                    need = req.requests[r].amount
-                    if need > rcls.ZERO:
-                        g = gs[req.network]
-                        g.add_node(req, requester=InsufficientRequesterInterface(task, req))
-                        g.add_edge("src", req, capacity=need)
-            for agent in agents:
-                for interface in agent.interfaces:
-                    have = interface.resources[r].available
-                    if have > rcls.ZERO:
-                        for network in interface.networks:
-                            g = gs[network]
-                            g.add_node(interface)
-                            g.add_edge(interface, "sink", capacity=have)
-                        for task in tasks:
-                            if agent_filter(agent, task):
-                                for req in task.logical_node.interfaces:
-                                    if req.matches(interface, None):  # TODO: NUMA awareness
-                                        g = gs[req.network]
-                                        g.add_edge(req, interface)  # Infinity capacity
-
-        # TODO: volumes
-
-        # First check if there is a singleton that cannot be allocated anywhere.
-        for g in graphs:
-            resource = g.graph["resource"]
-            rcls = g.graph["resource_class"]
-            for (_, lhs, need) in g.out_edges("src", data="capacity"):
-                have_max = rcls.ZERO
-                for (_, rhs) in g.out_edges(lhs, data=False):
-                    have_max = max(have_max, g.edges[rhs, "sink"]["capacity"])
-                if need > have_max:
-                    requester = g.nodes[lhs]["requester"]
-                    raise TaskInsufficientResourcesError(requester, resource, need, have_max)
-
-        # Next, consider some fixed sets
-        sets = []
-        subsystems = {task.logical_node.subsystem for task in tasks}
-        subsystems.discard(None)  # Only want specific subsystems
-        for subsystem in sorted(subsystems):  # Sort just for reproducibility
-            sets.append(
-                (f"all {subsystem} tasks", lambda task: task.logical_node.subsystem == subsystem)
-            )
-        sets.append(("all tasks", lambda task: True))
-        for set_name, set_filter in sets:
-            for g in graphs:
-                lhs, need, have = cls._diagnose_check_subset(g, set_filter)
-                if need > have:
-                    resource = g.graph["resource"]
-                    requesters = [g.nodes[item]["requester"] for item in lhs]
-                    raise GroupInsufficientResourcesError(
-                        requesters, set_name, resource, need, have
-                    )
-
-        # Now try to find a set of tasks that cannot be allocated, using the
-        # maxflow-mincut theorem.
-        for g in graphs:
-            total_need = sum(capacity for (_, _, capacity) in g.out_edges("src", data="capacity"))
-            cut_value, partition = networkx.minimum_cut(g, "src", "sink")
-            if cut_value < total_need:
-                # Maximum flow couldn't satisfy all the requirements. The
-                # tasks in the src side of the partition are unsatisfiable.
-                bad = [item for item in g.successors("src") if item in partition[0]]
-                need = sum(capacity for (_, _, capacity) in g.in_edges(bad, data="capacity"))
-                have = need - (total_need - cut_value)
-                resource = g.graph["resource"]
-                requesters = [g.nodes[item]["requester"] for item in bad]
-                raise GroupInsufficientResourcesError(requesters, None, resource, need, have)
-
-    @classmethod
-    def _diagnose_insufficient(cls, agents, nodes):
-        """Try to determine *why* offers are insufficient.
-
-        This function does not return, instead raising an instance of
-        :exc:`InsufficientResourcesError` or a subclass.
-
-        Parameters
-        ----------
-        agents : list
-            :class:`Agent`s from which allocation was attempted
-        nodes : list
-            :class:`PhysicalNode`s for which allocation failed. This may
-            include non-tasks, which will be ignored.
-        """
-        with decimal.localcontext(DECIMAL_CONTEXT):
-            # Non-tasks aren't relevant, so filter them out.
-            tasks = [node for node in nodes if isinstance(node, PhysicalTask)]
-
-            cls._diagnose_insufficient_filter(
-                agents, tasks, lambda agent, task: task.logical_node.valid_agent(agent)
-            )
-            # Check for a task that doesn't fit anywhere
-            for task in tasks:
-                logical_task = task.logical_node
-                if not any(agent.can_allocate(logical_task) for agent in agents):
-                    # Check if there is an interface/volume/GPU request that
-                    # doesn't match anywhere.
-                    for request in logical_task.interfaces:
-                        if not any(
-                            request.matches(interface, None)
-                            for agent in agents
-                            for interface in agent.interfaces
-                        ):
-                            raise TaskNoDeviceError(InsufficientRequesterInterface(task, request))
-                    for request in logical_task.volumes:
-                        if not any(
-                            request.matches(volume, None)
-                            for agent in agents
-                            for volume in agent.volumes
-                        ):
-                            raise TaskNoDeviceError(InsufficientRequesterVolume(task, request))
-                    for i, request in enumerate(logical_task.gpus):
-                        if not any(
-                            request.matches(gpu, None) for agent in agents for gpu in agent.gpus
-                        ):
-                            raise TaskNoDeviceError(InsufficientRequesterGPU(task, i))
-                    raise TaskNoAgentError(task)
-
-            # Try the mincut algorithm again, but now with a stronger filter
-            cls._diagnose_insufficient_filter(
-                agents, tasks, lambda agent, task: agent.can_allocate(task.logical_node)
-            )
-            # Not a simple error e.g. due to packing problems
-            raise InsufficientResourcesError("Insufficient resources to launch all tasks")
-
     def _update_agents_multicast(self, agents):
         """Update the multicast group information for a freshly minted set of :class:`Agent` s."""
         # The agent objects in active tasks are not the same Python objects
@@ -3489,7 +3103,9 @@ class SchedulerBase:
                         allocations.append((node, allocation))
                 if insufficient:
                     # Raises an InsufficientResourcesError
-                    self._diagnose_insufficient(orig_agents, nodes)
+                    from .diagnose_insufficient import diagnose_insufficient
+
+                    diagnose_insufficient(orig_agents, nodes)
             except InsufficientResourcesError as error:
                 logger.debug("Could not yet launch graph: %s", error)
                 group.last_insufficient = error
@@ -4266,17 +3882,7 @@ __all__ = [
     "ResourceAllocation",
     "GPUResources",
     "InterfaceResources",
-    "ResourceGroup",
-    "InsufficientResource",
-    "InsufficientRequester",
-    "InsufficientRequesterGPU",
-    "InsufficientRequesterInterface",
-    "InsufficientRequesterVolume",
     "InsufficientResourcesError",
-    "TaskNoAgentError",
-    "TaskInsufficientResourcesError",
-    "TaskNoDeviceError",
-    "GroupInsufficientResourcesError",
     "InterfaceRequest",
     "GPURequest",
     "Image",

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -1432,7 +1432,7 @@ class InsufficientRequester:
 
 @dataclass
 class InsufficientRequesterGPU(InsufficientRequester):
-    request_index: GPURequest
+    request_index: int
 
     def __str__(self) -> str:
         return f"{self.task.name} (GPU request #{self.request_index})"

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -2663,7 +2663,7 @@ class _LaunchGroup:
         A future that is set once the resources are acquired. The value is
         ``None``, so it is only useful to get completion (it is not used
         for exceptions; see :attr:`last_insufficient` instead).
-    last_insufficient : :class:`InsufficientResourcesError`
+    last_insufficient : :exc:`InsufficientResourcesError`
         An exception describing in more detail why there were insufficient
         resources. It is set to ``None`` once the resources are acquired.
     future : :class:`asyncio.Future`

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -1402,7 +1402,7 @@ class ResourceGroup(Enum):
 
 @dataclass
 class InsufficientResource:
-    """Describes the resource that is unsatisfiable in InsufficientResourcesError."""
+    """A resource that is unsatisfiable in :class:`InsufficientResourcesError`."""
 
     resource: str  # Name of the resource
     resource_group: ResourceGroup
@@ -1422,7 +1422,7 @@ class InsufficientResource:
 
 @dataclass
 class InsufficientRequester:
-    """Describes the requestor that need too much of a resource."""
+    """A requester that need too much of a resource in :class:`InsufficientResourcesError`."""
 
     task: "PhysicalTask"
 
@@ -1513,7 +1513,11 @@ class TaskNoDeviceError(TaskNoAgentError):
 
 
 class GroupInsufficientResourcesError(InsufficientResourcesError):
-    """A group of tasks collectively required more of some resource than available."""
+    """A group of tasks collectively required more of some resource than available.
+
+    If `requesters_desc` is provided, it is a human-readable summary of the
+    requesters. If set to None, a description is generated.
+    """
 
     def __init__(
         self,
@@ -3171,16 +3175,16 @@ class SchedulerBase:
     def _diagnose_check_subset(
         cls, g: networkx.DiGraph, task_filter: Callable[["PhysicalTask"], bool]
     ) -> Tuple[list, Union[int, Decimal], Union[int, Decimal]]:
-        """Check the required and available resources for a subset of graph nodes.
+        """Measure the required and available resources for a subset of graph nodes.
 
         Returns
         -------
         lhs
             The graph nodes corresponding to the task filter
         needed
-            The resources required by the nodes in `nodes`
+            The resources required by the nodes in `lhs`
         available
-            The resources available on all the nodes reachable from `nodes`
+            The resources available on all the nodes reachable from `lhs`
         """
         lhs = [node for node in g.successors("src") if task_filter(g.nodes[node]["requester"].task)]
         needed = sum(capacity for _, _, capacity in g.in_edges(lhs, data="capacity"))

--- a/test/test_diagnose_insufficient.py
+++ b/test/test_diagnose_insufficient.py
@@ -1,0 +1,364 @@
+import pytest
+
+from katsdpcontroller import scheduler
+from katsdpcontroller.diagnose_insufficient import (
+    GroupInsufficientResourcesError,
+    InsufficientRequesterGPU,
+    InsufficientRequesterInterface,
+    InsufficientRequesterVolume,
+    InsufficientResource,
+    InsufficientResourcesError,
+    ResourceGroup,
+    TaskInsufficientResourcesError,
+    TaskNoAgentError,
+    TaskNoDeviceError,
+    diagnose_insufficient,
+)
+
+from .utils import make_json_attr, make_offer
+
+
+class TestDiagnoseInsufficient:
+    """Test :class:`katsdpcontroller.diagnose_insufficient.diagnose_insufficient."""
+
+    def _make_offer(self, resources, agent_num=0, attrs=()):
+        return make_offer(
+            "frameworkid", f"agentid{agent_num}", f"agenthost{agent_num}", resources, attrs
+        )
+
+    def setup_method(self):
+        # Create a number of agents, each of which has a large quantity of
+        # some resource but not much of others. This makes it easier to
+        # control which resources are plentiful in the simulated cluster.
+        numa_attr = make_json_attr("katsdpcontroller.numa", [[0, 2, 4, 6], [1, 3, 5, 7]])
+        gpu_attr = make_json_attr(
+            "katsdpcontroller.gpus",
+            [
+                {
+                    "name": "Dummy GPU",
+                    "device_attributes": {},
+                    "compute_capability": (5, 2),
+                    "numa_node": 1,
+                    "uuid": "GPU-123",
+                }
+            ],
+        )
+        interface_attr = make_json_attr(
+            "katsdpcontroller.interfaces",
+            [
+                {
+                    "name": "eth0",
+                    "network": "net0",
+                    "ipv4_address": "192.168.1.1",
+                    "infiniband_devices": ["/dev/infiniband/rdma_cm", "/dev/infiniband/uverbs0"],
+                },
+                {"name": "eth1", "network": "net1", "ipv4_address": "192.168.1.2"},
+            ],
+        )
+        volume_attr = make_json_attr(
+            "katsdpcontroller.volumes", [{"name": "vol0", "host_path": "/host0"}]
+        )
+
+        self.cpus_agent = scheduler.Agent([self._make_offer({"cpus": 32, "mem": 2, "disk": 7}, 0)])
+        self.mem_agent = scheduler.Agent(
+            [self._make_offer({"cpus": 1.25, "mem": 256, "disk": 8}, 1)]
+        )
+        self.disk_agent = scheduler.Agent(
+            [self._make_offer({"cpus": 1.5, "mem": 3, "disk": 1024}, 2)]
+        )
+        self.ports_agent = scheduler.Agent(
+            [self._make_offer({"cpus": 1.75, "mem": 4, "disk": 9, "ports": [(30000, 30005)]}, 3)]
+        )
+        self.cores_agent = scheduler.Agent(
+            [self._make_offer({"cpus": 6, "mem": 5, "disk": 10, "cores": [(0, 6)]}, 4, [numa_attr])]
+        )
+        self.gpu_compute_agent = scheduler.Agent(
+            [
+                self._make_offer(
+                    {
+                        "cpus": 0.75,
+                        "mem": 6,
+                        "disk": 11,
+                        "katsdpcontroller.gpu.0.compute": 1.0,
+                        "katsdpcontroller.gpu.0.mem": 2.25,
+                    },
+                    5,
+                    [numa_attr, gpu_attr],
+                )
+            ]
+        )
+        self.gpu_mem_agent = scheduler.Agent(
+            [
+                self._make_offer(
+                    {
+                        "cpus": 1.0,
+                        "mem": 7,
+                        "disk": 11,
+                        "katsdpcontroller.gpu.0.compute": 0.125,
+                        "katsdpcontroller.gpu.0.mem": 256.0,
+                    },
+                    6,
+                    [numa_attr, gpu_attr],
+                )
+            ]
+        )
+        self.interface_agent = scheduler.Agent(
+            [
+                self._make_offer(
+                    {
+                        "cpus": 1.0,
+                        "mem": 1,
+                        "disk": 1,
+                        "katsdpcontroller.interface.0.bandwidth_in": 1e9,
+                        "katsdpcontroller.interface.0.bandwidth_out": 1e9,
+                        "katsdpcontroller.interface.1.bandwidth_in": 1e9,
+                        "katsdpcontroller.interface.1.bandwidth_out": 1e9,
+                    },
+                    7,
+                    [interface_attr],
+                )
+            ]
+        )
+        self.volume_agent = scheduler.Agent(
+            [self._make_offer({"cpus": 1.0, "mem": 1, "disk": 1}, 8, [volume_attr])]
+        )
+        # Create some template logical and physical tasks
+        self.logical_tasks = [scheduler.LogicalTask(f"logical{i}") for i in range(3)]
+        self.physical_tasks = [task.physical_factory(task) for task in self.logical_tasks]
+        for i, task in enumerate(self.physical_tasks):
+            task.name = f"physical{i}"
+
+    def test_task_insufficient_scalar_resource(self):
+        """A task requests more of a scalar resource than any agent has"""
+        self.logical_tasks[0].cpus = 4
+        with pytest.raises(TaskInsufficientResourcesError) as cm:
+            diagnose_insufficient([self.mem_agent, self.disk_agent], [self.physical_tasks[0]])
+        assert cm.value.task is self.physical_tasks[0]
+        assert cm.value.resource == InsufficientResource("cpus", ResourceGroup.GLOBAL)
+        assert cm.value.needed == 4
+        assert cm.value.available == 1.5
+        assert str(cm.value) == "Not enough cpus for physical0 on any agent (4.000 > 1.500)"
+
+    def test_task_insufficient_range_resource(self):
+        """A task requests more of a range resource than any agent has"""
+        self.logical_tasks[0].ports = ["a", "b", "c"]
+        with pytest.raises(TaskInsufficientResourcesError) as cm:
+            diagnose_insufficient([self.mem_agent, self.disk_agent], [self.physical_tasks[0]])
+        assert cm.value.task is self.physical_tasks[0]
+        assert cm.value.resource == InsufficientResource("ports", ResourceGroup.GLOBAL)
+        assert cm.value.needed == 3
+        assert cm.value.available == 0
+        assert str(cm.value) == "Not enough ports for physical0 on any agent (3 > 0)"
+
+    def test_task_insufficient_cores(self):
+        """A task requests more cores than are available on a single NUMA node"""
+        self.logical_tasks[0].cores = ["a", "b", "c", "d"]
+        with pytest.raises(TaskInsufficientResourcesError) as cm:
+            diagnose_insufficient([self.mem_agent, self.cores_agent], [self.physical_tasks[0]])
+        assert cm.value.task is self.physical_tasks[0]
+        assert cm.value.resource == InsufficientResource("cores", ResourceGroup.GLOBAL)
+        assert cm.value.needed == 4
+        assert cm.value.available == 3
+        assert str(cm.value) == "Not enough cores for physical0 on any agent (4 > 3)"
+
+    def test_task_insufficient_gpu_scalar_resource(self):
+        """A task requests more of a GPU scalar resource than any agent has"""
+        req = scheduler.GPURequest()
+        req.mem = 2048
+        self.logical_tasks[0].gpus = [req]
+        with pytest.raises(TaskInsufficientResourcesError) as cm:
+            diagnose_insufficient(
+                [self.mem_agent, self.gpu_compute_agent], [self.physical_tasks[0]]
+            )
+        assert cm.value.task is self.physical_tasks[0]
+        assert cm.value.requester == InsufficientRequesterGPU(self.physical_tasks[0], 0)
+        assert cm.value.resource == InsufficientResource("mem", ResourceGroup.GPU)
+        assert cm.value.needed == 2048
+        assert cm.value.available == 2.25
+        assert (
+            str(cm.value)
+            == "Not enough GPU mem for physical0 (GPU request #0) on any agent (2048.000 > 2.250)"
+        )
+
+    def test_task_insufficient_interface_scalar_resources(self):
+        """A task requests more of an interface scalar resource than any agent has"""
+        req = scheduler.InterfaceRequest("net0")
+        req.bandwidth_in = 5e9
+        self.logical_tasks[0].interfaces = [req]
+        with pytest.raises(TaskInsufficientResourcesError) as cm:
+            diagnose_insufficient([self.mem_agent, self.interface_agent], [self.physical_tasks[0]])
+        assert cm.value.task is self.physical_tasks[0]
+        assert cm.value.requester == InsufficientRequesterInterface(self.physical_tasks[0], req)
+        assert cm.value.resource == InsufficientResource(
+            "bandwidth_in", ResourceGroup.INTERFACE, "net0"
+        )
+        assert cm.value.needed == 5e9
+        assert cm.value.available == 1e9
+        assert (
+            str(cm.value) == "Not enough interface bandwidth_in on network net0 for "
+            "physical0 (network net0) on any agent (5000000000.000 > 1000000000.000)"
+        )
+
+    def test_task_no_interface(self):
+        """A task requests a network interface that is not available on any agent"""
+        self.logical_tasks[0].interfaces = [
+            scheduler.InterfaceRequest("net0"),
+            scheduler.InterfaceRequest("badnet"),
+        ]
+        with pytest.raises(TaskNoDeviceError) as cm:
+            diagnose_insufficient([self.mem_agent, self.interface_agent], [self.physical_tasks[0]])
+        assert cm.value.task is self.physical_tasks[0]
+        assert cm.value.requester == InsufficientRequesterInterface(
+            self.physical_tasks[0], self.logical_tasks[0].interfaces[1]
+        )
+        assert str(cm.value) == "physical0 (network badnet) could not be satisfied by any agent"
+
+    def test_task_no_volume(self):
+        """A task requests a volume that is not available on any agent"""
+        self.logical_tasks[0].volumes = [
+            scheduler.VolumeRequest("vol0", "/vol0", "RW"),
+            scheduler.VolumeRequest("badvol", "/badvol", "RO"),
+        ]
+        with pytest.raises(TaskNoDeviceError) as cm:
+            diagnose_insufficient([self.mem_agent, self.volume_agent], [self.physical_tasks[0]])
+        assert cm.value.task is self.physical_tasks[0]
+        assert cm.value.requester == InsufficientRequesterVolume(
+            self.physical_tasks[0], self.logical_tasks[0].volumes[1]
+        )
+        assert str(cm.value) == "physical0 (volume badvol) could not be satisfied by any agent"
+
+    def test_task_no_gpu(self):
+        """A task requests a GPU that is not available on any agent"""
+        req = scheduler.GPURequest()
+        req.name = "GPU that does not exist"
+        self.logical_tasks[0].gpus = [req]
+        with pytest.raises(TaskNoDeviceError) as cm:
+            diagnose_insufficient(
+                [self.mem_agent, self.gpu_compute_agent], [self.physical_tasks[0]]
+            )
+        assert cm.value.task == self.physical_tasks[0]
+        assert cm.value.requester == InsufficientRequesterGPU(self.physical_tasks[0], 0)
+        assert str(cm.value) == "physical0 (GPU request #0) could not be satisfied by any agent"
+
+    def test_task_no_agent(self):
+        """A task does not fit on any agent, but not due to a single reason"""
+        # Ask for more combined cpu+ports than is available on one agent
+        self.logical_tasks[0].cpus = 8
+        self.logical_tasks[0].ports = ["a", "b", "c"]
+        with pytest.raises(TaskNoAgentError) as cm:
+            diagnose_insufficient([self.cpus_agent, self.ports_agent], [self.physical_tasks[0]])
+        assert cm.value.task is self.physical_tasks[0]
+        # Make sure that it didn't incorrectly return a subclass
+        assert cm.type == TaskNoAgentError
+        assert str(cm.value) == "No agent was found suitable for physical0"
+
+    def test_group_insufficient_scalar_resource(self):
+        """A group of tasks require more of a scalar resource than available"""
+        self.logical_tasks[0].cpus = 24
+        self.logical_tasks[1].cpus = 16
+        with pytest.raises(GroupInsufficientResourcesError) as cm:
+            diagnose_insufficient([self.cpus_agent, self.mem_agent], self.physical_tasks[:2])
+        assert cm.value.requesters_desc == "all tasks"
+        assert cm.value.resource == InsufficientResource("cpus", ResourceGroup.GLOBAL)
+        assert cm.value.needed == 40
+        assert cm.value.available == 33.25
+        assert str(cm.value) == "Insufficient cpus to launch all tasks (40.000 > 33.250)"
+
+    def test_group_insufficient_range_resource(self):
+        """A group of tasks require more of a range resource than available"""
+        self.logical_tasks[0].ports = ["a", "b", "c"]
+        self.logical_tasks[1].ports = ["d", "e", "f"]
+        with pytest.raises(GroupInsufficientResourcesError) as cm:
+            diagnose_insufficient([self.ports_agent], self.physical_tasks[:2])
+        assert cm.value.requesters_desc == "all tasks"
+        assert cm.value.resource == InsufficientResource("ports", ResourceGroup.GLOBAL)
+        assert cm.value.needed == 6
+        assert cm.value.available == 5
+        assert str(cm.value) == "Insufficient ports to launch all tasks (6 > 5)"
+
+    def test_group_insufficient_gpu_scalar_resources(self):
+        """A group of tasks require more of a GPU scalar resource than available"""
+        self.logical_tasks[0].gpus = [scheduler.GPURequest()]
+        self.logical_tasks[0].gpus[-1].compute = 0.75
+        self.logical_tasks[1].gpus = [scheduler.GPURequest()]
+        self.logical_tasks[1].gpus[-1].compute = 0.5
+        with pytest.raises(GroupInsufficientResourcesError) as cm:
+            diagnose_insufficient(
+                [self.gpu_compute_agent, self.gpu_mem_agent],
+                self.physical_tasks[:2],
+            )
+        assert cm.value.requesters_desc == "all tasks"
+        assert cm.value.resource == InsufficientResource("compute", ResourceGroup.GPU)
+        assert cm.value.needed == 1.25
+        assert cm.value.available == 1.125
+        assert str(cm.value) == "Insufficient GPU compute to launch all tasks (1.250 > 1.125)"
+
+    def test_group_insufficient_interface_scalar_resources(self):
+        """A group of tasks require more of a network resource than available"""
+        self.logical_tasks[0].interfaces = [
+            scheduler.InterfaceRequest("net0"),
+            scheduler.InterfaceRequest("net1"),
+        ]
+        self.logical_tasks[0].interfaces[0].bandwidth_in = 800e6
+        # An amount that must not be added to the needed value reported
+        self.logical_tasks[0].interfaces[1].bandwidth_in = 50e6
+        self.logical_tasks[1].interfaces = [scheduler.InterfaceRequest("net0")]
+        self.logical_tasks[1].interfaces[0].bandwidth_in = 700e6
+        with pytest.raises(GroupInsufficientResourcesError) as cm:
+            diagnose_insufficient([self.interface_agent], self.physical_tasks[:2])
+        assert cm.value.requesters_desc == "all tasks"
+        assert cm.value.resource == InsufficientResource(
+            "bandwidth_in", ResourceGroup.INTERFACE, "net0"
+        )
+        assert cm.value.needed == 1500e6
+        assert cm.value.available == 1000e6
+        assert (
+            str(cm.value) == "Insufficient interface bandwidth_in on network net0 "
+            "to launch all tasks (1500000000.000 > 1000000000.000)"
+        )
+
+    def test_subsystem(self):
+        """A subsystem has insufficient resources, although the system has enough."""
+        self.logical_tasks[0].subsystem = "sdp"
+        self.logical_tasks[0].cpus = 32  # Consumes all of cpus_agent
+        self.logical_tasks[1].subsystem = "sdp"
+        self.logical_tasks[1].cpus = 1
+        self.cpus_agent.subsystems = {"sdp"}
+        self.cores_agent.subsystems = {"cbf", "other"}
+        with pytest.raises(GroupInsufficientResourcesError) as cm:
+            diagnose_insufficient([self.cpus_agent, self.cores_agent], self.physical_tasks[:2])
+        assert cm.value.requesters_desc == "all sdp tasks"
+        assert cm.value.resource == InsufficientResource("cpus", ResourceGroup.GLOBAL)
+        assert cm.value.needed == 33
+        assert cm.value.available == 32
+        assert str(cm.value) == "Insufficient cpus to launch all sdp tasks (33.000 > 32.000)"
+
+    def test_subset(self):
+        """A subset of the tasks has insufficient resources, although the system has enough."""
+        # Tasks 1 and 2 can each only run on cpus_agent, but can't both fit
+        self.logical_tasks[0].cpus = 17
+        self.logical_tasks[1].cpus = 17
+        self.logical_tasks[2].cpus = 1
+        with pytest.raises(GroupInsufficientResourcesError) as cm:
+            diagnose_insufficient([self.cpus_agent, self.cores_agent], self.physical_tasks[:3])
+        assert cm.value.requesters_desc == "physical0, physical1"
+        assert cm.value.resource == InsufficientResource("cpus", ResourceGroup.GLOBAL)
+        assert cm.value.needed == 34
+        assert cm.value.available == 32
+        assert str(cm.value) == "Insufficient cpus to launch physical0, physical1 (34.000 > 32.000)"
+
+    def test_generic(self):
+        """A group of tasks can't fit, but no simpler explanation is available"""
+        # Create a task that uses just too much memory for the
+        # low-memory agents, forcing it to consume memory from the
+        # big-memory agent and not leaving enough for the big-memory task.
+        self.logical_tasks[0].mem = 5
+        self.logical_tasks[1].mem = 251
+        with pytest.raises(InsufficientResourcesError) as cm:
+            diagnose_insufficient(
+                [self.cpus_agent, self.mem_agent, self.disk_agent],
+                self.physical_tasks[:2],
+            )
+        # Check that it wasn't a subclass raised
+        assert cm.type == InsufficientResourcesError
+        assert str(cm.value) == "Insufficient resources to launch all tasks"

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -1696,10 +1696,10 @@ class TestDiagnoseInsufficient:
             scheduler.Scheduler._diagnose_insufficient(
                 [self.cpus_agent, self.cores_agent], [self.physical_task, self.physical_task2]
             )
-        assert cm.value.resource == "cpus"
+        assert cm.value.requesters_desc == "all sdp tasks"
+        assert cm.value.resource == InsufficientResource("cpus", ResourceGroup.GLOBAL)
         assert cm.value.needed == 33
         assert cm.value.available == 32
-        assert cm.value.subsystem == "sdp"
 
     def test_generic(self):
         """A group of tasks can't fit, but no simpler explanation is available"""

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -1,11 +1,9 @@
 import asyncio
 import base64
 import ipaddress
-import json
 import logging
 import socket
 import time
-import uuid
 from collections import Counter
 from decimal import Decimal
 from typing import Any, AsyncGenerator, Callable, Generator, Optional
@@ -22,40 +20,18 @@ from addict import Dict
 from yarl import URL
 
 from katsdpcontroller import scheduler
-from katsdpcontroller.scheduler import (
-    InsufficientRequesterGPU,
-    InsufficientRequesterInterface,
-    InsufficientRequesterVolume,
-    InsufficientResource,
-    ResourceGroup,
-    TaskState,
+from katsdpcontroller.diagnose_insufficient import TaskInsufficientResourcesError
+from katsdpcontroller.scheduler import TaskState
+
+from .utils import (
+    AnyOrderList,
+    exhaust_callbacks,
+    future_return,
+    make_json_attr,
+    make_offer,
+    make_resources,
+    make_text_attr,
 )
-
-from .utils import exhaust_callbacks, future_return
-
-
-class AnyOrderList(list):
-    """Used for asserting that a list is present in a call, but without
-    constraining the order. It does not require the elements to be hashable.
-    """
-
-    def __eq__(self, other):
-        if isinstance(other, list):
-            if len(self) != len(other):
-                return False
-            tmp = list(other)
-            for item in self:
-                try:
-                    tmp.remove(item)
-                except ValueError:
-                    return False
-            return True
-        return NotImplemented
-
-    def __ne__(self, other):
-        if isinstance(other, list):
-            return not (self == other)
-        return NotImplemented
 
 
 class SimpleTaskStats(scheduler.TaskStats):
@@ -721,48 +697,6 @@ class TestTaskIDAllocator:
         assert tid1 == "test-baz-00000001"
 
 
-def _make_resources(resources, role="default"):
-    out = AnyOrderList()
-    for name, value in resources.items():
-        resource = Dict()
-        resource.name = name
-        resource.allocation_info.role = role
-        if isinstance(value, (int, float)):
-            resource.type = "SCALAR"
-            resource.scalar.value = float(value)
-        else:
-            resource.type = "RANGES"
-            resource.ranges.range = []
-            for start, stop in value:
-                resource.ranges.range.append(Dict(begin=start, end=stop - 1))
-        out.append(resource)
-    return out
-
-
-def _make_text_attr(name, value):
-    attr = Dict()
-    attr.name = name
-    attr.type = "TEXT"
-    attr.text.value = value
-    return attr
-
-
-def _make_json_attr(name, value):
-    return _make_text_attr(name, base64.urlsafe_b64encode(json.dumps(value).encode("utf-8")))
-
-
-def _make_offer(framework_id, agent_id, host, resources, attrs=(), role="default"):
-    offer = Dict()
-    offer.id.value = uuid.uuid4().hex
-    offer.framework_id.value = framework_id
-    offer.agent_id.value = agent_id
-    offer.allocation_info.role = role
-    offer.hostname = host
-    offer.resources = _make_resources(resources, role)
-    offer.attributes = attrs
-    return offer
-
-
 def _make_status(task_id, state):
     status = Dict()
     status.task_id.value = task_id
@@ -773,14 +707,14 @@ def _make_status(task_id, state):
 class TestAgent:
     """Tests for :class:`katsdpcontroller.scheduler.Agent`."""
 
-    def _make_offer(self, resources, attrs=()):
-        return _make_offer(self.framework_id, self.agent_id, self.host, resources, attrs)
+    def make_offer(self, resources, attrs=()):
+        return make_offer(self.framework_id, self.agent_id, self.host, resources, attrs)
 
     def setup_method(self):
         self.agent_id = "agentid"
         self.host = "agenthostname"
         self.framework_id = "framework"
-        self.if_attr = _make_json_attr(
+        self.if_attr = make_json_attr(
             "katsdpcontroller.interfaces",
             [
                 {
@@ -794,7 +728,7 @@ class TestAgent:
             ],
         )
         # Same as if_attr but without infiniband_multicast_loopback
-        self.if_attr_loopback = _make_json_attr(
+        self.if_attr_loopback = make_json_attr(
             "katsdpcontroller.interfaces",
             [
                 {
@@ -806,18 +740,18 @@ class TestAgent:
                 }
             ],
         )
-        self.if_attr_bad_json = _make_text_attr(
+        self.if_attr_bad_json = make_text_attr(
             "katsdpcontroller.interfaces", base64.urlsafe_b64encode(b"{not valid json")
         )
-        self.if_attr_bad_schema = _make_json_attr("katsdpcontroller.interfaces", [{"name": "eth1"}])
-        self.volume_attr = _make_json_attr(
+        self.if_attr_bad_schema = make_json_attr("katsdpcontroller.interfaces", [{"name": "eth1"}])
+        self.volume_attr = make_json_attr(
             "katsdpcontroller.volumes",
             [
                 {"name": "vol1", "host_path": "/host1"},
                 {"name": "vol2", "host_path": "/host2", "numa_node": 1},
             ],
         )
-        self.gpu_attr = _make_json_attr(
+        self.gpu_attr = make_json_attr(
             "katsdpcontroller.gpus",
             [
                 {
@@ -836,8 +770,8 @@ class TestAgent:
                 },
             ],
         )
-        self.numa_attr = _make_json_attr("katsdpcontroller.numa", [[0, 2, 4, 6], [1, 3, 5, 7]])
-        self.subsystem_attr = _make_json_attr(
+        self.numa_attr = make_json_attr("katsdpcontroller.numa", [[0, 2, 4, 6], [1, 3, 5, 7]])
+        self.subsystem_attr = make_json_attr(
             "katsdpcontroller.subsystems", ["subsystem1", "subsystem2"]
         )
         self.priority_attr = Dict()
@@ -849,11 +783,11 @@ class TestAgent:
         """Construct an agent from some offers"""
         attrs = [self.if_attr, self.volume_attr, self.gpu_attr, self.numa_attr, self.priority_attr]
         offers = [
-            self._make_offer(
+            self.make_offer(
                 {"cpus": 4.0, "mem": 1024.0, "ports": [(100, 200), (300, 350)], "cores": [(0, 7)]},
                 attrs,
             ),
-            self._make_offer(
+            self.make_offer(
                 {
                     "cpus": 0.5,
                     "mem": 123.5,
@@ -866,7 +800,7 @@ class TestAgent:
                 },
                 attrs,
             ),
-            self._make_offer(
+            self.make_offer(
                 {
                     "katsdpcontroller.gpu.0.compute": 0.5,
                     "katsdpcontroller.gpu.0.mem": 1024.0,
@@ -913,7 +847,7 @@ class TestAgent:
     def test_construct_implicit_priority(self):
         """Test computation of priority when none is given"""
         attrs = [self.if_attr, self.volume_attr, self.gpu_attr, self.numa_attr]
-        offers = [self._make_offer({"cpus": 0.5, "mem": 123.5, "disk": 1024.5}, attrs)]
+        offers = [self.make_offer({"cpus": 0.5, "mem": 123.5, "disk": 1024.5}, attrs)]
         agent = scheduler.Agent(offers)
         assert agent.priority == 5
 
@@ -924,7 +858,7 @@ class TestAgent:
 
     def test_special_disk_resource(self):
         """A resource for a non-root disk is ignored"""
-        offers = [self._make_offer({"disk": 1024})]
+        offers = [self.make_offer({"disk": 1024})]
         # Example from https://mesos.apache.org/documentation/latest/multiple-disk/
         offers[0].resources[0].disk.source.type = "PATH"
         offers[0].resources[0].disk.source.path.root = "/mnt/data"
@@ -933,7 +867,7 @@ class TestAgent:
 
     def test_bad_json(self, caplog):
         """A warning must be printed if an interface description is not valid JSON"""
-        offers = [self._make_offer({}, [self.if_attr_bad_json])]
+        offers = [self.make_offer({}, [self.if_attr_bad_json])]
         with caplog.at_level(logging.WARNING, logger="katsdpcontroller.scheduler"):
             agent = scheduler.Agent(offers)
         assert "Could not parse" in caplog.text
@@ -941,7 +875,7 @@ class TestAgent:
 
     def test_bad_schema(self, caplog):
         """A warning must be printed if an interface description does not conform to the schema"""
-        offers = [self._make_offer({}, [self.if_attr_bad_schema])]
+        offers = [self.make_offer({}, [self.if_attr_bad_schema])]
         with caplog.at_level(logging.WARNING, logger="katsdpcontroller.scheduler"):
             agent = scheduler.Agent(offers)
         assert "Validation error" in caplog.text
@@ -951,7 +885,7 @@ class TestAgent:
         """allocate raises if the task does not accept the agent"""
         task = scheduler.LogicalTask("task")
         task.valid_agent = lambda x: False
-        agent = scheduler.Agent([self._make_offer({}, [])])
+        agent = scheduler.Agent([self.make_offer({}, [])])
         with pytest.raises(scheduler.InsufficientResourcesError):
             agent.allocate(task)
 
@@ -959,7 +893,7 @@ class TestAgent:
         """allocate raises if the task is owned by a subsystem not valid on the agent"""
         task = scheduler.LogicalTask("task")
         task.subsystem = "foo"
-        agent = scheduler.Agent([self._make_offer({}, [self.subsystem_attr])])
+        agent = scheduler.Agent([self.make_offer({}, [self.subsystem_attr])])
         with pytest.raises(scheduler.InsufficientResourcesError):
             agent.allocate(task)
 
@@ -967,7 +901,7 @@ class TestAgent:
         """allocate raises if the task requires too much of a scalar resource"""
         task = scheduler.LogicalTask("task")
         task.cpus = 4.0
-        agent = scheduler.Agent([self._make_offer({"cpus": 2.0}, [])])
+        agent = scheduler.Agent([self.make_offer({"cpus": 2.0}, [])])
         with pytest.raises(scheduler.InsufficientResourcesError):
             agent.allocate(task)
 
@@ -975,7 +909,7 @@ class TestAgent:
         """allocate raises if the task requires too much of a range resource"""
         task = scheduler.LogicalTask("task")
         task.cores = [None] * 3
-        agent = scheduler.Agent([self._make_offer({"cores": [(4, 6)]}, [])])
+        agent = scheduler.Agent([self.make_offer({"cores": [(4, 6)]}, [])])
         with pytest.raises(scheduler.InsufficientResourcesError):
             agent.allocate(task)
 
@@ -983,7 +917,7 @@ class TestAgent:
         """allocate raises if the task requires a network that is not present"""
         task = scheduler.LogicalTask("task")
         task.interfaces = [scheduler.InterfaceRequest("net0"), scheduler.InterfaceRequest("net1")]
-        agent = scheduler.Agent([self._make_offer({}, [self.if_attr])])
+        agent = scheduler.Agent([self.make_offer({}, [self.if_attr])])
         with pytest.raises(scheduler.InsufficientResourcesError):
             agent.allocate(task)
 
@@ -991,7 +925,7 @@ class TestAgent:
         """allocate raises if the task requires a volume that is not present"""
         task = scheduler.LogicalTask("task")
         task.volumes = [scheduler.VolumeRequest("vol-missing", "/container-path", "RW")]
-        agent = scheduler.Agent([self._make_offer({}, [self.volume_attr])])
+        agent = scheduler.Agent([self.make_offer({}, [self.volume_attr])])
         with pytest.raises(scheduler.InsufficientResourcesError):
             agent.allocate(task)
 
@@ -1003,7 +937,7 @@ class TestAgent:
         task.gpus[-1].mem = 3000.0
         agent = scheduler.Agent(
             [
-                self._make_offer(
+                self.make_offer(
                     {
                         "katsdpcontroller.gpu.0.compute": 1.0,
                         "katsdpcontroller.gpu.0.mem": 2048.0,
@@ -1024,7 +958,7 @@ class TestAgent:
         task.interfaces[-1].bandwidth_in = 1200e6
         agent = scheduler.Agent(
             [
-                self._make_offer(
+                self.make_offer(
                     {
                         "katsdpcontroller.interface.0.bandwidth_in": 1000e6,
                         "katsdpcontroller.interface.0.bandwidth_out": 2000e6,
@@ -1046,7 +980,7 @@ class TestAgent:
         task.interfaces[-1].multicast_out |= {"mc"}
         agent = scheduler.Agent(
             [
-                self._make_offer(
+                self.make_offer(
                     {
                         "katsdpcontroller.interface.0.bandwidth_in": 1000e6,
                         "katsdpcontroller.interface.0.bandwidth_out": 2000e6,
@@ -1069,7 +1003,7 @@ class TestAgent:
         task.interfaces[-1].multicast_in |= {"mc"}
         agent = scheduler.Agent(
             [
-                self._make_offer(
+                self.make_offer(
                     {
                         "katsdpcontroller.interface.0.bandwidth_in": 1000e6,
                         "katsdpcontroller.interface.0.bandwidth_out": 2000e6,
@@ -1089,7 +1023,7 @@ class TestAgent:
         task.interfaces[-1].multicast_out |= {"mc"}
         agent = scheduler.Agent(
             [
-                self._make_offer(
+                self.make_offer(
                     {
                         "katsdpcontroller.interface.0.bandwidth_in": 1000e6,
                         "katsdpcontroller.interface.0.bandwidth_out": 2000e6,
@@ -1109,7 +1043,7 @@ class TestAgent:
         task.interfaces[-1].multicast_out |= {"mc"}
         agent = scheduler.Agent(
             [
-                self._make_offer(
+                self.make_offer(
                     {
                         "katsdpcontroller.interface.0.bandwidth_in": 1000e6,
                         "katsdpcontroller.interface.0.bandwidth_out": 2000e6,
@@ -1130,7 +1064,7 @@ class TestAgent:
         task.cores = ["a", "b", None]
         agent = scheduler.Agent(
             [
-                self._make_offer(
+                self.make_offer(
                     {
                         "cpus": 5.0,
                         "mem": 200.0,
@@ -1156,7 +1090,7 @@ class TestAgent:
         task.gpus[-1].affinity = True
         agent = scheduler.Agent(
             [
-                self._make_offer(
+                self.make_offer(
                     {
                         "cpus": 5.0,
                         "mem": 200.0,
@@ -1183,7 +1117,7 @@ class TestAgent:
         task.interfaces.append(scheduler.InterfaceRequest("net0", affinity=True))
         agent = scheduler.Agent(
             [
-                self._make_offer(
+                self.make_offer(
                     {"cpus": 5.0, "mem": 200.0, "cores": [(0, 5)]}, [self.if_attr, self.numa_attr]
                 )
             ]
@@ -1198,7 +1132,7 @@ class TestAgent:
         task.cpus = 1.0
         task.mem = 128.0
         task.interfaces.append(scheduler.InterfaceRequest("net0", infiniband=True))
-        if_attr = _make_json_attr(
+        if_attr = make_json_attr(
             "katsdpcontroller.interfaces",
             [
                 {
@@ -1211,7 +1145,7 @@ class TestAgent:
             ],
         )
         agent = scheduler.Agent(
-            [self._make_offer({"cpus": 5.0, "mem": 200.0, "cores": [(0, 5)]}, [if_attr])]
+            [self.make_offer({"cpus": 5.0, "mem": 200.0, "cores": [(0, 5)]}, [if_attr])]
         )
         with pytest.raises(scheduler.InsufficientResourcesError):
             agent.allocate(task)
@@ -1226,7 +1160,7 @@ class TestAgent:
         task.volumes.append(scheduler.VolumeRequest("vol2", "/container-path", "RW", affinity=True))
         agent = scheduler.Agent(
             [
-                self._make_offer(
+                self.make_offer(
                     {"cpus": 5.0, "mem": 200.0, "cores": [(0, 5)]},
                     [self.volume_attr, self.numa_attr],
                 )
@@ -1253,7 +1187,7 @@ class TestAgent:
         task.gpus[1].affinity = True
         agent = scheduler.Agent(
             [
-                self._make_offer(
+                self.make_offer(
                     {
                         "cpus": 4.0,
                         "mem": 200.0,
@@ -1320,21 +1254,21 @@ class TestPhysicalTask:
         self.eth1.bandwidth_out = 200e6
         self.vol0 = scheduler.Volume("vol0", "/host0", numa_node=1)
         attributes = [
-            _make_json_attr(
+            make_json_attr(
                 "katsdpcontroller.interfaces",
                 [
                     {"name": "eth0", "network": "net0", "ipv4_address": "192.168.1.1"},
                     {"name": "eth1", "network": "net1", "ipv4_address": "192.168.2.1"},
                 ],
             ),
-            _make_json_attr(
+            make_json_attr(
                 "katsdpcontroller.volumes",
                 [{"name": "vol0", "host_path": "/host0", "numa_node": 1}],
             ),
-            _make_json_attr("katsdpcontroller.numa", [[0, 2, 4, 6], [1, 3, 5, 7]]),
+            make_json_attr("katsdpcontroller.numa", [[0, 2, 4, 6], [1, 3, 5, 7]]),
         ]
         offers = [
-            _make_offer(
+            make_offer(
                 "framework",
                 "agentid",
                 "agenthost",
@@ -1386,377 +1320,6 @@ class TestPhysicalTask:
         assert physical_task.ports["port2"] in range(30000, 31001)
         assert physical_task.ports["port1"] != physical_task.ports["port2"]
         assert physical_task.cores == {"core1": 2, "core2": 4, "core3": 6}
-
-
-class TestDiagnoseInsufficient:
-    """Test :class:`katsdpcontroller.scheduler.Scheduler._diagnose_insufficient.
-
-    This is split out from TestScheduler to make it easier to set up fixtures.
-    """
-
-    def _make_offer(self, resources, agent_num=0, attrs=()):
-        return _make_offer(
-            "frameworkid", f"agentid{agent_num}", f"agenthost{agent_num}", resources, attrs
-        )
-
-    def setup_method(self):
-        # Create a number of agents, each of which has a large quantity of
-        # some resource but not much of others. This makes it easier to
-        # control which resources are plentiful in the simulated cluster.
-        numa_attr = _make_json_attr("katsdpcontroller.numa", [[0, 2, 4, 6], [1, 3, 5, 7]])
-        gpu_attr = _make_json_attr(
-            "katsdpcontroller.gpus",
-            [
-                {
-                    "name": "Dummy GPU",
-                    "device_attributes": {},
-                    "compute_capability": (5, 2),
-                    "numa_node": 1,
-                    "uuid": "GPU-123",
-                }
-            ],
-        )
-        interface_attr = _make_json_attr(
-            "katsdpcontroller.interfaces",
-            [
-                {
-                    "name": "eth0",
-                    "network": "net0",
-                    "ipv4_address": "192.168.1.1",
-                    "infiniband_devices": ["/dev/infiniband/rdma_cm", "/dev/infiniband/uverbs0"],
-                },
-                {"name": "eth1", "network": "net1", "ipv4_address": "192.168.1.2"},
-            ],
-        )
-        volume_attr = _make_json_attr(
-            "katsdpcontroller.volumes", [{"name": "vol0", "host_path": "/host0"}]
-        )
-
-        self.cpus_agent = scheduler.Agent([self._make_offer({"cpus": 32, "mem": 2, "disk": 7}, 0)])
-        self.mem_agent = scheduler.Agent(
-            [self._make_offer({"cpus": 1.25, "mem": 256, "disk": 8}, 1)]
-        )
-        self.disk_agent = scheduler.Agent(
-            [self._make_offer({"cpus": 1.5, "mem": 3, "disk": 1024}, 2)]
-        )
-        self.ports_agent = scheduler.Agent(
-            [self._make_offer({"cpus": 1.75, "mem": 4, "disk": 9, "ports": [(30000, 30005)]}, 3)]
-        )
-        self.cores_agent = scheduler.Agent(
-            [self._make_offer({"cpus": 6, "mem": 5, "disk": 10, "cores": [(0, 6)]}, 4, [numa_attr])]
-        )
-        self.gpu_compute_agent = scheduler.Agent(
-            [
-                self._make_offer(
-                    {
-                        "cpus": 0.75,
-                        "mem": 6,
-                        "disk": 11,
-                        "katsdpcontroller.gpu.0.compute": 1.0,
-                        "katsdpcontroller.gpu.0.mem": 2.25,
-                    },
-                    5,
-                    [numa_attr, gpu_attr],
-                )
-            ]
-        )
-        self.gpu_mem_agent = scheduler.Agent(
-            [
-                self._make_offer(
-                    {
-                        "cpus": 1.0,
-                        "mem": 7,
-                        "disk": 11,
-                        "katsdpcontroller.gpu.0.compute": 0.125,
-                        "katsdpcontroller.gpu.0.mem": 256.0,
-                    },
-                    6,
-                    [numa_attr, gpu_attr],
-                )
-            ]
-        )
-        self.interface_agent = scheduler.Agent(
-            [
-                self._make_offer(
-                    {
-                        "cpus": 1.0,
-                        "mem": 1,
-                        "disk": 1,
-                        "katsdpcontroller.interface.0.bandwidth_in": 1e9,
-                        "katsdpcontroller.interface.0.bandwidth_out": 1e9,
-                        "katsdpcontroller.interface.1.bandwidth_in": 1e9,
-                        "katsdpcontroller.interface.1.bandwidth_out": 1e9,
-                    },
-                    7,
-                    [interface_attr],
-                )
-            ]
-        )
-        self.volume_agent = scheduler.Agent(
-            [self._make_offer({"cpus": 1.0, "mem": 1, "disk": 1}, 8, [volume_attr])]
-        )
-        # Create some template logical and physical tasks
-        self.logical_tasks = [scheduler.LogicalTask(f"logical{i}") for i in range(3)]
-        self.physical_tasks = [task.physical_factory(task) for task in self.logical_tasks]
-        for i, task in enumerate(self.physical_tasks):
-            task.name = f"physical{i}"
-
-    def test_task_insufficient_scalar_resource(self):
-        """A task requests more of a scalar resource than any agent has"""
-        self.logical_tasks[0].cpus = 4
-        with pytest.raises(scheduler.TaskInsufficientResourcesError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.mem_agent, self.disk_agent], [self.physical_tasks[0]]
-            )
-        assert cm.value.task is self.physical_tasks[0]
-        assert cm.value.resource == InsufficientResource("cpus", ResourceGroup.GLOBAL)
-        assert cm.value.needed == 4
-        assert cm.value.available == 1.5
-        assert str(cm.value) == "Not enough cpus for physical0 on any agent (4.000 > 1.500)"
-
-    def test_task_insufficient_range_resource(self):
-        """A task requests more of a range resource than any agent has"""
-        self.logical_tasks[0].ports = ["a", "b", "c"]
-        with pytest.raises(scheduler.TaskInsufficientResourcesError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.mem_agent, self.disk_agent], [self.physical_tasks[0]]
-            )
-        assert cm.value.task is self.physical_tasks[0]
-        assert cm.value.resource == InsufficientResource("ports", ResourceGroup.GLOBAL)
-        assert cm.value.needed == 3
-        assert cm.value.available == 0
-        assert str(cm.value) == "Not enough ports for physical0 on any agent (3 > 0)"
-
-    def test_task_insufficient_cores(self):
-        """A task requests more cores than are available on a single NUMA node"""
-        self.logical_tasks[0].cores = ["a", "b", "c", "d"]
-        with pytest.raises(scheduler.TaskInsufficientResourcesError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.mem_agent, self.cores_agent], [self.physical_tasks[0]]
-            )
-        assert cm.value.task is self.physical_tasks[0]
-        assert cm.value.resource == InsufficientResource("cores", ResourceGroup.GLOBAL)
-        assert cm.value.needed == 4
-        assert cm.value.available == 3
-        assert str(cm.value) == "Not enough cores for physical0 on any agent (4 > 3)"
-
-    def test_task_insufficient_gpu_scalar_resource(self):
-        """A task requests more of a GPU scalar resource than any agent has"""
-        req = scheduler.GPURequest()
-        req.mem = 2048
-        self.logical_tasks[0].gpus = [req]
-        with pytest.raises(scheduler.TaskInsufficientResourcesError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.mem_agent, self.gpu_compute_agent], [self.physical_tasks[0]]
-            )
-        assert cm.value.task is self.physical_tasks[0]
-        assert cm.value.requester == InsufficientRequesterGPU(self.physical_tasks[0], 0)
-        assert cm.value.resource == InsufficientResource("mem", ResourceGroup.GPU)
-        assert cm.value.needed == 2048
-        assert cm.value.available == 2.25
-        assert (
-            str(cm.value)
-            == "Not enough GPU mem for physical0 (GPU request #0) on any agent (2048.000 > 2.250)"
-        )
-
-    def test_task_insufficient_interface_scalar_resources(self):
-        """A task requests more of an interface scalar resource than any agent has"""
-        req = scheduler.InterfaceRequest("net0")
-        req.bandwidth_in = 5e9
-        self.logical_tasks[0].interfaces = [req]
-        with pytest.raises(scheduler.TaskInsufficientResourcesError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.mem_agent, self.interface_agent], [self.physical_tasks[0]]
-            )
-        assert cm.value.task is self.physical_tasks[0]
-        assert cm.value.requester == InsufficientRequesterInterface(self.physical_tasks[0], req)
-        assert cm.value.resource == InsufficientResource(
-            "bandwidth_in", ResourceGroup.INTERFACE, "net0"
-        )
-        assert cm.value.needed == 5e9
-        assert cm.value.available == 1e9
-        assert (
-            str(cm.value) == "Not enough interface bandwidth_in on network net0 for "
-            "physical0 (network net0) on any agent (5000000000.000 > 1000000000.000)"
-        )
-
-    def test_task_no_interface(self):
-        """A task requests a network interface that is not available on any agent"""
-        self.logical_tasks[0].interfaces = [
-            scheduler.InterfaceRequest("net0"),
-            scheduler.InterfaceRequest("badnet"),
-        ]
-        with pytest.raises(scheduler.TaskNoDeviceError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.mem_agent, self.interface_agent], [self.physical_tasks[0]]
-            )
-        assert cm.value.task is self.physical_tasks[0]
-        assert cm.value.requester == InsufficientRequesterInterface(
-            self.physical_tasks[0], self.logical_tasks[0].interfaces[1]
-        )
-        assert str(cm.value) == "physical0 (network badnet) could not be satisfied by any agent"
-
-    def test_task_no_volume(self):
-        """A task requests a volume that is not available on any agent"""
-        self.logical_tasks[0].volumes = [
-            scheduler.VolumeRequest("vol0", "/vol0", "RW"),
-            scheduler.VolumeRequest("badvol", "/badvol", "RO"),
-        ]
-        with pytest.raises(scheduler.TaskNoDeviceError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.mem_agent, self.volume_agent], [self.physical_tasks[0]]
-            )
-        assert cm.value.task is self.physical_tasks[0]
-        assert cm.value.requester == InsufficientRequesterVolume(
-            self.physical_tasks[0], self.logical_tasks[0].volumes[1]
-        )
-        assert str(cm.value) == "physical0 (volume badvol) could not be satisfied by any agent"
-
-    def test_task_no_gpu(self):
-        """A task requests a GPU that is not available on any agent"""
-        req = scheduler.GPURequest()
-        req.name = "GPU that does not exist"
-        self.logical_tasks[0].gpus = [req]
-        with pytest.raises(scheduler.TaskNoDeviceError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.mem_agent, self.gpu_compute_agent], [self.physical_tasks[0]]
-            )
-        assert cm.value.task == self.physical_tasks[0]
-        assert cm.value.requester == InsufficientRequesterGPU(self.physical_tasks[0], 0)
-        assert str(cm.value) == "physical0 (GPU request #0) could not be satisfied by any agent"
-
-    def test_task_no_agent(self):
-        """A task does not fit on any agent, but not due to a single reason"""
-        # Ask for more combined cpu+ports than is available on one agent
-        self.logical_tasks[0].cpus = 8
-        self.logical_tasks[0].ports = ["a", "b", "c"]
-        with pytest.raises(scheduler.TaskNoAgentError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.cpus_agent, self.ports_agent], [self.physical_tasks[0]]
-            )
-        assert cm.value.task is self.physical_tasks[0]
-        # Make sure that it didn't incorrectly return a subclass
-        assert cm.type == scheduler.TaskNoAgentError
-        assert str(cm.value) == "No agent was found suitable for physical0"
-
-    def test_group_insufficient_scalar_resource(self):
-        """A group of tasks require more of a scalar resource than available"""
-        self.logical_tasks[0].cpus = 24
-        self.logical_tasks[1].cpus = 16
-        with pytest.raises(scheduler.GroupInsufficientResourcesError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.cpus_agent, self.mem_agent], self.physical_tasks[:2]
-            )
-        assert cm.value.requesters_desc == "all tasks"
-        assert cm.value.resource == InsufficientResource("cpus", ResourceGroup.GLOBAL)
-        assert cm.value.needed == 40
-        assert cm.value.available == 33.25
-        assert str(cm.value) == "Insufficient cpus to launch all tasks (40.000 > 33.250)"
-
-    def test_group_insufficient_range_resource(self):
-        """A group of tasks require more of a range resource than available"""
-        self.logical_tasks[0].ports = ["a", "b", "c"]
-        self.logical_tasks[1].ports = ["d", "e", "f"]
-        with pytest.raises(scheduler.GroupInsufficientResourcesError) as cm:
-            scheduler.Scheduler._diagnose_insufficient([self.ports_agent], self.physical_tasks[:2])
-        assert cm.value.requesters_desc == "all tasks"
-        assert cm.value.resource == InsufficientResource("ports", ResourceGroup.GLOBAL)
-        assert cm.value.needed == 6
-        assert cm.value.available == 5
-        assert str(cm.value) == "Insufficient ports to launch all tasks (6 > 5)"
-
-    def test_group_insufficient_gpu_scalar_resources(self):
-        """A group of tasks require more of a GPU scalar resource than available"""
-        self.logical_tasks[0].gpus = [scheduler.GPURequest()]
-        self.logical_tasks[0].gpus[-1].compute = 0.75
-        self.logical_tasks[1].gpus = [scheduler.GPURequest()]
-        self.logical_tasks[1].gpus[-1].compute = 0.5
-        with pytest.raises(scheduler.GroupInsufficientResourcesError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.gpu_compute_agent, self.gpu_mem_agent],
-                self.physical_tasks[:2],
-            )
-        assert cm.value.requesters_desc == "all tasks"
-        assert cm.value.resource == InsufficientResource("compute", ResourceGroup.GPU)
-        assert cm.value.needed == 1.25
-        assert cm.value.available == 1.125
-        assert str(cm.value) == "Insufficient GPU compute to launch all tasks (1.250 > 1.125)"
-
-    def test_group_insufficient_interface_scalar_resources(self):
-        """A group of tasks require more of a network resource than available"""
-        self.logical_tasks[0].interfaces = [
-            scheduler.InterfaceRequest("net0"),
-            scheduler.InterfaceRequest("net1"),
-        ]
-        self.logical_tasks[0].interfaces[0].bandwidth_in = 800e6
-        # An amount that must not be added to the needed value reported
-        self.logical_tasks[0].interfaces[1].bandwidth_in = 50e6
-        self.logical_tasks[1].interfaces = [scheduler.InterfaceRequest("net0")]
-        self.logical_tasks[1].interfaces[0].bandwidth_in = 700e6
-        with pytest.raises(scheduler.GroupInsufficientResourcesError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.interface_agent], self.physical_tasks[:2]
-            )
-        assert cm.value.requesters_desc == "all tasks"
-        assert cm.value.resource == InsufficientResource(
-            "bandwidth_in", ResourceGroup.INTERFACE, "net0"
-        )
-        assert cm.value.needed == 1500e6
-        assert cm.value.available == 1000e6
-        assert (
-            str(cm.value) == "Insufficient interface bandwidth_in on network net0 "
-            "to launch all tasks (1500000000.000 > 1000000000.000)"
-        )
-
-    def test_subsystem(self):
-        """A subsystem has insufficient resources, although the system has enough."""
-        self.logical_tasks[0].subsystem = "sdp"
-        self.logical_tasks[0].cpus = 32  # Consumes all of cpus_agent
-        self.logical_tasks[1].subsystem = "sdp"
-        self.logical_tasks[1].cpus = 1
-        self.cpus_agent.subsystems = {"sdp"}
-        self.cores_agent.subsystems = {"cbf", "other"}
-        with pytest.raises(scheduler.GroupInsufficientResourcesError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.cpus_agent, self.cores_agent], self.physical_tasks[:2]
-            )
-        assert cm.value.requesters_desc == "all sdp tasks"
-        assert cm.value.resource == InsufficientResource("cpus", ResourceGroup.GLOBAL)
-        assert cm.value.needed == 33
-        assert cm.value.available == 32
-        assert str(cm.value) == "Insufficient cpus to launch all sdp tasks (33.000 > 32.000)"
-
-    def test_subset(self):
-        """A subset of the tasks has insufficient resources, although the system has enough."""
-        # Tasks 1 and 2 can each only run on cpus_agent, but can't both fit
-        self.logical_tasks[0].cpus = 17
-        self.logical_tasks[1].cpus = 17
-        self.logical_tasks[2].cpus = 1
-        with pytest.raises(scheduler.GroupInsufficientResourcesError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.cpus_agent, self.cores_agent], self.physical_tasks[:3]
-            )
-        assert cm.value.requesters_desc == "physical0, physical1"
-        assert cm.value.resource == InsufficientResource("cpus", ResourceGroup.GLOBAL)
-        assert cm.value.needed == 34
-        assert cm.value.available == 32
-        assert str(cm.value) == "Insufficient cpus to launch physical0, physical1 (34.000 > 32.000)"
-
-    def test_generic(self):
-        """A group of tasks can't fit, but no simpler explanation is available"""
-        # Create a task that uses just too much memory for the
-        # low-memory agents, forcing it to consume memory from the
-        # big-memory agent and not leaving enough for the big-memory task.
-        self.logical_tasks[0].mem = 5
-        self.logical_tasks[1].mem = 251
-        with pytest.raises(scheduler.InsufficientResourcesError) as cm:
-            scheduler.Scheduler._diagnose_insufficient(
-                [self.cpus_agent, self.mem_agent, self.disk_agent],
-                self.physical_tasks[:2],
-            )
-        # Check that it wasn't a subclass raised
-        assert cm.type == scheduler.InsufficientResourcesError
-        assert str(cm.value) == "Insufficient resources to launch all tasks"
 
 
 class TestSubgraph:
@@ -1867,9 +1430,9 @@ class TestScheduler:
             self.logical_batch_graph.add_node(batch_nodes[0])
             self.logical_batch_graph.add_node(batch_nodes[1])
             self.logical_batch_graph.add_edge(batch_nodes[1], batch_nodes[0], depends_finished=True)
-            self.numa_attr = _make_json_attr("katsdpcontroller.numa", [[0, 2, 4, 6], [1, 3, 5, 7]])
+            self.numa_attr = make_json_attr("katsdpcontroller.numa", [[0, 2, 4, 6], [1, 3, 5, 7]])
             self.agent0_attrs = [
-                _make_json_attr(
+                make_json_attr(
                     "katsdpcontroller.gpus",
                     [
                         {
@@ -1886,10 +1449,10 @@ class TestScheduler:
                         },
                     ],
                 ),
-                _make_json_attr(
+                make_json_attr(
                     "katsdpcontroller.volumes", [{"name": "vol0", "host_path": "/host0"}]
                 ),
-                _make_json_attr(
+                make_json_attr(
                     "katsdpcontroller.interfaces",
                     [
                         {
@@ -1921,7 +1484,7 @@ class TestScheduler:
             self.sched.registered(self.driver, "framework", mock.sentinel.master_info)
 
         def make_offer(self, resources, agent_num=0, attrs=()):
-            return _make_offer(
+            return make_offer(
                 self.framework_id, f"agentid{agent_num}", f"agenthost{agent_num}", resources, attrs
             )
 
@@ -2176,7 +1739,7 @@ class TestScheduler:
         volume.host_path = "/host0"
         volume.container_path = "/container-path"
         expected_taskinfo0.container.volumes = [volume]
-        expected_taskinfo0.resources = _make_resources(
+        expected_taskinfo0.resources = make_resources(
             {
                 "cpus": 1.0,
                 "ports": [(30000, 30001)],
@@ -2209,7 +1772,7 @@ class TestScheduler:
         expected_taskinfo1.container.type = "DOCKER"
         expected_taskinfo1.container.docker.image = "sdp/image1:latest"
         expected_taskinfo1.container.docker.parameters = [{"key": "cpuset-cpus", "value": "0,2"}]
-        expected_taskinfo1.resources = _make_resources({"cpus": 0.5, "cores": [(0, 1), (2, 3)]})
+        expected_taskinfo1.resources = make_resources({"cpus": 0.5, "cores": [(0, 1), (2, 3)]})
         expected_taskinfo1.discovery.visibility = "EXTERNAL"
         expected_taskinfo1.discovery.name = "node1"
         expected_taskinfo1.discovery.ports.ports = []
@@ -2655,7 +2218,7 @@ class TestScheduler:
         )
         await asyncio.sleep(30)
         results = await task
-        with pytest.raises(scheduler.TaskInsufficientResourcesError):
+        with pytest.raises(TaskInsufficientResourcesError):
             raise next(iter(results.values()))
         assert fix.task_stats.batch_created == 1
         assert fix.task_stats.batch_started == 1


### PR DESCRIPTION
Use a more powerful approach to isolating a single reason that a set of tasks cannot be launched. See NGC-997 and the docstring of the diagnose_insufficient module for more details.

The functionality was getting a bit too big and complex to be part of the Scheduler class, so it's split into a new module (and the tests are also moved to a new matching test module).