### PR TITLE
Implement beamformer control requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 addict==2.1.1
 aiohttp
 aiohttp-jinja2==1.5.1
-aiokatcp
+aiokatcp==1.8.0
 aiozk==0.14.0
 async-timeout
 blinker==1.6.2             # via flask

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     addict!=2.0.*,!=2.4.0
     aiohttp~=3.5
     aiohttp-jinja2
-    aiokatcp>=1.7.0
+    aiokatcp>=1.8.0
     aiozk
     async_timeout
     dash>=1.18

--- a/src/katsdpcontroller/aggregate_sensors.py
+++ b/src/katsdpcontroller/aggregate_sensors.py
@@ -1,0 +1,192 @@
+################################################################################
+# Copyright (c) 2023-2024, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import re
+from typing import Any, Iterable, Optional, Tuple, Type, TypeVar
+
+from aiokatcp import (
+    AggregateSensor,
+    Reading,
+    Sensor,
+    SensorSampler,
+    SensorSet,
+    SimpleAggregateSensor,
+)
+
+_T = TypeVar("_T")
+
+
+class SumSensor(SimpleAggregateSensor[int]):
+    """Aggregate which takes the sum of its children.
+
+    It also tracks how many child readings are present, and sets the state to
+    FAILURE if they aren't all present.
+    """
+
+    def __init__(
+        self,
+        target: SensorSet,
+        name: str,
+        description: str,
+        units: str = "",
+        *,
+        auto_strategy: Optional[SensorSampler.Strategy] = None,
+        auto_strategy_parameters: Iterable[Any] = (),
+        name_regex: re.Pattern,
+        n_children: int,
+    ) -> None:
+        self.name_regex = name_regex
+        self.n_children = n_children
+        self._total = 0
+        self._known = 0
+        super().__init__(
+            target,
+            int,
+            name,
+            description,
+            units,
+            auto_strategy=auto_strategy,
+            auto_strategy_parameters=auto_strategy_parameters,
+        )
+
+    def filter_aggregate(self, sensor: Sensor) -> bool:
+        return bool(self.name_regex.fullmatch(sensor.name))
+
+    def aggregate_add(self, sensor: Sensor[_T], reading: Reading[_T]) -> bool:
+        assert isinstance(reading.value, int)
+        if reading.status.valid_value():
+            self._total += reading.value
+            self._known += 1
+            return True
+        return False
+
+    def aggregate_remove(self, sensor: Sensor[_T], reading: Reading[_T]) -> bool:
+        assert isinstance(reading.value, int)
+        if reading.status.valid_value():
+            self._total -= reading.value
+            self._known -= 1
+            return True
+        return False
+
+    def aggregate_compute(self) -> Tuple[Sensor.Status, int]:
+        status = Sensor.Status.NOMINAL if self._known == self.n_children else Sensor.Status.FAILURE
+        return (status, self._total)
+
+
+class SyncSensor(SimpleAggregateSensor[bool]):
+    """Aggregate which tracks whether its children are synchronised.
+
+    In this case,
+    - a 'synchronised' child has a reading of (True, NOMINAL), and
+    - an 'unsynchronised' child has a reading of (False, ERROR).
+    """
+
+    def __init__(
+        self,
+        target: SensorSet,
+        name: str,
+        description: str,
+        units: str = "",
+        *,
+        auto_strategy: Optional["SensorSampler.Strategy"] = None,
+        auto_strategy_parameters: Iterable[Any] = (),
+        name_regex: re.Pattern,
+        n_children: int,
+    ) -> None:
+        self.name_regex = name_regex
+        self.n_children = n_children
+        self._total_in_sync = 0
+
+        super().__init__(
+            target,
+            bool,
+            name,
+            description,
+            units,
+            auto_strategy=auto_strategy,
+            auto_strategy_parameters=auto_strategy_parameters,
+        )
+
+    def filter_aggregate(self, sensor: Sensor) -> bool:
+        return bool(self.name_regex.fullmatch(sensor.name))
+
+    def aggregate_add(self, sensor: Sensor[_T], reading: Reading[_T]) -> bool:
+        assert isinstance(reading.value, bool)
+        if reading.status.valid_value():
+            if reading.value:
+                self._total_in_sync += 1
+            return True
+        return False
+
+    def aggregate_remove(self, sensor: Sensor[_T], reading: Reading[_T]) -> bool:
+        assert isinstance(reading.value, bool)
+        if reading.status.valid_value():
+            if reading.value:
+                self._total_in_sync -= 1
+            return True
+        return False
+
+    def aggregate_compute(self) -> Tuple[Sensor.Status, bool]:
+        synchronised = self._total_in_sync == self.n_children
+        status = Sensor.Status.NOMINAL if synchronised else Sensor.Status.ERROR
+        return (status, synchronised)
+
+
+class LatestSensor(AggregateSensor[_T]):
+    """Aggregate sensor which returns the reading with the latest timestamp.
+
+    If the latest reading is later removed, because the sensor vanishes (or
+    the reading is updated with an older timestamp), the value of the
+    aggregate persists.
+    """
+
+    def __init__(
+        self,
+        target: SensorSet,
+        sensor_type: Type[_T],
+        name: str,
+        description: str,
+        units: str = "",
+        *,
+        auto_strategy: Optional["SensorSampler.Strategy"] = None,
+        auto_strategy_parameters: Iterable[Any] = (),
+        name_regex: re.Pattern,
+    ) -> None:
+        self.name_regex = name_regex
+        super().__init__(
+            target,
+            sensor_type,
+            name,
+            description,
+            units,
+            auto_strategy=auto_strategy,
+            auto_strategy_parameters=auto_strategy_parameters,
+        )
+
+    def filter_aggregate(self, sensor: Sensor[_T]) -> bool:
+        return bool(self.name_regex.fullmatch(sensor.name))
+
+    def update_aggregate(
+        self,
+        updated_sensor: Optional[Sensor],
+        reading: Optional[Reading],
+        old_reading: Optional[Reading],
+    ) -> Optional[Reading[_T]]:
+        if reading is None or not reading.status.valid_value():
+            return None  # It's not valid
+        if self.status.valid_value() and self.timestamp > reading.timestamp:
+            return None  # It's older than what we already have
+        return reading

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1023,7 +1023,7 @@ def _make_xbgpu(
                     str,
                     f"{stream.name}.source-indices",
                     "The global input indices of the sources summed in this beam",
-                    default=f"[{source_indices}]",
+                    default=f"{source_indices}",
                     initial_status=Sensor.Status.NOMINAL,
                 ),
                 SumSensor(

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1002,7 +1002,7 @@ def _make_xbgpu(
             ]
             stream_sensors.extend(xstream_sensors)
         elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
-            source_indices = str(list(range(stream.src_pol, len(stream.antennas) * 2, 2)))
+            source_indices = str(list(range(stream.src_pol, n_inputs, 2)))
             bstream_sensors: List[Sensor] = [
                 Sensor(
                     int,

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -1376,6 +1376,58 @@ class SubarrayProduct:
             timeout=GAIN_TIMEOUT,
         )
 
+    async def beam_weights(self, stream_name: str, weights: Sequence[float]) -> None:
+        if self.state not in {ProductState.CAPTURING, ProductState.IDLE}:
+            raise FailReply(f"Cannot set beam gains in state {self.state}")
+        stream = self._find_stream(stream_name)
+        if not isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
+            raise FailReply(f"Stream {stream_name!r} is of the wrong type")
+        expected = len(stream.antenna_channelised_voltage.src_streams) // 2
+        if len(weights) != expected:
+            raise FailReply(f"Expected {expected} values, received {len(weights)}")
+        await self._multi_request(
+            self.find_nodes(task_type="xb", streams=[stream]),
+            itertools.repeat(("beam-weights", stream_name) + tuple(weights)),
+            timeout=GAIN_TIMEOUT,
+        )
+
+    async def beam_quant_gains(self, stream_name: str, value: float) -> None:
+        if self.state not in {ProductState.CAPTURING, ProductState.IDLE}:
+            raise FailReply(f"Cannot set beam gains in state {self.state}")
+        stream = self._find_stream(stream_name)
+        if not isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
+            raise FailReply(f"Stream {stream_name!r} is of the wrong type")
+        await self._multi_request(
+            self.find_nodes(task_type="xb", streams=[stream]),
+            itertools.repeat(("beam-quant-gains", stream_name, value)),
+            timeout=GAIN_TIMEOUT,
+        )
+
+    async def beam_delays(self, stream_name: str, coefficient_sets: Sequence[str]) -> None:
+        if self.state not in {ProductState.CAPTURING, ProductState.IDLE}:
+            raise FailReply(f"Cannot set beam gains in state {self.state}")
+        stream = self._find_stream(stream_name)
+        if not isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
+            raise FailReply(f"Stream {stream_name!r} is of the wrong type")
+        expected = len(stream.antenna_channelised_voltage.src_streams) // 2
+        if len(coefficient_sets) != expected:
+            raise FailReply(f"Expected {expected} values, received {len(coefficient_sets)}")
+        for coefficient_set in coefficient_sets:
+            try:
+                # Parse it just for validation
+                parts = coefficient_set.split(":")
+                if len(parts) != 2:
+                    raise ValueError
+                for part in parts:
+                    float(part)
+            except ValueError:
+                raise FailReply(f"Invalid coefficient-set {coefficient_set!r}")
+        await self._multi_request(
+            self.find_nodes(task_type="xb", streams=[stream]),
+            itertools.repeat(("beam-delays", stream_name) + tuple(coefficient_sets)),
+            timeout=DELAYS_TIMEOUT,
+        )
+
     async def capture_start_stop(self, stream_name: str, *, start: bool) -> None:
         """Either start or stop transmission on a stream."""
         if self.state not in {ProductState.CAPTURING, ProductState.IDLE}:
@@ -1948,6 +2000,44 @@ class DeviceServer(aiokatcp.DeviceServer):
             "default" to restore the gains used at startup.
         """
         await self._get_product().gain_all(stream, values)
+
+    async def request_beam_weights(self, ctx, stream: str, *weights: float) -> None:
+        """Set input weights for a single beamformer data stream.
+
+        Parameters
+        ----------
+        stream
+            Tied-array-channelised-voltage stream on which to operate
+        *weights
+            Real-valued weights (one per input)
+        """
+        await self._get_product().beam_weights(stream, weights)
+
+    async def request_beam_quant_gains(self, ctx, stream: str, value: float) -> None:
+        """Set output gain of a single beamformer data stream.
+
+        Parameters
+        ----------
+        stream
+            Tied-array-channelised-voltage stream on which to operate
+        value
+            A real-value scaled factor
+        """
+        await self._get_product().beam_quant_gains(stream, value)
+
+    async def request_beam_delays(self, ctx, stream: str, *coefficient_sets: str) -> None:
+        """Set delays for a single beamformer data stream.
+
+        Parameters
+        ----------
+        stream
+            Tied-array-channelised-voltage stream on which to operate
+        *coefficient_sets
+            One coefficient set per input, each in the form <delay>:<phase>
+            where the delay is in seconds, the phase in radians and the phase
+            specifies the overall phase to apply at the centre of the band.
+        """
+        await self._get_product().beam_delays(stream, coefficient_sets)
 
     async def request_capture_start(self, ctx, stream: str) -> None:
         """Enable data transmission for the named data stream."""

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2013-2023, National Research Foundation (SARAO)
+# Copyright (c) 2013-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/test_aggregate_sensors.py
+++ b/test/test_aggregate_sensors.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2013-2023, National Research Foundation (SARAO)
+# Copyright (c) 2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/test_aggregate_sensors.py
+++ b/test/test_aggregate_sensors.py
@@ -136,17 +136,8 @@ class TestLatestSensor:
             target, int, "int-sensor", "int sensor", "bits", name_regex=re.compile("int-child-.*")
         )
 
-    @pytest.fixture
-    def str_sensor(self, target: SensorSet) -> LatestSensor[str]:
-        return LatestSensor(
-            target, str, "str-sensor", "str sensor", "", name_regex=re.compile("str-child-.*")
-        )
-
-    def test_initial_state(
-        self, int_sensor: LatestSensor[int], str_sensor: LatestSensor[str]
-    ) -> None:
+    def test_initial_state(self, int_sensor: LatestSensor[int]) -> None:
         assert int_sensor.reading == Reading(mock.ANY, Sensor.Status.UNKNOWN, 0)
-        assert str_sensor.reading == Reading(mock.ANY, Sensor.Status.UNKNOWN, "")
 
     def test_add(
         self, target: SensorSet, int_sensor: LatestSensor[int], int_children: List[Sensor[int]]

--- a/test/test_aggregate_sensors.py
+++ b/test/test_aggregate_sensors.py
@@ -37,6 +37,7 @@ def target() -> SensorSet:
 @pytest.fixture
 def int_children() -> List[Sensor[int]]:
     sensors = [Sensor(int, f"int-child-{i}", "") for i in range(4)]
+    # No status_func, so default status is NOMINAL
     sensors[0].set_value(3, timestamp=1234567890.0)
     sensors[1].set_value(4, timestamp=1234567891.0, status=Sensor.Status.WARN)
     sensors[2].set_value(5, timestamp=1234567892.0)

--- a/test/test_aggregate_sensors.py
+++ b/test/test_aggregate_sensors.py
@@ -1,0 +1,93 @@
+################################################################################
+# Copyright (c) 2013-2023, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Tests for :mod:`katsdpcontroller.aggregate_sensors`."""
+
+import re
+from typing import List
+from unittest import mock
+
+import pytest
+from aiokatcp import Reading, Sensor, SensorSet
+
+from katsdpcontroller.aggregate_sensors import LatestSensor
+
+
+@pytest.fixture
+def target() -> SensorSet:
+    return SensorSet()
+
+
+class TestLatestSensor:
+    """Test :class:`.LatestSensor`."""
+
+    @pytest.fixture
+    def int_sensor(self, target: SensorSet) -> LatestSensor[int]:
+        return LatestSensor(
+            target, int, "int-sensor", "int sensor", "bits", name_regex=re.compile("int-child-.*")
+        )
+
+    @pytest.fixture
+    def str_sensor(self, target: SensorSet) -> LatestSensor[str]:
+        return LatestSensor(
+            target, str, "str-sensor", "str sensor", "", name_regex=re.compile("str-child-.*")
+        )
+
+    @pytest.fixture
+    def int_children(self) -> List[Sensor[int]]:
+        sensors = [Sensor(int, f"int-child-{i}", "") for i in range(4)]
+        sensors[0].set_value(3, timestamp=1234567890.0)
+        sensors[1].set_value(4, timestamp=1234567891.0, status=Sensor.Status.WARN)
+        sensors[2].set_value(5, timestamp=1234567892.0)
+        sensors[3].set_value(6, timestamp=1234567893.0, status=Sensor.Status.UNREACHABLE)
+        return sensors
+
+    def test_initial_state(
+        self, int_sensor: LatestSensor[int], str_sensor: LatestSensor[str]
+    ) -> None:
+        assert int_sensor.reading == Reading(mock.ANY, Sensor.Status.UNKNOWN, 0)
+        assert str_sensor.reading == Reading(mock.ANY, Sensor.Status.UNKNOWN, "")
+
+    def test_add(
+        self, target: SensorSet, int_sensor: LatestSensor[int], int_children: List[Sensor[int]]
+    ) -> None:
+        target.add(int_children[1])
+        assert int_sensor.reading == int_children[1].reading
+        target.add(int_children[0])  # Older, so shouldn't affect it
+        assert int_sensor.reading == int_children[1].reading
+        target.add(int_children[2])  # Newer
+        assert int_sensor.reading == int_children[2].reading
+        target.add(int_children[3])  # Newer, but not a valid value
+        assert int_sensor.reading == int_children[2].reading
+
+    def test_remove(
+        self, target: SensorSet, int_sensor: LatestSensor[int], int_children: List[Sensor[int]]
+    ) -> None:
+        target.add(int_children[0])
+        target.remove(int_children[0])
+        assert int_sensor.reading == int_children[0].reading
+
+    def test_update(
+        self, target: SensorSet, int_sensor: LatestSensor[int], int_children: List[Sensor[int]]
+    ) -> None:
+        orig_reading = int_children[0].reading
+        target.add(int_children[0])
+        int_children[0].set_value(10, timestamp=123.0)  # Older, should not update
+        assert int_sensor.reading == orig_reading
+        int_children[0].set_value(20, timestamp=1234567899.0, status=Sensor.Status.UNREACHABLE)
+        assert int_sensor.reading == orig_reading
+        int_children[0].set_value(30, timestamp=1234567898.0, status=Sensor.Status.WARN)
+        assert int_sensor.reading == Reading(1234567898.0, Sensor.Status.WARN, 30)

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -1860,6 +1860,21 @@ class TestController(BaseTestController):
                 "0,0:0,0",
             ),
             # stream does not exist
+            ("beam-quant-gains", "foo", 1.0),
+            ("beam-weights", "foo", 1.0, 1.0, 1.0, 1.0),
+            ("beam-delays", "foo", "0:0", "0:0", "0:0", "0:0"),
+            # stream has wrong type
+            ("beam-quant-gains", "gpucbf_antenna_channelised_voltage", 1.0),
+            ("beam-weights", "gpucbf_antenna_channelised_voltage", 1.0, 1.0),
+            ("beam-delays", "gpucbf_antenna_channelised_voltage", "0:0", "0:0"),
+            # wrong number of arguments
+            ("beam-weights", "gpucbf_tied_array_channelised_voltage_0x", 1.0, 1.0, 1.0),
+            ("beam-delays", "gpucbf_tied_array_channelised_voltage_0x", "0:0", "0:0", "0:0"),
+            # bad delay formatting
+            ("beam-delays", "gpucbf_tied_array_channelised_voltage_0x", "0:0", "0:x"),
+            ("beam-delays", "gpucbf_tied_array_channelised_voltage_0x", "0:0", "0:0:0"),
+            ("beam-delays", "gpucbf_tied_array_channelised_voltage_0x", "0,0:0,0", "0:0"),
+            # stream does not exist
             ("capture-start", "foo"),
             # stream has wrong type
             ("capture-start", "gpucbf_antenna_channelised_voltage"),

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -768,6 +768,36 @@ class TestControllerInterface(BaseTestController):
             "(4280000000, 0.0, 0.0, 0.25, 0.0)",
         )
 
