### PR TITLE
Be robust to failed F/XB-engines

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -867,6 +867,7 @@ def _make_fgpu(
         # Identify the antenna, if the input labels are consistent
         if input_labels[0][:-1] == input_labels[1][:-1]:
             fgpu.consul_meta["antenna"] = input_labels[0][:-1]
+        fgpu.critical = False  # Can survive losing individual engines
         g.add_node(fgpu)
 
         # Wire it up to the multicast streams
@@ -1226,6 +1227,7 @@ def _make_xbgpu(
             i * stream.n_chans_per_substream,
             (i + 1) * stream.n_chans_per_substream,
         )
+        xbgpu.critical = False  # Can survive losing individual engines
         g.add_node(xbgpu)
 
         # Wire it up to the multicast streams

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -772,6 +772,7 @@ class SubarrayProduct:
         nodes: Iterable[tasks.ProductAnyPhysicalTask],
         messages: Iterable[Iterable],
         timeout: Union[float, None] = None,
+        log_level: int = logging.INFO,
     ) -> None:
         """Send katcp requests for multiple nodes in parallel.
 
@@ -799,7 +800,7 @@ class SubarrayProduct:
         # Now that we've validated things, send the messages
         futures = []
         for node, msg in reqs:
-            futures.append(node.issue_req(msg[0], msg[1:], timeout=timeout))
+            futures.append(node.issue_req(msg[0], msg[1:], timeout=timeout, log_level=log_level))
         if futures:  # gather doesn't like having zero futures
             results = await asyncio.gather(*futures, return_exceptions=True)
             for result in results:
@@ -1323,7 +1324,8 @@ class SubarrayProduct:
             )
             for node in nodes
         ]
-        await self._multi_request(nodes, msgs, timeout=DELAYS_TIMEOUT)
+        # Use debug-level logging because we expect to get this request every few seconds
+        await self._multi_request(nodes, msgs, timeout=DELAYS_TIMEOUT, log_level=logging.DEBUG)
 
     async def gain(self, stream_name: str, input: str, values: Sequence[str]) -> Sequence[str]:
         """Set F-engine gains."""

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -778,8 +778,7 @@ class SubarrayProduct:
         If any of the critical nodes has no current katcp connection, abort
         before sending any of the messages. Otherwise, send the messages and
         wait for all of them to complete (even if some of them fail). If any
-        fail, or if there is a non-critical node with no katcp connection,
-        raise the first failure.
+        fail, raise the first failure.
 
         Each message is given as an iterable of arguments (starting with the
         request name). It is acceptable for the messages iterator to be
@@ -807,7 +806,7 @@ class SubarrayProduct:
                 if isinstance(result, Exception):
                     raise result
         if non_critical:
-            raise FailReply(f"No katcp connection to some nodes: {non_critical}")
+            logger.debug("multi_request: no katcp connection to some nodes: %s", non_critical)
 
     async def _capture_done_impl(self, capture_block: CaptureBlock) -> None:
         """Stop a capture block.

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -460,6 +460,7 @@ class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
                     self.sdp_controller,
                     prefix,
                     renames=self.logical_node.sensor_renames,
