### PR TITLE
Add parsing for product-configure 3.5

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -2503,6 +2503,10 @@ def build_logical_graph(
         _make_fgpu(g, configuration, fgpu_streams, sync_time)
     for stream in configuration.by_class(product_config.GpucbfBaselineCorrelationProductsStream):
         _make_xbgpu(g, configuration, stream, sync_time, sensors)
+    for stream in configuration.by_class(product_config.GpucbfTiedArrayChannelisedVoltageStream):
+        # TODO: NGC-1116 might change make_xbgpu's function signature,
+        # iterating (and raising) separately for now.
+        raise NotImplementedError("beamformer isn't supported yet")
 
     # Pair up spectral and continuum L0 outputs
     l0_done = set()

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -1257,7 +1257,7 @@ class GpucbfTiedArrayChannelisedVoltageStream(TiedArrayChannelisedVoltageStreamB
     if TYPE_CHECKING:  # pragma: nocover
         # Refine the return type for mypy
         @property
-        def antenna_channelised_voltage(self) -> AntennaChannelisedVoltageStreamBase:
+        def antenna_channelised_voltage(self) -> GpucbfAntennaChannelisedVoltageStream:
             ...
 
     @classmethod

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -1226,6 +1226,7 @@ class TiedArrayChannelisedVoltageStream(CbfStream, TiedArrayChannelisedVoltageSt
             instrument_dev_name=config["instrument_dev_name"],
         )
 
+
 class GpucbfTiedArrayChannelisedVoltageStream(TiedArrayChannelisedVoltageStreamBase):
     """Real tied-array-channelised-voltage stream (GPU beamformer)."""
 
@@ -1253,7 +1254,7 @@ class GpucbfTiedArrayChannelisedVoltageStream(TiedArrayChannelisedVoltageStreamB
         self.src_pol = src_pol
         self.command_line_extra = list(command_line_extra)
 
-    if TYPE_CHECKING:   # pragma: nocover
+    if TYPE_CHECKING:  # pragma: nocover
         # Refine the return type for mypy
         @property
         def antenna_channelised_voltage(self) -> AntennaChannelisedVoltageStreamBase:
@@ -1261,12 +1262,12 @@ class GpucbfTiedArrayChannelisedVoltageStream(TiedArrayChannelisedVoltageStreamB
 
     @classmethod
     def from_config(
-        cls: type[_S],
+        cls,
         options: Options,
         name: str,
         config: Mapping[str, Any],
         src_streams: Sequence[Stream],
-        sensors: Mapping[str, Any]
+        sensors: Mapping[str, Any],
     ) -> "GpucbfTiedArrayChannelisedVoltageStream":
         return cls(
             name,

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -1,5 +1,5 @@
 {% macro versions() %}
-["2.4", "2.5", "2.6", "3.0", "3.1", "3.2", "3.3", "3.4"]
+["2.4", "2.5", "2.6", "3.0", "3.1", "3.2", "3.3", "3.4", "3.5"]
 {% endmacro %}
 
 {% macro validate(version) %}
@@ -277,6 +277,9 @@
                                 "sim.dig.baseband_voltage",
                                 "gpucbf.antenna_channelised_voltage",
                                 "gpucbf.baseline_correlation_products",
+{% endif %}
+{% if verison >= "3.5" %}
+                                "gpucbf.tied_array_channelised_voltage",
 {% endif %}
                                 "sdp.vis",
                                 "sdp.cal",
@@ -602,6 +605,24 @@
                                 },
                                 "additionalProperties": false,
                                 "required": ["src_streams", "int_time"]
+                            }
+                        },
+                        {
+                            "if": {"properties": {"type": {"const": "gpucbf.tied_array_channelised_voltage"}}},
+                            "then": {
+                                "properties": {
+                                    "type": {},
+                                    "src_streams": {"$ref": "#/definitions/singleton"},
+                                    // TODO: Clarify `positive_integer` vs `positive_number`. It's likely
+                                    // `positive_number` allows for float-type values - which we don't need.
+                                    "src_pol": {"$ref": "#/definitions/positive_integer"},
+                                    "command_line_extra": {
+                                        "type": "array",
+                                        "items": {"type": "string"}
+                                    }
+                                },
+                                "additionalProperties": false,
+                                "required": ["src_streams", "src_pol"]
                             }
                         }
                     ]

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -613,8 +613,6 @@
                                 "properties": {
                                     "type": {},
                                     "src_streams": {"$ref": "#/definitions/singleton"},
-                                    // TODO: Clarify `positive_integer` vs `positive_number`. It's likely
-                                    // `positive_number` allows for float-type values - which we don't need.
                                     "src_pol": {"$ref": "#/definitions/positive_integer"},
                                     "command_line_extra": {
                                         "type": "array",

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -613,7 +613,7 @@
                                 "properties": {
                                     "type": {},
                                     "src_streams": {"$ref": "#/definitions/singleton"},
-                                    "src_pol": {"$ref": "#/definitions/positive_integer"},
+                                    "src_pol": {"type": { "enum": [0, 1] }},
                                     "command_line_extra": {
                                         "type": "array",
                                         "items": {"type": "string"}

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -278,7 +278,7 @@
                                 "gpucbf.antenna_channelised_voltage",
                                 "gpucbf.baseline_correlation_products",
 {% endif %}
-{% if verison >= "3.5" %}
+{% if version >= "3.5" %}
                                 "gpucbf.tied_array_channelised_voltage",
 {% endif %}
                                 "sdp.vis",

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -613,7 +613,7 @@
                                 "properties": {
                                     "type": {},
                                     "src_streams": {"$ref": "#/definitions/singleton"},
-                                    "src_pol": {"type": { "enum": [0, 1] }},
+                                    "src_pol": {"type": "integer", "enum": [0, 1]},
                                     "command_line_extra": {
                                         "type": "array",
                                         "items": {"type": "string"}

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -43,6 +43,7 @@ from katsdpcontroller.product_config import (
     FlagsStream,
     GpucbfAntennaChannelisedVoltageStream,
     GpucbfBaselineCorrelationProductsStream,
+    GpucbfTiedArrayChannelisedVoltageStream,
     Options,
     ServiceOverride,
     SimAntennaChannelisedVoltageStream,
@@ -879,6 +880,45 @@ class TestTiedArrayChannelisedVoltageStream:
         assert tacv.bandwidth == 107e6
         assert tacv.antennas == ["m000", "another_antenna"]
         assert round(abs(tacv.int_time * 1712e6 - 524288 * 256), 7) == 0
+
+
+class TestGpucbfTiedArrayChannelisedVoltageStream:
+    """Test :class:`~.GpucbfTiedArrayChannelisedVoltageStream`.
+
+    This is not as thorough as :class:`TestTiedArrayChannelisedVoltageStream`
+    because that test covers the important base class components already.
+    """
+
+    @pytest.fixture
+    def acv(self) -> GpucbfAntennaChannelisedVoltageStream:
+        return make_gpucbf_antenna_channelised_voltage()
+
+    @pytest.fixture
+    def config(self) -> Dict[str, Any]:
+        return {
+            "type": "gpucbf.tied_array_channelised_voltage",
+            "src_streams": "wide1_acv",
+            "src_pol": 0,
+        }
+
+    def test_from_config(
+        self, acv: GpucbfAntennaChannelisedVoltageStream, config: Dict[str, Any]
+    ) -> None:
+        tacv = GpucbfTiedArrayChannelisedVoltageStream.from_config(
+            Options(), "wide2_tacv", config, [acv], {}
+        )
+        assert tacv.n_chans_per_substream == 1024
+        assert tacv.src_pol == 0
+        assert tacv.command_line_extra == []
+
+    def test_command_line_extra(
+        self, acv: GpucbfAntennaChannelisedVoltageStream, config: Dict[str, Any]
+    ) -> None:
+        config["command_line_extra"] = ["--extra-arg"]
+        tacv = GpucbfTiedArrayChannelisedVoltageStream.from_config(
+            Options(), "wide2_tacv", config, [acv], {}
+        )
+        assert tacv.command_line_extra == config["command_line_extra"]
 
 
 class TestSimTiedArrayChannelisedVoltageStream:

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -1426,7 +1426,7 @@ class TestSpectralImageStream:
 @pytest.fixture
 def config() -> Dict[str, Any]:
     return {
-        "version": "3.4",
+        "version": "3.5",
         "inputs": {
             "camdata": {"type": "cam.http", "url": "http://10.8.67.235/api/client/1"},
             "i0_antenna_channelised_voltage": {
@@ -1588,7 +1588,7 @@ def config_v2() -> Dict[str, Any]:
 @pytest.fixture
 def config_sim() -> Dict[str, Any]:
     return {
-        "version": "3.4",
+        "version": "3.5",
         "outputs": {
             "acv": {
                 "type": "sim.cbf.antenna_channelised_voltage",


### PR DESCRIPTION
It parses a GpucbfTiedArrayChannelisedVoltageStream config object, but doesn't
actually do anything with it. Trying to instantiate a beamformer with it will result in
a `NotImplementedError` being raised.

See suggested edits in the doc below for the schema update.
- https://docs.google.com/document/d/15ZIyuBf4Vk4ESIEdKsQxdSBoLEwh85eyKeDJouLRAZY/edit?usp=sharing

Closes: NGC-932 and NGC-933.