+    async def test_beam_weights(self, client: aiokatcp.Client) -> None:
+        """Test beam-weights."""
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        await client.request("beam-weights", "gpucbf_tied_array_channelised_voltage_0x", 2.0, 3.5)
+        await assert_sensor_value(
+            client, "gpucbf_tied_array_channelised_voltage_0x.weight", "[2.0, 3.5]"
+        )
+        await client.request("product-deconfigure")
+
+    async def test_beam_quant_gains(self, client: aiokatcp.Client) -> None:
+        """Test beam-quant-gains."""
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        await client.request("beam-quant-gains", "gpucbf_tied_array_channelised_voltage_0x", "2.5")
+        await assert_sensor_value(
+            client, "gpucbf_tied_array_channelised_voltage_0x.quantiser-gain", 2.5
+        )
+        await client.request("product-deconfigure")
+
+    async def test_beam_delays(self, client: aiokatcp.Client) -> None:
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        await client.request(
+            "beam-delays", "gpucbf_tied_array_channelised_voltage_0x", "0.5:0.0", "-1.5:-2.0"
+        )
+        await assert_sensor_value(
+            client,
+            "gpucbf_tied_array_channelised_voltage_0x.delay",
+            "(12345678, 0.5, 0.0, -1.5, -2.0)",
+        )
+        await client.request("product-deconfigure")
+
     async def test_input_data_suspect(self, client: aiokatcp.Client, server: DeviceServer) -> None:
         await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
         await assert_sensor_value(

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2013-2023, National Research Foundation (SARAO)
+# Copyright (c) 2013-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -110,6 +110,9 @@ STREAMS = """{
 }"""
 
 EXPECTED_REQUEST_LIST = [
+    "beam-delays",
+    "beam-quant-gains",
+    "beam-weights",
     "capture-done",
     "capture-init",
     "capture-list",

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -1867,7 +1867,7 @@ class TestController(BaseTestController):
             ("beam-quant-gains", "gpucbf_antenna_channelised_voltage", 1.0),
             ("beam-weights", "gpucbf_antenna_channelised_voltage", 1.0, 1.0),
             ("beam-delays", "gpucbf_antenna_channelised_voltage", "0:0", "0:0"),
-            # wrong number of arguments
+            # wrong number of arguments (expected 2 values but 3 provided)
             ("beam-weights", "gpucbf_tied_array_channelised_voltage_0x", 1.0, 1.0, 1.0),
             ("beam-delays", "gpucbf_tied_array_channelised_voltage_0x", "0:0", "0:0", "0:0"),
             # bad delay formatting


### PR DESCRIPTION
Add the `?beam-quant-gains`, `?beam-delays` and `?beam-weights` requests. Additionally, implement the aggregate sensors corresponding to the values of these requests, and tests for the new and existing sensor types, which are moved to their own module.