### PR TITLE
Update to the latest version of async_solipsism

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,7 +14,7 @@ aiosignal==1.3.1
     # via
     #   -c requirements.txt
     #   aiohttp
-async-solipsism==0.5
+async-solipsism==0.6
     # via -r test-requirements.in
 async-timeout==4.0.3
     # via

--- a/test/test_master_controller.py
+++ b/test/test_master_controller.py
@@ -62,7 +62,6 @@ from .utils import (
     EXPECTED_INTERFACE_SENSOR_LIST,
     EXPECTED_PRODUCT_CONTROLLER_SENSOR_LIST,
     S3_CONFIG,
-    AsyncSolipsismEventLoopPolicy,
     Background,
     DelayedManager,
     assert_request_fails,
@@ -326,9 +325,9 @@ class TestSingularityProductManager:
             return product
 
     @pytest.fixture
-    def event_loop_policy(self) -> AsyncSolipsismEventLoopPolicy:
+    def event_loop_policy(self) -> async_solipsism.EventLoopPolicy:
         """Use async_solipsism's event loop for the tests."""
-        return AsyncSolipsismEventLoopPolicy()
+        return async_solipsism.EventLoopPolicy()
 
     @pytest.fixture
     async def singularity_server(self) -> AsyncGenerator[fake_singularity.SingularityServer, None]:
@@ -755,9 +754,9 @@ class TestDeviceServer:
     """
 
     @pytest.fixture
-    def event_loop_policy(self) -> AsyncSolipsismEventLoopPolicy:
+    def event_loop_policy(self) -> async_solipsism.EventLoopPolicy:
         """Use async_solipsism's event loop for the tests."""
-        return AsyncSolipsismEventLoopPolicy()
+        return async_solipsism.EventLoopPolicy()
 
     @pytest.fixture
     def rmock(self) -> Generator[aioresponses.aioresponses, None, None]:
@@ -1183,9 +1182,9 @@ class TestDeviceServerReal:
     """
 
     @pytest.fixture
-    def event_loop_policy(self) -> AsyncSolipsismEventLoopPolicy:
+    def event_loop_policy(self) -> async_solipsism.EventLoopPolicy:
         """Use async_solipsism's event loop for the tests."""
-        return AsyncSolipsismEventLoopPolicy()
+        return async_solipsism.EventLoopPolicy()
 
     @pytest.fixture(autouse=True)
     def open_mock(self, mocker) -> open_file_mock.MockOpen:

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -27,6 +27,7 @@ from unittest import mock
 
 import aiohttp
 import aioresponses
+import async_solipsism
 import networkx
 import open_file_mock
 import pymesos
@@ -40,7 +41,6 @@ from katsdpcontroller.scheduler import TaskState
 
 from .utils import (
     AnyOrderList,
-    AsyncSolipsismEventLoopPolicy,
     exhaust_callbacks,
     future_return,
     make_json_attr,
@@ -1376,8 +1376,8 @@ class TestScheduler:
 
     # Override pytest-asyncio to use async-solipsism event loop
     @pytest.fixture
-    def event_loop_policy(self) -> AsyncSolipsismEventLoopPolicy:
-        return AsyncSolipsismEventLoopPolicy()
+    def event_loop_policy(self) -> async_solipsism.EventLoopPolicy:
+        return async_solipsism.EventLoopPolicy()
 
     @staticmethod
     def _dummy_random():

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -36,8 +36,6 @@ from aiokatcp import Sensor, SensorSet
 
 from katsdpcontroller import web
 
-from .utils import AsyncSolipsismEventLoopPolicy
-
 EXTERNAL_URL = yarl.URL("http://proxy.invalid:1234")
 ROOT_GUI_URLS: List[Dict[str, Any]] = [
     {
@@ -197,8 +195,8 @@ class TestWeb:
         return ("localhost.invalid", 80) if use_haproxy else None
 
     @pytest.fixture
-    def event_loop_policy(self) -> AsyncSolipsismEventLoopPolicy:
-        return AsyncSolipsismEventLoopPolicy()
+    def event_loop_policy(self) -> async_solipsism.EventLoopPolicy:
+        return async_solipsism.EventLoopPolicy()
 
     @pytest.fixture
     def mc_server(self, use_haproxy: bool) -> mock.MagicMock:

--- a/test/utils.py
+++ b/test/utils.py
@@ -36,7 +36,6 @@ from typing import (
 from unittest import mock
 
 import aiokatcp
-import async_solipsism
 import pytest
 from addict import Dict
 
@@ -586,8 +585,3 @@ def make_text_attr(name, value):
 
 def make_json_attr(name, value):
     return make_text_attr(name, base64.urlsafe_b64encode(json.dumps(value).encode("utf-8")))
-
-
-class AsyncSolipsismEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
-    def new_event_loop(self) -> async_solipsism.EventLoop:
-        return async_solipsism.EventLoop()


### PR DESCRIPTION
It now provides its own EventLoopPolicy, so we don't need to write one in test/utils.py.