### PR TITLE
Reduce logging for large katcp messages

### DIFF
--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -452,7 +452,9 @@ class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
                 f"Cannot issue request {req} to node {self.name} without a katcp connection"
             )
         log_args = args
-        # Don't bother trimming if it won't be logged anyway
+        # Limit the number of arguments we report to avoid spamming the logs
+        # with huge messages. But don't bother trimming if it won't be logged
+        # anyway.
         if self.logger.isEnabledFor(log_level):
             max_args = 20
             if len(args) > max_args:

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -441,12 +441,18 @@ class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
             raise FailReply(
                 f"Cannot issue request {req} to node {self.name} without a katcp connection"
             )
+        log_args = args
+        # Don't bother trimming if it won't be logged anyway
+        if self.logger.isEnabledFor(log_level):
+            max_args = 20
+            if len(args) > max_args:
+                log_args = tuple(args[:max_args]) + ("...",)
         if timeout is None:
             self.logger.log(
                 log_level,
                 "Issuing request %s %s to node %s (no timeout)",
                 req,
-                args,
+                log_args,
                 self.name,
             )
         else:
@@ -454,7 +460,7 @@ class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
                 log_level,
                 "Issuing request %s %s to node %s (timeout %gs)",
                 req,
-                args,
+                log_args,
                 self.name,
                 timeout,
             )
@@ -462,7 +468,9 @@ class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
             async with async_timeout.timeout(timeout):
                 await self.katcp_connection.wait_connected()
                 reply, informs = await self.katcp_connection.request(req, *args)
-            self.logger.log(log_level, "Request %s %s to node %s successful", req, args, self.name)
+            self.logger.log(
+                log_level, "Request %s %s to node %s successful", req, log_args, self.name
+            )
             return (reply, informs)
         except (FailReply, InvalidReply, OSError, asyncio.TimeoutError) as error:
             if isinstance(error, asyncio.TimeoutError):

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -334,6 +334,16 @@ class DeviceStatusObserver:
         self.sensor.detach(self)
 
 
+class _ElidedArgs:
+    """Reports request arguments elided from a log message."""
+
+    def __init__(self, n: int) -> None:
+        self.n = n
+
+    def __repr__(self) -> str:
+        return f"[{self.n} more arguments omitted]"
+
+
 class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
     """Augments task classes with functionality specific to subarray products.
 
@@ -446,7 +456,7 @@ class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
         if self.logger.isEnabledFor(log_level):
             max_args = 20
             if len(args) > max_args:
-                log_args = tuple(args[:max_args]) + ("...",)
+                log_args = tuple(args[:max_args]) + (_ElidedArgs(len(args) - max_args),)
         if timeout is None:
             self.logger.log(
                 log_level,

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2013-2023, National Research Foundation (SARAO)
+# Copyright (c) 2013-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy


### PR DESCRIPTION
issue_req logs the full message that is being issued to the task, and again when it is successful. For large messages like ?gain, this can take a significant portion of the message processing time.

Prune the message by limiting the logging to 20 arguments.

See NGC-1233.