### PR TITLE
Sandbox: include lo as a gpucbf network

### DIFF
--- a/sandbox/prepare.sh
+++ b/sandbox/prepare.sh
@@ -23,8 +23,7 @@ mkdir -p "$dir/logs"
 PYTHONPATH="$dir/../src:$PYTHONPATH" python -m katsdpcontroller.agent_mkconfig \
     --attributes-dir "$dir/etc/mesos-agent/attributes" \
     --resources-dir "$dir/etc/mesos-agent/resources" \
-    --network "lo:cbf" \
-    --network "lo:sdp_10g" \
+    --network "lo:cbf,gpucbf,sdp_10g" \
     --volume "data:$dir/data" \
     --volume "data_local:$dir/data" \
     --volume "obj_data:$dir/data" \


### PR DESCRIPTION
Also change the way agent_mkconfig is invoked so that lo is treated as a single interface with connections to all three networks, instead of 3 separate interfaces. This ensures that the bandwidth can only be allocated once instead of once per virtual network.

This was missed as part of #713 (NGC-1228).