### PR TITLE
Support using skopeo for copying images to sandbox

### DIFF
--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -80,6 +80,11 @@ authenticate to the registry), you can replace the last step with
 ```
 which will be faster since it will avoid building a number of images.
 
+If you have [skopeo](https://github.com/containers/skopeo), you can pass
+`--skopeo` to use that for copying images between registries, rather than
+pulling to your local Docker daemon. If you need to authenticate to the
+upstream registry, use `skopeo login` rather than `docker login`.
+
 ## Starting up the sandbox
 
 1. Run `./prepare.sh`. This will query your system for information


### PR DESCRIPTION
The standard process involves first copying the image to the local Docker registry (with `docker pull`) then tagging it and pushing it (with `docker push`). That leads to a lot of unwanted tagged images in one's local Docker engine.

Skopeo is a tool that directly copies from one registry to another, without involving the Docker daemon. For now it's optional.