### PR TITLE
Do not return gains from gain-setting

### DIFF
--- a/src/katsdpcontroller/fake_servers.py
+++ b/src/katsdpcontroller/fake_servers.py
@@ -234,7 +234,9 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
             self.sensors[f"{stream_name}.input{input}.eq"].value = (
                 "[" + ", ".join(_format_complex(gain) for gain in cvalues) + "]"
             )
-        return tuple(_format_complex(v) for v in self._gains[stream_name][input])
+            return ()
+        else:
+            return tuple(_format_complex(v) for v in self._gains[stream_name][input])
 
     async def request_gain_all(self, ctx, stream_name: str, *values: str) -> None:
         """Set the eq gains for all inputs."""

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -1892,7 +1892,7 @@ class DeviceServer(aiokatcp.DeviceServer):
         -------
         values
             A complex gain per channel, or a single value that is used for all
-            channels.
+            channels, or nothing if gains were being set.
         """
         return tuple(await self._get_product().gain(stream, input, values))
 

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -582,6 +582,10 @@ class TestControllerInterface(BaseTestController):
             "gain", "gpucbf_antenna_channelised_voltage", "gpucbf_m901h", "1+2j"
         )
         assert reply == []
+        reply, _ = await client.request(
+            "gain", "gpucbf_antenna_channelised_voltage", "gpucbf_m901h"
+        )
+        assert reply == [b"1.0+2.0j"]
         await assert_sensor_value(
             client, "gpucbf_antenna_channelised_voltage.gpucbf_m901h.eq", "[1.0+2.0j]"
         )
@@ -595,6 +599,10 @@ class TestControllerInterface(BaseTestController):
             "gain", "gpucbf_antenna_channelised_voltage", "gpucbf_m901h", *gains
         )
         assert reply == []
+        reply, _ = await client.request(
+            "gain", "gpucbf_antenna_channelised_voltage", "gpucbf_m901h"
+        )
+        assert reply == gains
         await assert_sensor_value(
             client,
             "gpucbf_antenna_channelised_voltage.gpucbf_m901h.eq",

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -581,7 +581,7 @@ class TestControllerInterface(BaseTestController):
         reply, _ = await client.request(
             "gain", "gpucbf_antenna_channelised_voltage", "gpucbf_m901h", "1+2j"
         )
-        assert reply == [b"1.0+2.0j"]
+        assert reply == []
         await assert_sensor_value(
             client, "gpucbf_antenna_channelised_voltage.gpucbf_m901h.eq", "[1.0+2.0j]"
         )
@@ -594,7 +594,7 @@ class TestControllerInterface(BaseTestController):
         reply, _ = await client.request(
             "gain", "gpucbf_antenna_channelised_voltage", "gpucbf_m901h", *gains
         )
-        assert reply == gains
+        assert reply == []
         await assert_sensor_value(
             client,
             "gpucbf_antenna_channelised_voltage.gpucbf_m901h.eq",


### PR DESCRIPTION
Update the fake server to return nothing when setting gains, and only return gains when they're being explicitly queried. This should reduce network traffic.

See NGC-999.