### PR TITLE
Launch beamformer from make_xbgpu

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -953,12 +953,14 @@ def _make_xbgpu(
 
     base_name = "base-name-placeholder"
     xbgpu_group = LogicalGroup(f"xbgpu.{base_name}")
+    dst_multicasts = []
     g.add_node(xbgpu_group)
     for stream in all_streams:
         dst_multicast = LogicalMulticast(
             stream.name, stream.n_substreams, initial_transmit_state=TransmitState.DOWN
         )
         g.add_node(dst_multicast)
+        dst_multicasts.append(dst_multicast)
         g.add_edge(dst_multicast, xbgpu_group, depends_init=True, depends_ready=True)
 
         data_suspect_sensor = Sensor(
@@ -1331,7 +1333,8 @@ def _make_xbgpu(
                 depends_init=True,
                 depends_ready=True,
             )
-            g.add_edge(xbgpu, dst_multicast, port="spead", depends_resolve=True)
+            for dst_multicast in dst_multicasts:
+                g.add_edge(xbgpu, dst_multicast, port="spead", depends_resolve=True)
             xbgpu.command += [
                 f"{{endpoints_vector[multicast.{acv.name}_spead][{i}]}}",
             ]

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -984,7 +984,7 @@ def _make_xbgpu(
             f"{stream.name}.channel-data-suspect",
             "A bitmask of flags indicating whether each channel should be considered "
             "to be garbage.",
-            default="0" * stream.n_chans,  # type: ignore
+            default="0" * stream.n_chans,
             initial_status=Sensor.Status.NOMINAL,
         )
         data_suspect_sensors.append(data_suspect_sensor)
@@ -1004,6 +1004,20 @@ def _make_xbgpu(
                 "The analogue bandwidth of the digitised band",
                 "Hz",
                 default=acv.bandwidth,
+                initial_status=Sensor.Status.NOMINAL,
+            ),
+            Sensor(
+                int,
+                f"{stream.name}.n-chans",
+                "The number of frequency channels in this stream's overall output",
+                default=stream.n_chans,
+                initial_status=Sensor.Status.NOMINAL,
+            ),
+            Sensor(
+                int,
+                f"{stream.name}.n-chans-per-substream",
+                "Number of channels in each substream for this data stream",
+                default=stream.n_chans_per_substream,
                 initial_status=Sensor.Status.NOMINAL,
             ),
             data_suspect_sensor,
@@ -1073,20 +1087,6 @@ def _make_xbgpu(
                     f"{stream.name}.n-bls",
                     "The number of baselines produced by this correlator instrument.",
                     default=stream.n_baselines,
-                    initial_status=Sensor.Status.NOMINAL,
-                ),
-                Sensor(
-                    int,
-                    f"{stream.name}.n-chans",
-                    "The number of frequency channels in an integration",
-                    default=stream.n_chans,
-                    initial_status=Sensor.Status.NOMINAL,
-                ),
-                Sensor(
-                    int,
-                    f"{stream.name}.n-chans-per-substream",
-                    "Number of channels in each substream for this X-engine stream",
-                    default=stream.n_chans_per_substream,
                     initial_status=Sensor.Status.NOMINAL,
                 ),
                 SumSensor(

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -78,6 +78,10 @@ if TYPE_CHECKING:
 
 
 _T = TypeVar("_T")
+GpucbfXBStream = Union[
+    product_config.GpucbfBaselineCorrelationProductsStream,
+    product_config.GpucbfTiedArrayChannelisedVoltageStream,
+]
 
 
 def normalise_gpu_name(name):
@@ -557,6 +561,18 @@ def _fgpu_key(stream: product_config.GpucbfAntennaChannelisedVoltageStream) -> t
     )
 
 
+def _xbgpu_key(stream: GpucbfXBStream) -> tuple:
+    """Comparison key for an X/B stream.
+
+    The keys for two streams should be the same if and only if they can run
+    in the same engine.
+    """
+    return (
+        stream.antenna_channelised_voltage.name,
+        stream.command_line_extra,
+    )
+
+
 def _make_fgpu(
     g: networkx.MultiDiGraph,
     configuration: Configuration,
@@ -926,24 +942,23 @@ def _make_xbgpu(
     configuration: Configuration,
     sync_time: int,
     sensors: SensorSet,
-    xstream: product_config.GpucbfBaselineCorrelationProductsStream,
-    bstreams: Sequence[product_config.GpucbfTiedArrayChannelisedVoltageStream],
+    streams: Iterable[GpucbfXBStream],
 ) -> scheduler.LogicalNode:
+    # Ensure that streams is a sequence, not just an iterable. Also put
+    # baseline correlation products first (typically there will just be one,
+    # and this will ensure it becomes base_name below) and sort by name after
+    # that.
+    streams = sorted(
+        streams,
+        key=lambda stream: (
+            not isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream),
+            stream.name,
+        ),
+    )
+
     ibv = not configuration.options.develop.disable_ibverbs
-    # TODO: Clarify type annotation of `bstreams`
-    all_streams: Sequence[
-        Union[
-            product_config.GpucbfBaselineCorrelationProductsStream,
-            product_config.GpucbfTiedArrayChannelisedVoltageStream,
-        ]
-    ]
-    # if bstreams:
-    #     all_streams = bstreams
-    # else:
-    #     all_streams = [xstream]
-    all_streams = [xstream, *bstreams]
-    acv = all_streams[0].antenna_channelised_voltage
-    n_engines = all_streams[0].n_substreams
+    acv = streams[0].antenna_channelised_voltage
+    n_engines = streams[0].n_substreams
     n_inputs = len(acv.src_streams)
 
     # Input labels list `h` and `v` pols separately so the reshape is to
@@ -951,11 +966,12 @@ def _make_xbgpu(
     ants = np.array(acv.input_labels).reshape(-1, 2)
     n_ants = ants.shape[0]
 
-    base_name = "base-name-placeholder"
+    base_name = streams[0].name
     xbgpu_group = LogicalGroup(f"xbgpu.{base_name}")
     dst_multicasts = []
     g.add_node(xbgpu_group)
-    for stream in all_streams:
+    data_suspect_sensors = []
+    for stream in streams:
         dst_multicast = LogicalMulticast(
             stream.name, stream.n_substreams, initial_transmit_state=TransmitState.DOWN
         )
@@ -968,9 +984,10 @@ def _make_xbgpu(
             f"{stream.name}.channel-data-suspect",
             "A bitmask of flags indicating whether each channel should be considered "
             "to be garbage.",
-            default="0" * all_streams[0].n_chans,  # type: ignore
+            default="0" * streams[0].n_chans,  # type: ignore
             initial_status=Sensor.Status.NOMINAL,
         )
+        data_suspect_sensors.append(data_suspect_sensor)
 
         stream_sensors: List[Sensor] = [
             Sensor(
@@ -1022,7 +1039,7 @@ def _make_xbgpu(
                             idx = get_baseline_index(a1, a2) * 4 + p1 + p2 * 2
                             bls_ordering[idx] = (ants[a1, p1], ants[a2, p2])
             n_accs = round(
-                xstream.int_time * acv.adc_sample_rate / acv.n_samples_between_spectra
+                stream.int_time * acv.adc_sample_rate / acv.n_samples_between_spectra
             )  # type: ignore
 
             xstream_sensors: List[Sensor] = [
@@ -1112,7 +1129,6 @@ def _make_xbgpu(
             telstate_data = {
                 "src_streams": [stream.antenna_channelised_voltage],
                 "instrument_dev_name": "gpucbf",  # Made-up instrument name
-                "n_beams": len(bstreams),
                 "bandwidth": acv.bandwidth,
                 "n_chans_per_substream": stream.n_chans_per_substream,
             }
@@ -1149,120 +1165,121 @@ def _make_xbgpu(
     # Memory allocated for buffering and reordering incoming data
     recv_buffer = free_chunks * chunk_size
 
-    for stream in all_streams:
-        send_buffer = 0
-        if isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
-            # Compute how much memory to provide for output
-            vis_size = (
-                stream.n_baselines
-                * stream.n_chans_per_substream
-                * stream.bits_per_sample
-                // 8
-                * COMPLEX
+    for i in range(n_engines):
+        # One Process per section of the band
+        xbgpu = ProductLogicalTask(f"xb.{base_name}.{i}", streams=streams, index=i)
+        xbgpu.subsystem = "cbf"
+        xbgpu.image = "katgpucbf"
+        xbgpu.fake_katcp_server_cls = FakeXbgpuDeviceServer
+        # Affects relative share, between processes
+        # All this is mainly about packing alongside each othere
+        xbgpu.cpus = 0.5 * bw_scale if configuration.options.develop.less_resources else 1.5
+        xbgpu.mem = 512 + _mb(recv_buffer)
+        if not configuration.options.develop.less_resources:
+            xbgpu.cores = ["src", "dst"]
+            xbgpu.numa_nodes = 0.5 * bw_scale  # It's easily starved of bandwidth
+            taskset = ["taskset", "-c", "{cores[dst]}"]
+        else:
+            taskset = []
+        xbgpu.ports = ["port", "prometheus", "aiomonitor", "aioconsole"]
+        xbgpu.wait_ports = ["port", "prometheus"]
+        # Note: we use just one name for the input stream, even though we only
+        # subscribe to a single multicast group of many. Every xbgpu receives
+        # data from every fgpu, so finer-grained tracking is not useful. For
+        # the destination it is more useful.
+        xbgpu.interfaces = [
+            scheduler.InterfaceRequest(
+                "cbf",
+                infiniband=ibv,
+                multicast_in={acv.name},
+                multicast_out={(stream, i) for stream in streams},
             )
-            # intermediate accumulators (* 2 because they're 64-bit not 32-bit)
-            mid_vis_size = batches_per_chunk * vis_size * 2
-            send_buffer = vis_size * 5  # Magic number is default in XSend class
-        elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
-            # TODO: How big does this data size need to be? Maybe the buffer needs to
-            # accommodate for len(bstreams), but not `beam_size` itself?
-            # But also, we get rid of the beam dimension when actually sending data
-            # TODO: Rename this variable
-            beam_size = (
-                batches_per_chunk
-                * len(bstreams)
-                * stream.n_chans_per_substream
-                * stream.spectra_per_heap
-                * COMPLEX
-            )
-            send_buffer = beam_size * 2  # Magic number default for xbgpu
-
-        # TODO: Increment the final octet of the dst address
-        for i in range(0, stream.n_substreams):
-            # One Process per section of the band
-            xbgpu = ProductLogicalTask(f"xb.{stream.name}.{i}", streams=[stream], index=i)
-            xbgpu.subsystem = "cbf"
-            xbgpu.image = "katgpucbf"
-            xbgpu.fake_katcp_server_cls = FakeXbgpuDeviceServer
-            # Affects relative share, between processes
-            # All this is mainly about packing alongside each othere
-            xbgpu.cpus = 0.5 * bw_scale if configuration.options.develop.less_resources else 1.5
-            xbgpu.mem = 512 + _mb(recv_buffer + send_buffer)
-            if not configuration.options.develop.less_resources:
-                xbgpu.cores = ["src", "dst"]
-                xbgpu.numa_nodes = 0.5 * bw_scale  # It's easily starved of bandwidth
-                taskset = ["taskset", "-c", "{cores[dst]}"]
-            else:
-                taskset = []
-            xbgpu.ports = ["port", "prometheus", "aiomonitor", "aioconsole"]
-            xbgpu.wait_ports = ["port", "prometheus"]
-            # Note: we use just one name for the input stream, even though we only
-            # subscribe to a single multicast group of many. Every xbgpu receives
-            # data from every fgpu, so finer-grained tracking is not useful. For
-            # the destination it is more useful.
-            xbgpu.interfaces = [
-                scheduler.InterfaceRequest(
-                    "cbf", infiniband=ibv, multicast_in={acv.name}, multicast_out={(stream, i)}
-                )
-            ]
-            xbgpu.interfaces[0].bandwidth_in = acv.data_rate() / n_engines
-            xbgpu.interfaces[0].bandwidth_out = stream.data_rate() / n_engines
-            xbgpu.gpus = [scheduler.GPURequest()]
-            xbgpu.gpus[0].compute = 0.15 * bw_scale
+        ]
+        xbgpu.interfaces[0].bandwidth_in = acv.data_rate() / n_engines
+        xbgpu.interfaces[0].bandwidth_out = (
+            sum(stream.data_rate() for stream in streams) / n_engines
+        )
+        xbgpu.gpus = [scheduler.GPURequest()]
+        xbgpu.gpus[0].compute = (
+            0.15 * bw_scale
+        )  # TODO: update depending on number and type of streams
+        xbgpu.gpus[0].mem = 300 + _mb(3 * chunk_size)
+        for stream in streams:
             if isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
-                xbgpu.gpus[0].mem = 300 + _mb(3 * chunk_size + 2 * vis_size + mid_vis_size)
+                # Compute how much memory to provide for output
+                vis_size = (
+                    stream.n_baselines
+                    * stream.n_chans_per_substream
+                    * stream.bits_per_sample
+                    // 8
+                    * COMPLEX
+                )
+                # intermediate accumulators (* 2 because they're 64-bit not 32-bit)
+                mid_vis_size = batches_per_chunk * vis_size * 2
+                xbgpu.mem += _mb(vis_size * 5)  # Magic number is default in XSend class
+                xbgpu.gpus[0].mem += _mb(2 * vis_size + mid_vis_size)
+                # Minimum capability as a function of bits-per-sample, based on
+                # tensor_core_correlation_kernel.mako from katgpucbf.xbgpu.
+                min_compute_capability = {4: (7, 3), 8: (7, 2), 16: (7, 0)}
+                xbgpu.gpus[0].min_compute_capability = min_compute_capability[acv.bits_per_sample]
             elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
-                # TODO: Clarify how to accommodate for beamform.mako::cplx accum (float2 dtype)
-                xbgpu.gpus[0].mem = 300 + _mb(3 * chunk_size)
-                # xbgpu.gpus[0].mem = 300 + _mb(3 * chunk_size + 2 * vis_size + mid_vis_size)
+                # TODO: Update xbgpu.mem and xbgpu.gpus[0].mem
+                # TODO: How big does this data size need to be? Maybe the buffer needs to
+                # accommodate for len(bstreams), but not `beam_size` itself?
+                # But also, we get rid of the beam dimension when actually sending data
+                # TODO: Rename this variable
+                beam_size = (
+                    batches_per_chunk
+                    * stream.n_chans_per_substream
+                    * stream.spectra_per_heap
+                    * COMPLEX
+                )
+                xbgpu.mem += _mb(beam_size * 2)  # Magic number default for xbgpu
 
-            # Minimum capability as a function of bits-per-sample, based on
-            # tensor_core_correlation_kernel.mako from katgpucbf.xbgpu.
-            min_compute_capability = {4: (7, 3), 8: (7, 2), 16: (7, 0)}
-            xbgpu.gpus[0].min_compute_capability = min_compute_capability[acv.bits_per_sample]
-            first_dig = acv.sources(0)[0]
-            heap_time = acv.n_samples_between_spectra / acv.adc_sample_rate * acv.n_spectra_per_heap
-            xbgpu.command = (
-                ["schedrr"]
-                + taskset
-                + [
-                    "xbgpu",
-                    "--adc-sample-rate",
-                    str(first_dig.adc_sample_rate),
-                    "--array-size",
-                    str(len(acv.src_streams) // 2),  # 2 pols per antenna
-                    "--channels",
-                    str(stream.n_chans),
-                    "--channels-per-substream",
-                    str(stream.n_chans_per_substream),
-                    "--samples-between-spectra",
-                    str(acv.n_samples_between_spectra),
-                    "--spectra-per-heap",
-                    str(acv.n_spectra_per_heap),
-                    "--heaps-per-fengine-per-chunk",
-                    str(batches_per_chunk),
-                    "--channel-offset-value",
-                    str(i * stream.n_chans_per_substream),
-                    "--sample-bits",
-                    str(acv.bits_per_sample),
-                    "--src-interface",
-                    "{interfaces[cbf].name}",
-                    "--dst-interface",
-                    "{interfaces[cbf].name}",
-                    "--sync-epoch",
-                    str(sync_time),
-                    "--katcp-port",
-                    "{ports[port]}",
-                    "--prometheus-port",
-                    "{ports[prometheus]}",
-                    "--aiomonitor",
-                    "--aiomonitor-port",
-                    "{ports[aiomonitor]}",
-                    "--aioconsole-port",
-                    "{ports[aioconsole]}",
-                ]
-            )
+        first_dig = acv.sources(0)[0]
+        heap_time = acv.n_samples_between_spectra / acv.adc_sample_rate * acv.n_spectra_per_heap
+        xbgpu.command = (
+            ["schedrr"]
+            + taskset
+            + [
+                "xbgpu",
+                "--adc-sample-rate",
+                str(first_dig.adc_sample_rate),
+                "--array-size",
+                str(len(acv.src_streams) // 2),  # 2 pols per antenna
+                "--channels",
+                str(acv.n_chans),
+                "--channels-per-substream",
+                str(acv.n_chans_per_substream),
+                "--samples-between-spectra",
+                str(acv.n_samples_between_spectra),
+                "--spectra-per-heap",
+                str(acv.n_spectra_per_heap),
+                "--heaps-per-fengine-per-chunk",
+                str(batches_per_chunk),
+                "--channel-offset-value",
+                str(i * acv.n_chans_per_substream),
+                "--sample-bits",
+                str(acv.bits_per_sample),
+                "--src-interface",
+                "{interfaces[cbf].name}",
+                "--dst-interface",
+                "{interfaces[cbf].name}",
+                "--sync-epoch",
+                str(sync_time),
+                "--katcp-port",
+                "{ports[port]}",
+                "--prometheus-port",
+                "{ports[prometheus]}",
+                "--aiomonitor",
+                "--aiomonitor-port",
+                "{ports[aiomonitor]}",
+                "--aioconsole-port",
+                "{ports[aioconsole]}",
+            ]
+        )
 
+        for stream in streams:
             if isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
                 output_config = {
                     "name": escape_format(stream.name),
@@ -1274,97 +1291,95 @@ def _make_xbgpu(
                     ",".join(f"{key}={value}" for (key, value) in output_config.items()),
                 ]
             elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
-                for beam_config in bstreams:
-                    output_config = {
-                        "name": escape_format(beam_config.name),
-                        # TODO: Clarify how this works in order to increment dst address in
-                        # an orderly fashion. Maybe we can dictate an `output_address_base`?
-                        "dst": f"{{endpoints_vector[multicast.{beam_config.name}_spead][{i}]}}",
-                        "pol": beam_config.src_pol,
-                    }
-                    xbgpu.command += [
-                        "--beam",
-                        ",".join(f"{key}={value}" for (key, value) in output_config.items()),
-                    ]
-
-            if not configuration.options.develop.less_resources:
+                output_config = {
+                    "name": escape_format(stream.name),
+                    "dst": f"{{endpoints_vector[multicast.{stream.name}_spead][{i}]}}",
+                    "pol": stream.src_pol,
+                }
                 xbgpu.command += [
-                    "--src-affinity",
+                    "--beam",
+                    ",".join(f"{key}={value}" for (key, value) in output_config.items()),
+                ]
+
+        if not configuration.options.develop.less_resources:
+            xbgpu.command += [
+                "--src-affinity",
+                "{cores[src]}",
+                "--dst-affinity",
+                "{cores[dst]}",
+            ]
+        xbgpu.capabilities.append("SYS_NICE")  # For schedrr
+        if ibv:
+            # Enable cap_net_raw capability for access to raw QPs
+            xbgpu.capabilities.append("NET_RAW")
+            xbgpu.command += [
+                "--src-ibv",
+                "--dst-ibv",
+            ]
+            if not configuration.options.develop.less_resources:
+                # Use the core number as completion vector. This ensures that
+                # multiple instances on a machine will use distinct vectors.
+                xbgpu.command += [
+                    "--src-comp-vector",
                     "{cores[src]}",
-                    "--dst-affinity",
+                    "--dst-comp-vector",
                     "{cores[dst]}",
                 ]
-            xbgpu.capabilities.append("SYS_NICE")  # For schedrr
-            if ibv:
-                # Enable cap_net_raw capability for access to raw QPs
-                xbgpu.capabilities.append("NET_RAW")
-                xbgpu.command += [
-                    "--src-ibv",
-                    "--dst-ibv",
-                ]
-                if not configuration.options.develop.less_resources:
-                    # Use the core number as completion vector. This ensures that
-                    # multiple instances on a machine will use distinct vectors.
-                    xbgpu.command += [
-                        "--src-comp-vector",
-                        "{cores[src]}",
-                        "--dst-comp-vector",
-                        "{cores[dst]}",
-                    ]
-            xbgpu.command += stream.command_line_extra
-            # xbgpu doesn't use katsdpservices for configuration, or telstate
-            xbgpu.katsdpservices_config = False
-            xbgpu.pass_telstate = False
-            xbgpu.data_suspect_sensors = [data_suspect_sensor]
-            xbgpu.data_suspect_range = (
-                i * stream.n_chans_per_substream,
-                (i + 1) * stream.n_chans_per_substream,
-            )
-            xbgpu.critical = False  # Can survive losing individual engines
-            g.add_node(xbgpu)
+        xbgpu.command += streams[0].command_line_extra
+        # xbgpu doesn't use katsdpservices for configuration, or telstate
+        xbgpu.katsdpservices_config = False
+        xbgpu.pass_telstate = False
+        xbgpu.data_suspect_sensors = data_suspect_sensors
+        xbgpu.data_suspect_range = (
+            i * acv.n_chans_per_substream,
+            (i + 1) * acv.n_chans_per_substream,
+        )
+        xbgpu.critical = False  # Can survive losing individual engines
+        g.add_node(xbgpu)
 
-            # Wire it up to the multicast streams
-            src_multicast = find_node(g, f"multicast.{acv.name}")
-            g.add_edge(
-                xbgpu,
-                src_multicast,
-                port="spead",
-                depends_resolve=True,
-                depends_init=True,
-                depends_ready=True,
-            )
-            for dst_multicast in dst_multicasts:
-                g.add_edge(xbgpu, dst_multicast, port="spead", depends_resolve=True)
-            xbgpu.command += [
-                f"{{endpoints_vector[multicast.{acv.name}_spead][{i}]}}",
-            ]
+        # Wire it up to the multicast streams
+        src_multicast = find_node(g, f"multicast.{acv.name}")
+        g.add_edge(
+            xbgpu,
+            src_multicast,
+            port="spead",
+            depends_resolve=True,
+            depends_init=True,
+            depends_ready=True,
+        )
+        for dst_multicast in dst_multicasts:
+            g.add_edge(xbgpu, dst_multicast, port="spead", depends_resolve=True)
+        xbgpu.command += [
+            f"{{endpoints_vector[multicast.{acv.name}_spead][{i}]}}",
+        ]
 
-            # Link it to the group, so that downstream tasks need only depend on the group.
-            g.add_edge(xbgpu_group, xbgpu, depends_ready=True, depends_init=True)
+        # Link it to the group, so that downstream tasks need only depend on the group.
+        g.add_edge(xbgpu_group, xbgpu, depends_ready=True, depends_init=True)
 
-            # Rename sensors that are relevant to the stream rather than the process
-            for name in [
-                "rx.timestamp",
-                "rx.unixtime",
-                "rx.missing-unixtime",
-            ]:
-                xbgpu.sensor_renames[name] = f"{stream.name}.{i}.{name}"
+        # Rename sensors that are relevant to the stream rather than the process
+        for name in [
+            "rx.timestamp",
+            "rx.unixtime",
+            "rx.missing-unixtime",
+        ]:
+            xbgpu.sensor_renames[name] = [f"{stream.name}.{i}.{name}" for stream in streams]
 
-            # Rename sensors that are relevant to the stream rather than the Pipeline
-            for name in [
-                "chan-range",
-                "rx.synchronised",
-                "xeng-clip-cnt",
-            ]:
+        # Rename sensors that are relevant to the stream rather than the Pipeline
+        for stream in streams:
+            if isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
+                renames = ["chan-range", "rx.synchronised", "xeng-clip-cnt"]
+            elif isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
+                renames = ["chan-range", "beng-clip-cnt"]
+            for name in renames:
                 xbgpu.sensor_renames[f"{stream.name}.{name}"] = f"{stream.name}.{i}.{name}"
 
-            xbgpu.static_gauges["xbgpu_expected_input_heaps_per_second"] = (
-                acv.adc_sample_rate
-                / (acv.n_samples_between_spectra * acv.n_spectra_per_heap)
-                * len(acv.src_streams)
-                / 2  # / 2 because each heap contains two pols
-            )
-            xbgpu.static_gauges["xbgpu_expected_engines"] = 1.0
+        xbgpu.static_gauges["xbgpu_expected_input_heaps_per_second"] = (
+            acv.adc_sample_rate
+            / (acv.n_samples_between_spectra * acv.n_spectra_per_heap)
+            * len(acv.src_streams)
+            / 2  # / 2 because each heap contains two pols
+        )
+        xbgpu.static_gauges["xbgpu_expected_engines"] = 1.0
 
     return xbgpu_group
 
@@ -2595,19 +2610,18 @@ def build_logical_graph(
         configuration.by_class(product_config.GpucbfAntennaChannelisedVoltageStream), key=_fgpu_key
     ):
         _make_fgpu(g, configuration, fgpu_streams, sync_time)
-    # TODO: Use a key for concurrent scheduling
-    bstreams = configuration.by_class(product_config.GpucbfTiedArrayChannelisedVoltageStream)
-    xstreams = configuration.by_class(product_config.GpucbfBaselineCorrelationProductsStream)
-    if xstreams:
-        for stream in xstreams:
-            _make_xbgpu(
-                g,
-                configuration,
-                xstream=stream,
-                bstreams=bstreams,
-                sync_time=sync_time,
-                sensors=sensors,
-            )
+    for xbgpu_streams in _groupby(
+        configuration.by_class(product_config.GpucbfTiedArrayChannelisedVoltageStream)
+        + configuration.by_class(product_config.GpucbfBaselineCorrelationProductsStream),
+        key=_xbgpu_key,
+    ):
+        _make_xbgpu(
+            g,
+            configuration,
+            streams=xbgpu_streams,
+            sync_time=sync_time,
+            sensors=sensors,
+        )
 
     # Pair up spectral and continuum L0 outputs
     l0_done = set()

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -935,6 +935,7 @@ def _make_xbgpu(
         Union[
             product_config.GpucbfBaselineCorrelationProductsStream,
             product_config.GpucbfTiedArrayChannelisedVoltageStream,
+            None,
         ]
     ] = [xstream] + bstreams
     acv = all_streams[0].antenna_channelised_voltage
@@ -961,7 +962,7 @@ def _make_xbgpu(
             f"{stream.name}.channel-data-suspect",
             "A bitmask of flags indicating whether each channel should be considered "
             "to be garbage.",
-            default="0" * xstream.n_chans,
+            default="0" * xstream.n_chans,  # type: ignore
             initial_status=Sensor.Status.NOMINAL,
         )
 
@@ -1014,7 +1015,9 @@ def _make_xbgpu(
                         for p2 in range(2):
                             idx = get_baseline_index(a1, a2) * 4 + p1 + p2 * 2
                             bls_ordering[idx] = (ants[a1, p1], ants[a2, p2])
-            n_accs = round(xstream.int_time * acv.adc_sample_rate / acv.n_samples_between_spectra)
+            n_accs = round(
+                xstream.int_time * acv.adc_sample_rate / acv.n_samples_between_spectra
+            )  # type: ignore
 
             xstream_sensors: List[Sensor] = [
                 Sensor(

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -937,11 +937,11 @@ def _make_xbgpu(
             product_config.GpucbfTiedArrayChannelisedVoltageStream,
         ]
     ]
-    if bstreams:
-        all_streams = bstreams
-    else:
-        all_streams = [xstream]
-    # all_streams = [xstream] + bstreams
+    # if bstreams:
+    #     all_streams = bstreams
+    # else:
+    #     all_streams = [xstream]
+    all_streams = [xstream, *bstreams]
     acv = all_streams[0].antenna_channelised_voltage
     n_engines = all_streams[0].n_substreams
     n_inputs = len(acv.src_streams)
@@ -1177,6 +1177,7 @@ def _make_xbgpu(
 
         # TODO: Increment the final octet of the dst address
         for i in range(0, stream.n_substreams):
+            # One Process per section of the band
             xbgpu = ProductLogicalTask(f"xb.{stream.name}.{i}", streams=[stream], index=i)
             xbgpu.subsystem = "cbf"
             xbgpu.image = "katgpucbf"

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -926,8 +926,8 @@ def _make_xbgpu(
     configuration: Configuration,
     sync_time: int,
     sensors: SensorSet,
-    xstream: product_config.GpucbfBaselineCorrelationProductsStream | None,
-    bstreams: List[product_config.GpucbfTiedArrayChannelisedVoltageStream] | None,
+    bstreams: List[product_config.GpucbfTiedArrayChannelisedVoltageStream],
+    xstream: Optional[product_config.GpucbfBaselineCorrelationProductsStream] = None,
 ) -> scheduler.LogicalNode:
     ibv = not configuration.options.develop.disable_ibverbs
     # TODO: Clarify type annotation of `bstreams`

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1145,7 +1145,6 @@ def _make_xbgpu(
         // 8
     )
     bw_scale = input_rate / (acv.n_substreams * defaults.XBGPU_MAX_SRC_DATA_RATE)
-    logger.info(f"Input rate: {input_rate} | BW Scale: {bw_scale}")
 
     # Compute how much memory to provide for input
 
@@ -1227,7 +1226,7 @@ def _make_xbgpu(
                 min_compute_capability = {4: (7, 3), 8: (7, 2), 16: (7, 0)}
                 xbgpu.gpus[0].min_compute_capability = min_compute_capability[acv.bits_per_sample]
             elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
-                # TODO: Update xbgpu.mem and xbgpu.gpus[0].mem
+                # TODO: NGC-1222 Update xbgpu.mem and xbgpu.gpus[0].mem
                 beam_size = (
                     batches_per_chunk
                     * stream.n_chans_per_substream

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1108,6 +1108,7 @@ def _make_xbgpu(
             for xsensor in xstream_sensors:
                 stream_sensors.append(xsensor)
         elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
+            # TODO: NGC-447
             pass
 
         # Add all sensors for all streams
@@ -1177,7 +1178,6 @@ def _make_xbgpu(
 
         # This is just the number of cores
         xbgpu.cpus = 0.5 * bw_scale if configuration.options.develop.less_resources else 1.5
-        logger.info(f"xbgpu.cpus: {xbgpu.cpus}")
         xbgpu.mem = 512 + _mb(recv_buffer)
         if not configuration.options.develop.less_resources:
             xbgpu.cores = ["src", "dst"]
@@ -1228,10 +1228,6 @@ def _make_xbgpu(
                 xbgpu.gpus[0].min_compute_capability = min_compute_capability[acv.bits_per_sample]
             elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
                 # TODO: Update xbgpu.mem and xbgpu.gpus[0].mem
-                # TODO: How big does this data size need to be? Maybe the buffer needs to
-                # accommodate for len(bstreams), but not `beam_size` itself?
-                # But also, we get rid of the beam dimension when actually sending data
-                # TODO: Rename this variable
                 beam_size = (
                     batches_per_chunk
                     * stream.n_chans_per_substream
@@ -1240,7 +1236,6 @@ def _make_xbgpu(
                 )
                 xbgpu.mem += _mb(beam_size * 2)  # Magic number default for xbgpu
 
-        logger.info(f"CPU Memory: {xbgpu.mem} MB")
         first_dig = acv.sources(0)[0]
         heap_time = acv.n_samples_between_spectra / acv.adc_sample_rate * acv.n_spectra_per_heap
         xbgpu.command = (

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1128,7 +1128,7 @@ def _make_xbgpu(
             }
         elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
             telstate_data = {
-                "src_streams": [stream.antenna_channelised_voltage],
+                "src_streams": [stream.antenna_channelised_voltage.name],
                 "instrument_dev_name": "gpucbf",  # Made-up instrument name
                 "bandwidth": acv.bandwidth,
                 "n_chans_per_substream": stream.n_chans_per_substream,

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -926,20 +926,30 @@ def _make_xbgpu(
     configuration: Configuration,
     sync_time: int,
     sensors: SensorSet,
-    bstreams: List[product_config.GpucbfTiedArrayChannelisedVoltageStream],
-    # xstream: Optional[product_config.GpucbfBaselineCorrelationProductsStream],
+    xstream: product_config.GpucbfBaselineCorrelationProductsStream,
+    bstreams: Sequence[product_config.GpucbfTiedArrayChannelisedVoltageStream],
 ) -> scheduler.LogicalNode:
     ibv = not configuration.options.develop.disable_ibverbs
     # TODO: Clarify type annotation of `bstreams`
-    all_streams = bstreams
+    all_streams: Sequence[
+        Union[
+            product_config.GpucbfBaselineCorrelationProductsStream,
+            product_config.GpucbfTiedArrayChannelisedVoltageStream,
+        ]
+    ]
+    if bstreams:
+        all_streams = bstreams
+    else:
+        all_streams = [xstream]
+    # all_streams = [xstream] + bstreams
     acv = all_streams[0].antenna_channelised_voltage
     n_engines = all_streams[0].n_substreams
     n_inputs = len(acv.src_streams)
 
     # Input labels list `h` and `v` pols separately so the reshape is to
     # make the process a bit smoother.
-    # ants = np.array(acv.input_labels).reshape(-1, 2)
-    # n_ants = ants.shape[0]
+    ants = np.array(acv.input_labels).reshape(-1, 2)
+    n_ants = ants.shape[0]
 
     for stream in all_streams:
         xbgpu_group = LogicalGroup(f"xbgpu.{stream.name}")
@@ -994,92 +1004,92 @@ def _make_xbgpu(
             data_suspect_sensor,
         ]
 
-        # if isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
+        if isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
 
-        #     def get_baseline_index(a1, a2):
-        #         return a2 * (a2 + 1) // 2 + a1
+            def get_baseline_index(a1, a2):
+                return a2 * (a2 + 1) // 2 + a1
 
-        #     # Calculating the inputs given the index is hard. So we iterate through
-        #     # combinations of inputs instead, and calculate the index, and update the
-        #     # relevant entry in a LUT.
-        #     bls_ordering = [None] * stream.n_baselines
-        #     for a2 in range(n_ants):
-        #         for a1 in range(a2 + 1):
-        #             for p1 in range(2):
-        #                 for p2 in range(2):
-        #                     idx = get_baseline_index(a1, a2) * 4 + p1 + p2 * 2
-        #                     bls_ordering[idx] = (ants[a1, p1], ants[a2, p2])
-        #     n_accs = round(
-        #         xstream.int_time * acv.adc_sample_rate / acv.n_samples_between_spectra
-        #     )  # type: ignore
+            # Calculating the inputs given the index is hard. So we iterate through
+            # combinations of inputs instead, and calculate the index, and update the
+            # relevant entry in a LUT.
+            bls_ordering = [None] * stream.n_baselines
+            for a2 in range(n_ants):
+                for a1 in range(a2 + 1):
+                    for p1 in range(2):
+                        for p2 in range(2):
+                            idx = get_baseline_index(a1, a2) * 4 + p1 + p2 * 2
+                            bls_ordering[idx] = (ants[a1, p1], ants[a2, p2])
+            n_accs = round(
+                xstream.int_time * acv.adc_sample_rate / acv.n_samples_between_spectra
+            )  # type: ignore
 
-        #     xstream_sensors: List[Sensor] = [
-        #         Sensor(
-        #             int,
-        #             f"{stream.name}.n-xengs",
-        #             "The number of X-engines in the instrument",
-        #             default=n_engines,
-        #             initial_status=Sensor.Status.NOMINAL,
-        #         ),
-        #         Sensor(
-        #             int,
-        #             f"{stream.name}.n-accs",
-        #             "The number of spectra that are accumulated per X-engine output",
-        #             default=n_accs,
-        #             initial_status=Sensor.Status.NOMINAL,
-        #         ),
-        #         Sensor(
-        #             float,
-        #             f"{stream.name}.int-time",
-        #             "The time, in seconds, for which the X-engines accumulate.",
-        #             "s",
-        #             default=stream.int_time,
-        #             initial_status=Sensor.Status.NOMINAL,
-        #         ),
-        #         Sensor(
-        #             int,
-        #             f"{stream.name}.xeng-out-bits-per-sample",
-        #             "X-engine output bits per sample. Per number, not complex pair- "
-        #             "Real and imaginary parts are both this wide",
-        #             default=stream.bits_per_sample,
-        #             initial_status=Sensor.Status.NOMINAL,
-        #         ),
-        #         Sensor(
-        #             str,
-        #             f"{stream.name}.bls-ordering",
-        #             "A string showing the output ordering of baseline data "
-        #             "produced by the X-engines in this instrument, as a list "
-        #             "of correlation pairs given by input label.",
-        #             default=str(bls_ordering),
-        #             initial_status=Sensor.Status.NOMINAL,
-        #         ),
-        #         Sensor(
-        #             int,
-        #             f"{stream.name}.n-bls",
-        #             "The number of baselines produced by this correlator instrument.",
-        #             default=stream.n_baselines,
-        #             initial_status=Sensor.Status.NOMINAL,
-        #         ),
-        #         SumSensor(
-        #             sensors,
-        #             f"{stream.name}.xeng-clip-cnt",
-        #             "Number of visibilities that saturated",
-        #             name_regex=re.compile(rf"{re.escape(stream.name)}\.[0-9]+\.xeng-clip-cnt"),
-        #             n_children=stream.n_substreams,
-        #         ),
-        #         SyncSensor(
-        #             sensors,
-        #             f"{stream.name}.xengs-synchronised",
-        #             "For the latest accumulation, was data present from all F-Engines "
-        #             "for all X-Engines",
-        #             name_regex=re.compile(rf"{re.escape(stream.name)}\.[0-9]+\.rx.synchronised"),
-        #             n_children=stream.n_substreams,
-        #         ),
-        #     ]
-        #     for xsensor in xstream_sensors:
-        #         stream_sensors.append(xsensor)
-        # elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
-        #     pass
+            xstream_sensors: List[Sensor] = [
+                Sensor(
+                    int,
+                    f"{stream.name}.n-xengs",
+                    "The number of X-engines in the instrument",
+                    default=n_engines,
+                    initial_status=Sensor.Status.NOMINAL,
+                ),
+                Sensor(
+                    int,
+                    f"{stream.name}.n-accs",
+                    "The number of spectra that are accumulated per X-engine output",
+                    default=n_accs,
+                    initial_status=Sensor.Status.NOMINAL,
+                ),
+                Sensor(
+                    float,
+                    f"{stream.name}.int-time",
+                    "The time, in seconds, for which the X-engines accumulate.",
+                    "s",
+                    default=stream.int_time,
+                    initial_status=Sensor.Status.NOMINAL,
+                ),
+                Sensor(
+                    int,
+                    f"{stream.name}.xeng-out-bits-per-sample",
+                    "X-engine output bits per sample. Per number, not complex pair- "
+                    "Real and imaginary parts are both this wide",
+                    default=stream.bits_per_sample,
+                    initial_status=Sensor.Status.NOMINAL,
+                ),
+                Sensor(
+                    str,
+                    f"{stream.name}.bls-ordering",
+                    "A string showing the output ordering of baseline data "
+                    "produced by the X-engines in this instrument, as a list "
+                    "of correlation pairs given by input label.",
+                    default=str(bls_ordering),
+                    initial_status=Sensor.Status.NOMINAL,
+                ),
+                Sensor(
+                    int,
+                    f"{stream.name}.n-bls",
+                    "The number of baselines produced by this correlator instrument.",
+                    default=stream.n_baselines,
+                    initial_status=Sensor.Status.NOMINAL,
+                ),
+                SumSensor(
+                    sensors,
+                    f"{stream.name}.xeng-clip-cnt",
+                    "Number of visibilities that saturated",
+                    name_regex=re.compile(rf"{re.escape(stream.name)}\.[0-9]+\.xeng-clip-cnt"),
+                    n_children=stream.n_substreams,
+                ),
+                SyncSensor(
+                    sensors,
+                    f"{stream.name}.xengs-synchronised",
+                    "For the latest accumulation, was data present from all F-Engines "
+                    "for all X-Engines",
+                    name_regex=re.compile(rf"{re.escape(stream.name)}\.[0-9]+\.rx.synchronised"),
+                    n_children=stream.n_substreams,
+                ),
+            ]
+            for xsensor in xstream_sensors:
+                stream_sensors.append(xsensor)
+        elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
+            pass
 
         # Add all sensors for all streams
         for ss in stream_sensors:
@@ -1091,9 +1101,9 @@ def _make_xbgpu(
                 "src_streams": [stream.antenna_channelised_voltage.name],
                 "instrument_dev_name": "gpucbf",  # Made-up instrument name
                 "bandwidth": acv.bandwidth,
-                # "bls_ordering": bls_ordering,
+                "bls_ordering": bls_ordering,
                 "int_time": stream.int_time,
-                # "n_accs": n_accs,
+                "n_accs": n_accs,
                 "n_chans_per_substream": stream.n_chans_per_substream,
             }
         elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
@@ -1137,21 +1147,20 @@ def _make_xbgpu(
     # Memory allocated for buffering and reordering incoming data
     recv_buffer = free_chunks * chunk_size
 
-    for stream in all_streams:
+    for stream in bstreams:
         send_buffer = 0
         if isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
-            pass
             # Compute how much memory to provide for output
-            # vis_size = (
-            #     stream.n_baselines
-            #     * stream.n_chans_per_substream
-            #     * stream.bits_per_sample
-            #     // 8
-            #     * COMPLEX
-            # )
-            # # intermediate accumulators (* 2 because they're 64-bit not 32-bit)
-            # mid_vis_size = batches_per_chunk * vis_size * 2
-            # send_buffer = vis_size * 5  # Magic number is default in XSend class
+            vis_size = (
+                stream.n_baselines
+                * stream.n_chans_per_substream
+                * stream.bits_per_sample
+                // 8
+                * COMPLEX
+            )
+            # intermediate accumulators (* 2 because they're 64-bit not 32-bit)
+            mid_vis_size = batches_per_chunk * vis_size * 2
+            send_buffer = vis_size * 5  # Magic number is default in XSend class
         elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
             # TODO: How big does this data size need to be? Maybe the buffer needs to
             # accommodate for len(bstreams), but not `beam_size` itself?
@@ -1198,8 +1207,7 @@ def _make_xbgpu(
             xbgpu.gpus = [scheduler.GPURequest()]
             xbgpu.gpus[0].compute = 0.15 * bw_scale
             if isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
-                pass
-                # xbgpu.gpus[0].mem = 300 + _mb(3 * chunk_size + 2 * vis_size + mid_vis_size)
+                xbgpu.gpus[0].mem = 300 + _mb(3 * chunk_size + 2 * vis_size + mid_vis_size)
             elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
                 # TODO: Clarify how to accommodate for beamform.mako::cplx accum (float2 dtype)
                 xbgpu.gpus[0].mem = 300 + _mb(3 * chunk_size)
@@ -2585,25 +2593,17 @@ def build_logical_graph(
         _make_fgpu(g, configuration, fgpu_streams, sync_time)
     # TODO: Use a key for concurrent scheduling
     bstreams = configuration.by_class(product_config.GpucbfTiedArrayChannelisedVoltageStream)
-    # xstreams = configuration.by_class(product_config.GpucbfBaselineCorrelationProductsStream)
-    # if xstreams:
-    #     for stream in xstreams:
-    #         _make_xbgpu(
-    #             g,
-    #             configuration,
-    #             xstream=stream,
-    #             bstreams=list(bstreams),
-    #             sync_time=sync_time,
-    #             sensors=sensors,
-    #         )
-    # else:
-    _make_xbgpu(
-        g,
-        configuration,
-        bstreams=list(bstreams),
-        sync_time=sync_time,
-        sensors=sensors,
-    )
+    xstreams = configuration.by_class(product_config.GpucbfBaselineCorrelationProductsStream)
+    if xstreams:
+        for stream in xstreams:
+            _make_xbgpu(
+                g,
+                configuration,
+                xstream=stream,
+                bstreams=bstreams,
+                sync_time=sync_time,
+                sensors=sensors,
+            )
 
     # Pair up spectral and continuum L0 outputs
     l0_done = set()

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -2590,7 +2590,7 @@ def build_logical_graph(
             g,
             configuration,
             xstream=stream,
-            bstreams=bstreams,
+            bstreams=list(bstreams),
             sync_time=sync_time,
             sensors=sensors,
         )

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1147,7 +1147,7 @@ def _make_xbgpu(
     # Memory allocated for buffering and reordering incoming data
     recv_buffer = free_chunks * chunk_size
 
-    for stream in bstreams:
+    for stream in all_streams:
         send_buffer = 0
         if isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
             # Compute how much memory to provide for output

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -951,10 +951,10 @@ def _make_xbgpu(
     ants = np.array(acv.input_labels).reshape(-1, 2)
     n_ants = ants.shape[0]
 
+    base_name = "base-name-placeholder"
+    xbgpu_group = LogicalGroup(f"xbgpu.{base_name}")
+    g.add_node(xbgpu_group)
     for stream in all_streams:
-        xbgpu_group = LogicalGroup(f"xbgpu.{stream.name}")
-        g.add_node(xbgpu_group)
-
         dst_multicast = LogicalMulticast(
             stream.name, stream.n_substreams, initial_transmit_state=TransmitState.DOWN
         )

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -1809,7 +1809,7 @@ class Configuration:
         for stream in streams:
             self._by_class.setdefault(type(stream), []).append(stream)
 
-    def by_class(self, stream_cls: Type[_S]) -> Sequence[_S]:
+    def by_class(self, stream_cls: Type[_S]) -> List[_S]:
         return self._by_class.get(stream_cls, [])  # type: ignore
 
     @classmethod

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -1381,7 +1381,13 @@ class SubarrayProduct:
         if self.state not in {ProductState.CAPTURING, ProductState.IDLE}:
             raise FailReply(f"Cannot start or stop streams in state {self.state}")
         stream = self._find_stream(stream_name)
-        if not isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
+        if not isinstance(
+            stream,
+            (
+                product_config.GpucbfBaselineCorrelationProductsStream,
+                product_config.GpucbfTiedArrayChannelisedVoltageStream,
+            ),
+        ):
             raise FailReply(f"Stream {stream_name!r} is of the wrong type")
 
         command = "capture-start" if start else "capture-stop"

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -2338,6 +2338,15 @@ class PhysicalTask(PhysicalNode):
         taskinfo.name = self.name
         taskinfo.task_id.value = resolver.task_id_allocator()
         args = self.subst_args(resolver)
+
+        logger.error("Args to parse:")
+        for key, value in args.items():
+            logger.info(f"Param {key} has value {value}")
+
+        logger.error(f"Logical_node.command type: {type(self.logical_node.command)}")
+        for command in self.logical_node.command:
+            logger.info(f"Command to run: {command}")
+
         command = [x.format(**args) for x in self.logical_node.command]
         if self.logical_node.wrapper is not None:
             uri = Dict()

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -2338,7 +2338,6 @@ class PhysicalTask(PhysicalNode):
         taskinfo.name = self.name
         taskinfo.task_id.value = resolver.task_id_allocator()
         args = self.subst_args(resolver)
-
         command = [x.format(**args) for x in self.logical_node.command]
         if self.logical_node.wrapper is not None:
             uri = Dict()

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -2339,14 +2339,6 @@ class PhysicalTask(PhysicalNode):
         taskinfo.task_id.value = resolver.task_id_allocator()
         args = self.subst_args(resolver)
 
-        logger.error("Args to parse:")
-        for key, value in args.items():
-            logger.info(f"Param {key} has value {value}")
-
-        logger.error(f"Logical_node.command type: {type(self.logical_node.command)}")
-        for command in self.logical_node.command:
-            logger.info(f"Command to run: {command}")
-
         command = [x.format(**args) for x in self.logical_node.command]
         if self.logical_node.wrapper is not None:
             uri = Dict()

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -2010,7 +2010,7 @@ class TestController(BaseTestController):
             b"down",
         ]
         assert re.fullmatch(rb"239\.192\.\d+\.\d+\+3:7148", informs[2].arguments[1])
-        assert informs[2].arguments == [
+        assert informs[3].arguments == [
             b"gpucbf_tied_array_channelised_voltage_0y",
             mock.ANY,
             b"down",

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -1999,11 +1999,23 @@ class TestController(BaseTestController):
     async def test_capture_list_no_args(self, client: aiokatcp.Client) -> None:
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
         _, informs = await client.request("capture-list")
-        assert len(informs) == 2
+        assert len(informs) == 4
         assert informs[0].arguments == [b"gpucbf_antenna_channelised_voltage", mock.ANY, b"up"]
         assert re.fullmatch(rb"239\.192\.\d+\.\d+\+3:7148", informs[0].arguments[1])
         assert informs[1].arguments == [b"gpucbf_baseline_correlation_products", mock.ANY, b"down"]
         assert re.fullmatch(rb"239\.192\.\d+\.\d+\+3:7148", informs[1].arguments[1])
+        assert informs[2].arguments == [
+            b"gpucbf_tied_array_channelised_voltage_0x",
+            mock.ANY,
+            b"down",
+        ]
+        assert re.fullmatch(rb"239\.192\.\d+\.\d+\+3:7148", informs[2].arguments[1])
+        assert informs[2].arguments == [
+            b"gpucbf_tied_array_channelised_voltage_0y",
+            mock.ANY,
+            b"down",
+        ]
+        assert re.fullmatch(rb"239\.192\.\d+\.\d+\+3:7148", informs[3].arguments[1])
 
     async def test_capture_list_explicit_stream(self, client: aiokatcp.Client) -> None:
         await self._configure_subarray(client, SUBARRAY_PRODUCT)

--- a/test/utils.py
+++ b/test/utils.py
@@ -218,7 +218,7 @@ CONFIG = """{
 }"""  # noqa: E501
 
 CONFIG_CBF_ONLY = """{
-    "version": "3.1",
+    "version": "3.5",
     "outputs": {
         "gpucbf_m900v": {
             "type": "sim.dig.baseband_voltage",
@@ -257,6 +257,16 @@ CONFIG_CBF_ONLY = """{
             "type": "gpucbf.baseline_correlation_products",
             "src_streams": ["gpucbf_antenna_channelised_voltage"],
             "int_time": 0.5
+        },
+        "gpucbf_tied_array_channelised_voltage_0x": {
+            "type": "gpucbf.tied_array_channelised_voltage",
+            "src_streams": ["gpucbf_antenna_channelised_voltage"],
+            "src_pol": 0,
+        },
+        "gpucbf_tied_array_channelised_voltage_0y": {
+            "type": "gpucbf.tied_array_channelised_voltage",
+            "src_streams": ["gpucbf_antenna_channelised_voltage"],
+            "src_pol": 1,
         }
     },
     "config": {}

--- a/test/utils.py
+++ b/test/utils.py
@@ -87,12 +87,12 @@ CONFIG = """{
         "gpucbf_tied_array_channelised_voltage_0x": {
             "type": "gpucbf.tied_array_channelised_voltage",
             "src_streams": ["gpucbf_antenna_channelised_voltage"],
-            "src_pol": 0,
+            "src_pol": 0
         },
         "gpucbf_tied_array_channelised_voltage_0y": {
             "type": "gpucbf.tied_array_channelised_voltage",
             "src_streams": ["gpucbf_antenna_channelised_voltage"],
-            "src_pol": 1,
+            "src_pol": 1
         },
 
         "i0_antenna_channelised_voltage": {
@@ -261,12 +261,12 @@ CONFIG_CBF_ONLY = """{
         "gpucbf_tied_array_channelised_voltage_0x": {
             "type": "gpucbf.tied_array_channelised_voltage",
             "src_streams": ["gpucbf_antenna_channelised_voltage"],
-            "src_pol": 0,
+            "src_pol": 0
         },
         "gpucbf_tied_array_channelised_voltage_0y": {
             "type": "gpucbf.tied_array_channelised_voltage",
             "src_streams": ["gpucbf_antenna_channelised_voltage"],
-            "src_pol": 1,
+            "src_pol": 1
         }
     },
     "config": {}

--- a/test/utils.py
+++ b/test/utils.py
@@ -44,7 +44,7 @@ _T = TypeVar("_T")
 # The "gpucbf" correlator components are not connected up to any SDP components.
 # They're there just as a smoke test for generator.py.
 CONFIG = """{
-    "version": "3.3",
+    "version": "3.5",
     "outputs": {
         "gpucbf_m900v": {
             "type": "sim.dig.baseband_voltage",
@@ -83,6 +83,16 @@ CONFIG = """{
             "type": "gpucbf.baseline_correlation_products",
             "src_streams": ["gpucbf_antenna_channelised_voltage"],
             "int_time": 0.5
+        },
+        "gpucbf_tied_array_channelised_voltage_0x": {
+            "type": "gpucbf.tied_array_channelised_voltage",
+            "src_streams": ["gpucbf_antenna_channelised_voltage"],
+            "src_pol": 0,
+        },
+        "gpucbf_tied_array_channelised_voltage_0y": {
+            "type": "gpucbf.tied_array_channelised_voltage",
+            "src_streams": ["gpucbf_antenna_channelised_voltage"],
+            "src_pol": 1,
         },
 
         "i0_antenna_channelised_voltage": {


### PR DESCRIPTION
With assistance from @bmerry, and building on the v3.5 schema update, `generator.py::_make_xbgpu`
now accepts and launches B-engine configuration alongside X-engines. The `capture-{start, stop}` command
has been updated to acknowledge `gpucbf.tied-array-channelised-voltage` streams. There was also a minor
tweak/update to the unit test config to reflect typical usage of the B-engine streams.

The sheer length of commits is because I was using sdp-jenkins to build and test the changes - apologies for
that. Most of the interesting stuff likely happened over the last week.

Resolves: NGC-1116.