### PR TITLE
Make sandbox testing work again

### DIFF
--- a/sandbox/prepare.sh
+++ b/sandbox/prepare.sh
@@ -23,7 +23,9 @@ mkdir -p "$dir/logs"
 PYTHONPATH="$dir/../src:$PYTHONPATH" python -m katsdpcontroller.agent_mkconfig \
     --attributes-dir "$dir/etc/mesos-agent/attributes" \
     --resources-dir "$dir/etc/mesos-agent/resources" \
-    --network "lo:cbf,gpucbf,sdp_10g" \
+    --network "lo:cbf" \
+    --network "lo:gpucbf" \
+    --network "lo:sdp_10g" \
     --volume "data:$dir/data" \
     --volume "data_local:$dir/data" \
     --volume "obj_data:$dir/data" \


### PR DESCRIPTION
In #717 I was too clever and merged the `lo` interface into a single katsdpcontroller interface attached to three networks. It turns out that functionality isn't completely functional (SPR1-3043) so split it back out again.