### PR TITLE
xbgpu sensor renames and capture-{start, stop} updates

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1260,6 +1260,16 @@ def _make_xbgpu(
         ]:
             xbgpu.sensor_renames[name] = f"{stream.name}.{i}.{name}"
 
+        # Rename sensors that are relevant to the Engine rather than the Pipeline
+        for name in [
+            "chan-range",
+            "rx.synchronised",
+            "xeng-clip-cnt",
+        ]:
+            xbgpu.sensor_renames[
+                f"{stream.name}.{i}.{stream.name}.{name}"
+            ] = f"{stream.name}.{i}.{name}"
+
         xbgpu.static_gauges["xbgpu_expected_input_heaps_per_second"] = (
             acv.adc_sample_rate
             / (acv.n_samples_between_spectra * acv.n_spectra_per_heap)

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1256,7 +1256,7 @@ def _make_xbgpu(
         ]:
             xbgpu.sensor_renames[name] = f"{stream.name}.{i}.{name}"
 
-        # Rename sensors that are relevant to the Engine rather than the Pipeline
+        # Rename sensors that are relevant to the stream rather than the Pipeline
         for name in [
             "chan-range",
             "rx.synchronised",

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1058,9 +1058,7 @@ def _make_xbgpu(
             sensors,
             f"{stream.name}.xengs-synchronised",
             "For the latest accumulation, was data present from all F-Engines for all X-Engines",
-            name_regex=re.compile(
-                rf"xb\.{re.escape(stream.name)}\.[0-9]+\.{re.escape(stream.name)}\.rx.synchronised"
-            ),
+            name_regex=re.compile(rf"xb\.{re.escape(stream.name)}\.[0-9]+\.rx.synchronised"),
             n_children=stream.n_substreams,
         ),
         data_suspect_sensor,
@@ -1266,9 +1264,7 @@ def _make_xbgpu(
             "rx.synchronised",
             "xeng-clip-cnt",
         ]:
-            xbgpu.sensor_renames[
-                f"{stream.name}.{i}.{stream.name}.{name}"
-            ] = f"{stream.name}.{i}.{name}"
+            xbgpu.sensor_renames[f"{stream.name}.{name}"] = f"{stream.name}.{i}.{name}"
 
         xbgpu.static_gauges["xbgpu_expected_input_heaps_per_second"] = (
             acv.adc_sample_rate

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1049,16 +1049,14 @@ def _make_xbgpu(
             sensors,
             f"{stream.name}.xeng-clip-cnt",
             "Number of visibilities that saturated",
-            name_regex=re.compile(
-                rf"xb\.{re.escape(stream.name)}\.[0-9]+\.{re.escape(stream.name)}\.xeng-clip-cnt"
-            ),
+            name_regex=re.compile(rf"{re.escape(stream.name)}\.[0-9]+\.xeng-clip-cnt"),
             n_children=stream.n_substreams,
         ),
         SyncSensor(
             sensors,
             f"{stream.name}.xengs-synchronised",
             "For the latest accumulation, was data present from all F-Engines for all X-Engines",
-            name_regex=re.compile(rf"xb\.{re.escape(stream.name)}\.[0-9]+\.rx.synchronised"),
+            name_regex=re.compile(rf"{re.escape(stream.name)}\.[0-9]+\.rx.synchronised"),
             n_children=stream.n_substreams,
         ),
         data_suspect_sensor,

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1049,14 +1049,18 @@ def _make_xbgpu(
             sensors,
             f"{stream.name}.xeng-clip-cnt",
             "Number of visibilities that saturated",
-            name_regex=re.compile(rf"xb\.{re.escape(stream.name)}\.[0-9]+\.xeng-clip-cnt"),
+            name_regex=re.compile(
+                rf"xb\.{re.escape(stream.name)}\.[0-9]+\.{re.escape(stream.name)}\.xeng-clip-cnt"
+            ),
             n_children=stream.n_substreams,
         ),
         SyncSensor(
             sensors,
             f"{stream.name}.xengs-synchronised",
             "For the latest accumulation, was data present from all F-Engines for all X-Engines",
-            name_regex=re.compile(rf"xb\.{re.escape(stream.name)}\.[0-9]+\.rx.synchronised"),
+            name_regex=re.compile(
+                rf"xb\.{re.escape(stream.name)}\.[0-9]+\.{re.escape(stream.name)}\.rx.synchronised"
+            ),
             n_children=stream.n_substreams,
         ),
         data_suspect_sensor,

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -1385,10 +1385,15 @@ class SubarrayProduct:
         if not isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
             raise FailReply(f"Stream {stream_name!r} is of the wrong type")
 
-        command = "capture-start" if start else "capture-stop"
+        # TODO: Still need to get the Pipeline within the stream
+        # For now, baseline-correlation-products stream has a
+        # single XPipeline with name baseline-correlation-products
+        pipeline_name = stream_name
+        command = f"capture-start {pipeline_name}" if start else f"capture-stop {pipeline_name}"
         await self._multi_request(
             self.find_nodes(task_type="xb", streams=[stream]), itertools.repeat((command,))
         )
+        # TODO: Clarify if/how the Pipeline-level abstraction affects the node.logical_name
         for node in self.physical_graph.nodes:
             if (
                 isinstance(node, generator.PhysicalMulticast)

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -1385,16 +1385,12 @@ class SubarrayProduct:
         if not isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
             raise FailReply(f"Stream {stream_name!r} is of the wrong type")
 
-        # TODO: Still need to get the Pipeline within the stream
-        # For now, baseline-correlation-products stream has a
-        # single XPipeline with name baseline-correlation-products
-        pipeline_name = stream_name
         command = "capture-start" if start else "capture-stop"
         await self._multi_request(
             self.find_nodes(task_type="xb", streams=[stream]),
-            itertools.repeat((command, pipeline_name)),
+            itertools.repeat((command, stream_name)),
         )
-        # TODO: Clarify if/how the Pipeline-level abstraction affects the node.logical_name
+
         for node in self.physical_graph.nodes:
             if (
                 isinstance(node, generator.PhysicalMulticast)

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -1389,7 +1389,7 @@ class SubarrayProduct:
         # For now, baseline-correlation-products stream has a
         # single XPipeline with name baseline-correlation-products
         pipeline_name = stream_name
-        command = f"capture-start" if start else f"capture-stop"
+        command = "capture-start" if start else "capture-stop"
         await self._multi_request(
             self.find_nodes(task_type="xb", streams=[stream]),
             itertools.repeat((command, pipeline_name)),

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -1389,9 +1389,10 @@ class SubarrayProduct:
         # For now, baseline-correlation-products stream has a
         # single XPipeline with name baseline-correlation-products
         pipeline_name = stream_name
-        command = f"capture-start {pipeline_name}" if start else f"capture-stop {pipeline_name}"
+        command = f"capture-start" if start else f"capture-stop"
         await self._multi_request(
-            self.find_nodes(task_type="xb", streams=[stream]), itertools.repeat((command,))
+            self.find_nodes(task_type="xb", streams=[stream]),
+            itertools.repeat((command, pipeline_name)),
         )
         # TODO: Clarify if/how the Pipeline-level abstraction affects the node.logical_name
         for node in self.physical_graph.nodes:

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -820,8 +820,7 @@ class TestControllerInterface(BaseTestController):
         # Check that the engine's sensors have been modified appropriately
         await assert_sensor_value(
             client,
-            "xb.gpucbf_baseline_correlation_products.1."
-            "gpucbf_baseline_correlation_products.xeng-clip-cnt",
+            "gpucbf_baseline_correlation_products.1.xeng-clip-cnt",
             mock.ANY,
             status=Sensor.Status.UNREACHABLE,
         )

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -1971,7 +1971,9 @@ class TestController(BaseTestController):
         katcp_client = sensor_proxy_client
         # TODO: this doesn't check that the requests are going to the correct
         # nodes.
-        katcp_client.request.assert_any_call("capture-start gpucbf_baseline_correlation_products")
+        katcp_client.request.assert_any_call(
+            "capture-start", "gpucbf_baseline_correlation_products"
+        )
 
     async def test_capture_start_bad_stream(self, client: aiokatcp.Client) -> None:
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
@@ -1989,7 +1991,7 @@ class TestController(BaseTestController):
         katcp_client = sensor_proxy_client
         # TODO: this doesn't check that the requests are going to the correct
         # nodes.
-        katcp_client.request.assert_any_call("capture-stop gpucbf_baseline_correlation_products")
+        katcp_client.request.assert_any_call("capture-stop", "gpucbf_baseline_correlation_products")
         # Check that the state changed to down in capture-list
         _, informs = await client.request("capture-list", "gpucbf_baseline_correlation_products")
         assert len(informs) == 1

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -820,7 +820,8 @@ class TestControllerInterface(BaseTestController):
         # Check that the engine's sensors have been modified appropriately
         await assert_sensor_value(
             client,
-            "xb.gpucbf_baseline_correlation_products.1.gpucbf_baseline_correlation_products.xeng-clip-cnt",
+            "xb.gpucbf_baseline_correlation_products.1."
+            "gpucbf_baseline_correlation_products.xeng-clip-cnt",
             mock.ANY,
             status=Sensor.Status.UNREACHABLE,
         )

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -820,7 +820,7 @@ class TestControllerInterface(BaseTestController):
         # Check that the engine's sensors have been modified appropriately
         await assert_sensor_value(
             client,
-            "xb.gpucbf_baseline_correlation_products.1.xeng-clip-cnt",
+            "xb.gpucbf_baseline_correlation_products.1.gpucbf_baseline_correlation_products.xeng-clip-cnt",
             mock.ANY,
             status=Sensor.Status.UNREACHABLE,
         )

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -1971,7 +1971,7 @@ class TestController(BaseTestController):
         katcp_client = sensor_proxy_client
         # TODO: this doesn't check that the requests are going to the correct
         # nodes.
-        katcp_client.request.assert_any_call("capture-start")
+        katcp_client.request.assert_any_call("capture-start gpucbf_baseline_correlation_products")
 
     async def test_capture_start_bad_stream(self, client: aiokatcp.Client) -> None:
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
@@ -1989,7 +1989,7 @@ class TestController(BaseTestController):
         katcp_client = sensor_proxy_client
         # TODO: this doesn't check that the requests are going to the correct
         # nodes.
-        katcp_client.request.assert_any_call("capture-stop")
+        katcp_client.request.assert_any_call("capture-stop gpucbf_baseline_correlation_products")
         # Check that the state changed to down in capture-list
         _, informs = await client.request("capture-list", "gpucbf_baseline_correlation_products")
         assert len(informs) == 1


### PR DESCRIPTION
Update xbgpu sensors and capture-{start, stop} request according to https://github.com/ska-sa/katgpucbf/pull/600
* The XPipeline-specific sensors have been abstracted here to be part of the **stream**, naming as follows
  * `<stream_name>.<xeng_id>.<sensor_name>`, e.g. `baseline-correlation-products.1.rx.synchronised`
* The capture-{start, stop} commands are still invoked the same way, `?capture-start <stream_name>`
   * But now the function handling the request makes the updated call to the XBEngine using the `stream_name` arg again
   * As previously agreed, at least in the case of the `baseline-correlation-products` stream, the Pipeline name is the same as the top-level stream name, so we can reuse the variable (i.e. not go digging further).

I've purposefully left out any logic required for eventual beamformer/tied-array-channelised-voltage streams as I'm not yet sure if there will be changes required to katgpucbf.
* Still, the (re)use of the `stream_name` is clear enough now that it will likely be unchanged in the beamformer-specific case(s).

Resolves: NGC-1049 and NGC-1057.