### PR TITLE
Eliminate custom DeviceStatus class

### DIFF
--- a/src/katsdpcontroller/controller.py
+++ b/src/katsdpcontroller/controller.py
@@ -181,17 +181,11 @@ class ProductState(scheduler.OrderedEnum):
     POSTPROCESSING = 6
 
 
-class DeviceStatus(scheduler.OrderedEnum):
-    OK = 1
-    DEGRADED = 2
-    FAIL = 3
-
-
-def device_status_to_sensor_status(status: DeviceStatus) -> aiokatcp.Sensor.Status:
+def device_status_to_sensor_status(status: aiokatcp.DeviceStatus) -> aiokatcp.Sensor.Status:
     mapping = {
-        DeviceStatus.OK: aiokatcp.Sensor.Status.NOMINAL,
-        DeviceStatus.DEGRADED: aiokatcp.Sensor.Status.WARN,
-        DeviceStatus.FAIL: aiokatcp.Sensor.Status.ERROR,
+        aiokatcp.DeviceStatus.OK: aiokatcp.Sensor.Status.NOMINAL,
+        aiokatcp.DeviceStatus.DEGRADED: aiokatcp.Sensor.Status.WARN,
+        aiokatcp.DeviceStatus.FAIL: aiokatcp.Sensor.Status.ERROR,
     }
     return mapping[status]
 

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -61,13 +61,12 @@ import async_timeout
 import jsonschema
 import katsdpservices
 import yarl
-from aiokatcp import Address, FailReply, Sensor, SensorSet
+from aiokatcp import Address, DeviceStatus, FailReply, Sensor, SensorSet
 
 import katsdpcontroller
 
 from . import product_config, product_controller, scheduler, sensor_proxy, singularity
 from .controller import (
-    DeviceStatus,
     ProductState,
     add_shared_options,
     device_server_sockname,
@@ -419,7 +418,11 @@ class ProductManagerBase(Generic[_P]):
         status = DeviceStatus.OK
         for name in self.products.keys():
             sensor = self._server.sensors.get(f"{name}.device-status")
-            if sensor is not None and sensor.status.valid_value() and sensor.value > status:
+            if (
+                sensor is not None
+                and sensor.status.valid_value()
+                and sensor.value.value > status.value
+            ):
                 status = sensor.value
         self._server.sensors["device-status"].value = status
 

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -47,7 +47,7 @@ import katsdptelstate.aio.memory
 import katsdptelstate.aio.redis
 import networkx
 import yarl
-from aiokatcp import FailReply, Sensor
+from aiokatcp import DeviceStatus, FailReply, Sensor
 from katsdptelstate.endpoint import Endpoint
 from prometheus_client import REGISTRY, CollectorRegistry, Counter, Gauge, Histogram
 
@@ -56,7 +56,6 @@ import katsdpcontroller
 from . import generator, product_config, scheduler, sensor_proxy, tasks
 from .consul import ConsulService
 from .controller import (
-    DeviceStatus,
     ProductState,
     device_status_to_sensor_status,
     load_json_dict,

--- a/test/test_master_controller.py
+++ b/test/test_master_controller.py
@@ -34,11 +34,10 @@ import async_solipsism
 import open_file_mock
 import pytest
 import yarl
-from aiokatcp import Client, Sensor
+from aiokatcp import Client, DeviceStatus, Sensor
 
 from katsdpcontroller import scheduler
 from katsdpcontroller.controller import (
-    DeviceStatus,
     ProductState,
     device_server_sockname,
     device_status_to_sensor_status,

--- a/test/test_sensor_proxy.py
+++ b/test/test_sensor_proxy.py
@@ -32,10 +32,10 @@ from unittest import mock
 
 import aiokatcp
 import pytest
-from aiokatcp import Address, Sensor, SensorSet
+from aiokatcp import Address, DeviceStatus, Sensor, SensorSet
 from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
 
-from katsdpcontroller.controller import DeviceStatus, device_server_sockname
+from katsdpcontroller.controller import device_server_sockname
 from katsdpcontroller.sensor_proxy import (
     CloseAction,
     PrometheusInfo,


### PR DESCRIPTION
Use the one provided by aiokatcp instead. The custom class used OrderedEnum, and restrictions on Python meant it couldn't be mixed in to the aiokatcp class. However, this functionality was only used in one place, so it is worked around by just comparing the enum values instead of the enums themselves.

Closes NGC-1036.