### PR TITLE
Fix disable_ibverbs develop option

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -460,7 +460,7 @@ def _make_dsim(
     An antenna has a separate stream per polarisation, so `streams` will
     normally have two elements.
     """
-    ibv = not configuration.options.develop.disable_ibv
+    ibv = not configuration.options.develop.disable_ibverbs
     # dsim assigns digitiser IDs positionally. According to M1000-0001-053,
     # the least significant bit is the polarization ID with 0 = vertical, so
     # sort by reverse of name so that if the streams are, for example,
@@ -566,7 +566,7 @@ def _make_fgpu(
     # streams needs to be a Sequence (not just an iterable that is consumed
     # once), which `sorted` achieves. Put wideband first for consistency.
     streams = sorted(streams, key=lambda stream: stream.narrowband is not None)
-    ibv = not configuration.options.develop.disable_ibv
+    ibv = not configuration.options.develop.disable_ibverbs
     n_engines = len(streams[0].src_streams) // 2
     base_name = streams[0].name
     fgpu_group = LogicalGroup(f"fgpu.{base_name}")
@@ -927,7 +927,7 @@ def _make_xbgpu(
     sync_time: int,
     sensors: SensorSet,
 ) -> scheduler.LogicalNode:
-    ibv = not configuration.options.develop.disable_ibv
+    ibv = not configuration.options.develop.disable_ibverbs
     acv = stream.antenna_channelised_voltage
     n_engines = stream.n_substreams
     n_inputs = len(acv.src_streams)
@@ -1278,7 +1278,7 @@ def _make_cbf_simulator(
     if isinstance(stream, product_config.SimBaselineCorrelationProductsStream):
         while stream.n_vis / n_sim > _N32_32:
             n_sim *= 2
-    ibv = not configuration.options.develop.disable_ibv
+    ibv = not configuration.options.develop.disable_ibverbs
 
     def make_cbf_simulator_config(
         task: ProductPhysicalTask, resolver: "product_controller.Resolver"
@@ -1653,7 +1653,7 @@ def _make_ingest(
         "continuum_factor": continuum.continuum_factor if continuum is not None else 1,
         "sd_continuum_factor": sd_continuum_factor,
         "sd_spead_rate": sd_spead_rate,
-        "cbf_ibv": not develop.disable_ibv,
+        "cbf_ibv": not develop.disable_ibverbs,
         "cbf_name": src.name,
         "servers": n_ingest,
         "antenna_mask": primary.antennas,
@@ -1725,7 +1725,7 @@ def _make_ingest(
             ingest.physical_factory = IngestTask
         ingest.fake_katcp_server_cls = FakeIngestDeviceServer
         ingest.image = "katsdpingest_" + normalise_gpu_name(defaults.INGEST_GPU_NAME)
-        if develop.disable_ibv:
+        if develop.disable_ibverbs:
             ingest.command = ["ingest.py"]
         else:
             ingest.command = ["capambel", "-c", "cap_net_raw+p", "--", "ingest.py"]
@@ -1758,8 +1758,8 @@ def _make_ingest(
         ingest.interfaces = [
             scheduler.InterfaceRequest(
                 "cbf",
-                affinity=not develop.disable_ibv,
-                infiniband=not develop.disable_ibv,
+                affinity=not develop.disable_ibverbs,
+                infiniband=not develop.disable_ibverbs,
             ),
             scheduler.InterfaceRequest("sdp_10g"),
         ]
@@ -2327,7 +2327,7 @@ def _make_beamformer_engineering_pol(
     bf_ingest.interfaces = [
         scheduler.InterfaceRequest(
             "cbf",
-            infiniband=not configuration.options.develop.disable_ibv,
+            infiniband=not configuration.options.develop.disable_ibverbs,
             affinity=timeplot or not ram,
         )
     ]
@@ -2353,7 +2353,7 @@ def _make_beamformer_engineering_pol(
         config = {
             "affinity": [task.cores["disk"], task.cores["network"]],
             "interface": task.interfaces["cbf"].name,
-            "ibv": not configuration.options.develop.disable_ibv,
+            "ibv": not configuration.options.develop.disable_ibverbs,
             "stream_name": src_stream.name,
             "aiomonitor": True,
         }

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -237,23 +237,23 @@ class ServiceOverride:
 
 class DevelopOptions:
     def __init__(
-        self, *, any_gpu: bool = False, disable_ibv: bool = False, less_resources: bool = False
+        self, *, any_gpu: bool = False, disable_ibverbs: bool = False, less_resources: bool = False
     ) -> None:
         self.any_gpu = any_gpu
-        self.disable_ibv = disable_ibv
+        self.disable_ibverbs = disable_ibverbs
         self.less_resources = less_resources
 
     @classmethod
     def from_config(cls, config: Mapping[str, bool]) -> "DevelopOptions":
         return cls(
             any_gpu=config.get("any_gpu", False),
-            disable_ibv=config.get("disable_ibv", False),
+            disable_ibverbs=config.get("disable_ibverbs", False),
             less_resources=config.get("less_resources", False),
         )
 
     @classmethod
     def from_bool(cls, opt: bool) -> "DevelopOptions":
-        return cls(any_gpu=opt, disable_ibv=opt, less_resources=opt)
+        return cls(any_gpu=opt, disable_ibverbs=opt, less_resources=opt)
 
 
 class Options:

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -201,13 +201,13 @@ class TestOptions:
 
     def test_from_config_dict(self) -> None:
         config = {
-            "develop": {"disable_ibv": True, "less_resources": True},
+            "develop": {"disable_ibverbs": True, "less_resources": True},
             "wrapper": "http://test.invalid/wrapper.sh",
             "service_overrides": {"service1": {"host": "testhost"}},
         }
         options = Options.from_config(config)
         assert options.develop.any_gpu is False
-        assert options.develop.disable_ibv is True
+        assert options.develop.disable_ibverbs is True
         assert options.develop.less_resources is True
         assert options.wrapper == config["wrapper"]
         assert list(options.service_overrides.keys()) == ["service1"]
@@ -221,7 +221,7 @@ class TestOptions:
         }
         options = Options.from_config(config)
         assert options.develop.any_gpu is True
-        assert options.develop.disable_ibv is True
+        assert options.develop.disable_ibverbs is True
         assert options.develop.less_resources is True
         assert options.wrapper == config["wrapper"]
         assert list(options.service_overrides.keys()) == ["service1"]
@@ -230,7 +230,7 @@ class TestOptions:
     def test_defaults(self) -> None:
         options = Options.from_config({})
         assert options.develop.any_gpu is False
-        assert options.develop.disable_ibv is False
+        assert options.develop.disable_ibverbs is False
         assert options.develop.less_resources is False
         assert options.wrapper is None
         assert options.service_overrides == {}


### PR DESCRIPTION
Internally it was being looked up as `config.get("disable_ibv", False`, which was always false because the actual name is "disable_ibverbs".

Renamed to disable_ibverbs throughout for consistency.