+                    close_action=sensor_proxy.CloseAction.UNREACHABLE,
                     host=self.host,
                     port=self.ports["port"],
                 )

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -425,8 +425,8 @@ class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
         """Issue a request to the katcp connection.
 
         The reply and informs are returned. If the request failed, a log
-        message is printed, a FailReply is raised, and (if defined),
-        data-suspect flags are set.
+        message is printed, a FailReply is raised. If the failure is due to
+        a timeout or an OSError, the data-suspect flags are set.
         """
         if self.katcp_connection is None:
             raise FailReply(
@@ -453,7 +453,8 @@ class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
                 error_msg = str(error)
             msg = f"Failed to issue req {req} to node {self.name}. {error_msg}"
             self.logger.warning("%s", msg)
-            self.mark_suspect()
+            if not isinstance(error, (FailReply, InvalidReply)):
+                self.mark_suspect()
             raise FailReply(msg) from error
 
     async def wait_ready(self):

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -553,7 +553,6 @@ class TestControllerInterface(BaseTestController):
         # Deconfigure and check that the server shuts down
         interface_changed_callback.reset_mock()
         await client.request("product-deconfigure")
-        interface_changed_callback.assert_called_with(b"sensor-list")
         await client.wait_disconnected()
         client.remove_inform_callback("interface-changed", interface_changed_callback)
 

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -666,12 +666,7 @@ class TestControllerInterface(BaseTestController):
         await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
         assert server.product is not None  # Keeps mypy happy
         server.product._nodes["f.gpucbf_antenna_channelised_voltage.0"].kill(None)
-        with pytest.raises(
-            FailReply,
-            match=r"No katcp connection to some nodes: "
-            r"\['f.gpucbf_antenna_channelised_voltage.0'\]",
-        ):
-            await client.request("gain-all", "gpucbf_antenna_channelised_voltage", "3.0")
+        await client.request("gain-all", "gpucbf_antenna_channelised_voltage", "3.0")
         # Check that the other engine still had its gains set
         await assert_sensor_value(
             client, "gpucbf_antenna_channelised_voltage.gpucbf_m901v.eq", b"[3.0+0.0j]"
@@ -754,21 +749,16 @@ class TestControllerInterface(BaseTestController):
         await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
         assert server.product is not None  # Keeps mypy happy
         server.product._nodes["f.gpucbf_antenna_channelised_voltage.0"].kill(None)
-        with pytest.raises(
-            FailReply,
-            match=r"No katcp connection to some nodes: "
-            r"\['f.gpucbf_antenna_channelised_voltage.0'\]",
-        ):
-            await client.request(
-                "delays",
-                "gpucbf_antenna_channelised_voltage",
-                "123456791.5",
-                "0.5,0.0:0.0,0.0",
-                "0.0,0.125:0.0,0.0",
-                "0.0,0.0:0.25,0.0",
-                "0.0,0.0:0.0,1.0",
-            )
-        # Check that delay setting still happens
+        await client.request(
+            "delays",
+            "gpucbf_antenna_channelised_voltage",
+            "123456791.5",
+            "0.5,0.0:0.0,0.0",
+            "0.0,0.125:0.0,0.0",
+            "0.0,0.0:0.25,0.0",
+            "0.0,0.0:0.0,1.0",
+        )
+        # Check that delay setting still happens on the non-failed engine
         await assert_sensor_value(
             client,
             "gpucbf_antenna_channelised_voltage.gpucbf_m901v.delay",

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -711,6 +711,19 @@ class TestControllerInterface(BaseTestController):
             b"0011",
             status=Sensor.Status.WARN,
         )
+        # Check that the engine's sensors are modified appropriately
+        await assert_sensor_value(
+            client,
+            "f.gpucbf_antenna_channelised_voltage.1.time.esterror",
+            mock.ANY,
+            status=Sensor.Status.UNREACHABLE,
+        )
+        await assert_sensor_value(
+            client,
+            "f.gpucbf_antenna_channelised_voltage.1.device-status",
+            b"fail",
+            status=Sensor.Status.ERROR,
+        )
         # Kill off the other, to check that the sensor goes into ERROR
         server.product._nodes["f.gpucbf_antenna_channelised_voltage.0"].kill(None)
         await assert_sensor_value(
@@ -735,6 +748,19 @@ class TestControllerInterface(BaseTestController):
             "gpucbf_baseline_correlation_products.channel-data-suspect",
             b"0" * 1024 + b"1" * 1024 + b"0" * 2048,
             status=Sensor.Status.WARN,
+        )
+        # Check that the engine's sensors have been modified appropriately
+        await assert_sensor_value(
+            client,
+            "xb.gpucbf_baseline_correlation_products.1.xeng-clip-cnt",
+            mock.ANY,
+            status=Sensor.Status.UNREACHABLE,
+        )
+        await assert_sensor_value(
+            client,
+            "xb.gpucbf_baseline_correlation_products.1.device-status",
+            b"fail",
+            status=Sensor.Status.ERROR,
         )
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -348,7 +348,7 @@ async def assert_sensor_value(
     value: Any,
     status: aiokatcp.Sensor.Status = aiokatcp.Sensor.Status.NOMINAL,
 ) -> None:
-    encoded = aiokatcp.encode(value)
+    encoded = mock.ANY if value is mock.ANY else aiokatcp.encode(value)
     reply, informs = await client.request("sensor-value", name)
     assert informs[0].arguments[4] == encoded
     assert informs[0].arguments[3] == aiokatcp.encode(status)


### PR DESCRIPTION
If an XB-engine or an F-engine dies (and Mesos tells us it's died):
- Don't mark the whole array as failed.
- Make ?gain-all, ?delays, ?capture-start, ?capture-stop continue to report success, ignoring the failed engine and taking effect on the remaining ones.
- Keep its sensors around, but mark them as unreachable, so that the last values can still be queried, and we don't trigger a bunch of sensor-list resynchronisation from CAM and the master controller.

Additionally, if a command issued to an engine fails or takes too long, mark the data-suspect bits corresponding to that engine, and fail the request.

Implements the first phase of NGC-443.