### PR TITLE
Add gpucbf B-engine sensors

### DIFF
--- a/src/katsdpcontroller/fake_servers.py
+++ b/src/katsdpcontroller/fake_servers.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2013-2023, National Research Foundation (SARAO)
+# Copyright (c) 2013-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -267,10 +267,11 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
 class FakeXbgpuDeviceServer(FakeDeviceServer):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        antennas = self.get_command_argument(int, "--array-size")
         channel_offset = self.get_command_argument(int, "--channel-offset-value")
         channels_per_substream = self.get_command_argument(int, "--channels-per-substream")
-        beam_outpus = self.get_command_arguments(_parse_key_val, "--beam")
-        beam_names = [beam["name"] for beam in beam_outpus]
+        beam_outputs = self.get_command_arguments(_parse_key_val, "--beam")
+        beam_names = [beam["name"] for beam in beam_outputs]
         corrprod_outputs = self.get_command_arguments(_parse_key_val, "--corrprod")
         corrprod_names = [corrprod["name"] for corrprod in corrprod_outputs]
 
@@ -284,13 +285,15 @@ class FakeXbgpuDeviceServer(FakeDeviceServer):
                     initial_status=Sensor.Status.NOMINAL,
                 )
             )
+            default_delays_str = str([0.0] * antennas)
             self.sensors.add(
                 Sensor(
                     str,
                     f"{beam_name}.delay",
-                    "The delay settings of the inputs for this beam: (loadmcnt "
-                    "<ADC sample count when model was loaded>, delay <in seconds>,"
-                    "phase <radians>, ...)",
+                    "The delay settings of the inputs for this beam. Each input has "
+                    "a delay [s] and phase [rad]: (loadmcnt, delay0, phase0, delay1,"
+                    "phase1, ...)",
+                    default=f"(0, {default_delays_str[1:-1]})",
                     initial_status=Sensor.Status.NOMINAL,
                 )
             )
@@ -299,7 +302,7 @@ class FakeXbgpuDeviceServer(FakeDeviceServer):
                     float,
                     f"{beam_name}.quantiser-gain",
                     "Non-complex post-summation quantiser gain applied to this beam",
-                    default=0.0,
+                    default=1.0,
                     initial_status=Sensor.Status.NOMINAL,
                 )
             )
@@ -308,6 +311,7 @@ class FakeXbgpuDeviceServer(FakeDeviceServer):
                     str,
                     f"{beam_name}.weight",
                     "The summing weights applied to all the inputs of this beam",
+                    default=str([1.0] * antennas),
                     initial_status=Sensor.Status.NOMINAL,
                 )
             )

--- a/src/katsdpcontroller/fake_servers.py
+++ b/src/katsdpcontroller/fake_servers.py
@@ -285,7 +285,7 @@ class FakeXbgpuDeviceServer(FakeDeviceServer):
                     initial_status=Sensor.Status.NOMINAL,
                 )
             )
-            default_delays_str = str([0.0] * antennas)
+            default_delays = (0,) + (0.0, 0.0) * antennas
             self.sensors.add(
                 Sensor(
                     str,
@@ -293,7 +293,7 @@ class FakeXbgpuDeviceServer(FakeDeviceServer):
                     "The delay settings of the inputs for this beam. Each input has "
                     "a delay [s] and phase [rad]: (loadmcnt, delay0, phase0, delay1,"
                     "phase1, ...)",
-                    default=f"(0, {default_delays_str[1:-1]})",
+                    default=str(default_delays),
                     initial_status=Sensor.Status.NOMINAL,
                 )
             )

--- a/src/katsdpcontroller/fake_servers.py
+++ b/src/katsdpcontroller/fake_servers.py
@@ -308,7 +308,6 @@ class FakeXbgpuDeviceServer(FakeDeviceServer):
                     str,
                     f"{beam_name}.weight",
                     "The summing weights applied to all the inputs of this beam",
-                    default="",
                     initial_status=Sensor.Status.NOMINAL,
                 )
             )

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -994,7 +994,7 @@ def _make_xbgpu(
             Sensor(
                 float,
                 f"{stream.name}.scale-factor-timestamp",
-                "Factor by which to divide instrument timestamps to convert to unix seconds",
+                "Factor by which to divide instrument timestamps to convert to seconds",
                 "Hz",
                 default=stream.adc_sample_rate,
                 initial_status=Sensor.Status.NOMINAL,

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1146,7 +1146,7 @@ def _make_xbgpu(
                 SumSensor(
                     sensors,
                     f"{stream.name}.beng-clip-cnt",
-                    "Number of visibilities that saturated",
+                    "Number of complex samples that saturated",
                     name_regex=re.compile(rf"{re.escape(stream.name)}\.[0-9]+\.xeng-clip-cnt"),
                     n_children=stream.n_substreams,
                 ),

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1143,6 +1143,13 @@ def _make_xbgpu(
                     default=f"[{source_indices}]",
                     initial_status=Sensor.Status.NOMINAL,
                 ),
+                SumSensor(
+                    sensors,
+                    f"{stream.name}.beng-clip-cnt",
+                    "Number of visibilities that saturated",
+                    name_regex=re.compile(rf"{re.escape(stream.name)}\.[0-9]+\.xeng-clip-cnt"),
+                    n_children=stream.n_substreams,
+                ),
             ]
             stream_sensors.extend(bstream_sensors)
 
@@ -1395,10 +1402,6 @@ def _make_xbgpu(
                 renames = ["chan-range", "delay", "quantiser-gain", "weight", "beng-clip-cnt"]
             for name in renames:
                 xbgpu.sensor_renames[f"{stream.name}.{name}"] = f"{stream.name}.{i}.{name}"
-                # TODO: Remove once tested
-                xbgpu.sensor_renames[
-                    f"{stream.name}.{stream.name}.{name}"
-                ] = f"99{stream.name}.{i}.{name}"
 
         xbgpu.static_gauges["xbgpu_expected_input_heaps_per_second"] = (
             acv.adc_sample_rate

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2013-2023, National Research Foundation (SARAO)
+# Copyright (c) 2013-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -654,7 +654,7 @@ def _make_fgpu(
             Sensor(
                 float,
                 f"{stream.name}.scale-factor-timestamp",
-                "Factor by which to divide instrument timestamps to convert to unix seconds",
+                "Factor by which to divide instrument timestamps to convert to seconds",
                 "Hz",
                 default=stream.adc_sample_rate,
                 initial_status=Sensor.Status.NOMINAL,
@@ -1116,15 +1116,12 @@ def _make_xbgpu(
             ]
             stream_sensors.extend(xstream_sensors)
         elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
-            source_indices = ", ".join(
-                str(i)
-                for i in range(stream.src_pol, (len(stream.antennas) * 2) + stream.src_pol, 2)
-            )
+            source_indices = str(list(range(stream.src_pol, len(stream.antennas) * 2, 2)))
             bstream_sensors: List[Sensor] = [
                 Sensor(
                     int,
                     f"{stream.name}.beng-out-bits-per-sample",
-                    "X-engine output bits per sample. Per number, not complex pair- "
+                    "B-engine output bits per sample. Per number, not complex pair- "
                     "Real and imaginary parts are both this wide",
                     default=stream.bits_per_sample,
                     initial_status=Sensor.Status.NOMINAL,
@@ -1147,7 +1144,7 @@ def _make_xbgpu(
                     sensors,
                     f"{stream.name}.beng-clip-cnt",
                     "Number of complex samples that saturated",
-                    name_regex=re.compile(rf"{re.escape(stream.name)}\.[0-9]+\.xeng-clip-cnt"),
+                    name_regex=re.compile(rf"{re.escape(stream.name)}\.[0-9]+\.beng-clip-cnt"),
                     n_children=stream.n_substreams,
                 ),
             ]


### PR DESCRIPTION
Also add 
* a SumSensor for beng-clip-cnt sensors at the Engine level - like xeng-clip-cnt, and
* a missing scale-factor-timestamp sensor.

Re: Proof this actually works
* The first screenshot/excerpt below is of a `?sensor-list` on a node running one `--corrprod` and two `--beam`s
* The second excerpt is from a `?sensor-list` on the product itself, to show the stream-level sensors

### One XB-engine's sensors
![image](https://github.com/ska-sa/katsdpcontroller/assets/25218138/e2586253-8510-4a4b-a781-8c61e1078077)

```bash
#sensor-list baseline-correlation-products.chan-range The range of channels processed by this X-engine, inclusive  string
< #sensor-list baseline-correlation-products.rx.synchronised For the latest accumulation, was data present from all F-Engines.  boolean
< #sensor-list baseline-correlation-products.xeng-clip-cnt Number of visibilities that saturated  integer
< #sensor-list device-status Overall engine health  discrete ok degraded fail
< #sensor-list rx.device-status XB-engine is receiving a good, clean F-engine stream  discrete ok degraded fail
< #sensor-list rx.missing-unixtime The timestamp (in UNIX time) when missing data was last detected  timestamp
< #sensor-list rx.timestamp The timestamp (in samples) of the last chunk of data received from an F-engine  integer
< #sensor-list rx.unixtime The timestamp (in UNIX time) of the last chunk of data received from an F-engine  timestamp
< #sensor-list tied-array-channelised-voltage0x.beng-clip-cnt Number of complex samples that saturated.  integer
< #sensor-list tied-array-channelised-voltage0x.chan-range The range of channels processed by this B-engine, inclusive  string
< #sensor-list tied-array-channelised-voltage0x.delay The delay settings of the inputs for this beam: (loadmcnt <ADC sample count when model was loaded>, delay <in seconds>, phase <radians>, ...)  string
< #sensor-list tied-array-channelised-voltage0x.quantiser-gain Non-complex post-summation quantiser gain applied to this beam  float
< #sensor-list tied-array-channelised-voltage0x.weight The summing weights applied to all the inputs of this beam  string
< #sensor-list tied-array-channelised-voltage0y.beng-clip-cnt Number of complex samples that saturated.  integer
< #sensor-list tied-array-channelised-voltage0y.chan-range The range of channels processed by this B-engine, inclusive  string
< #sensor-list tied-array-channelised-voltage0y.delay The delay settings of the inputs for this beam: (loadmcnt <ADC sample count when model was loaded>, delay <in seconds>, phase <radians>, ...)  string
< #sensor-list tied-array-channelised-voltage0y.quantiser-gain Non-complex post-summation quantiser gain applied to this beam  float
< #sensor-list tied-array-channelised-voltage0y.weight The summing weights applied to all the inputs of this beam  string
```

### Stream-level sensors
![image](https://github.com/ska-sa/katsdpcontroller/assets/25218138/f82adf26-920e-415e-b5ad-2027296fe9bd)

```bash
< #sensor-list tied-array-channelised-voltage0x.bandwidth The analogue bandwidth of the digitised band Hz float
< #sensor-list tied-array-channelised-voltage0x.beng-clip-cnt Number of visibilities that saturated  integer
< #sensor-list tied-array-channelised-voltage0x.beng-out-bits-per-sample X-engine output bits per sample. Per number, not complex pair- Real and imaginary parts are both this wide  integer< #sensor-list tied-array-channelised-voltage0x.channel-data-suspect A bitmask of flags indicating whether each channel should be considered to be garbage.  string
< #sensor-list tied-array-channelised-voltage0x.destination The IP address, range and port to which data for stream tied-array-channelised-voltage0x is sent  string
< #sensor-list tied-array-channelised-voltage0x.n-chans The number of frequency channels in this stream's overall output  integer
< #sensor-list tied-array-channelised-voltage0x.n-chans-per-substream Number of channels in each substream for this data stream  integer
< #sensor-list tied-array-channelised-voltage0x.scale-factor-timestamp Factor by which to divide instrument timestamps to convert to unix seconds Hz float
< #sensor-list tied-array-channelised-voltage0x.source-indices The global input indices of the sources summed in this beam  string
< #sensor-list tied-array-channelised-voltage0x.spectra-per-heap Number of spectra per heap of beamformer output  integer
< #sensor-list tied-array-channelised-voltage0x.sync-time The time at which the digitisers were synchronised. Seconds since the Unix Epoch. s float
```

Resolves: NGC-447.