### PR TITLE
Strip out support for product-configure schema version 2

### DIFF
--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -1,9 +1,8 @@
 {% macro versions() %}
-["2.4", "2.5", "2.6", "3.0", "3.1", "3.2", "3.3", "3.4", "3.5"]
+["3.0", "3.1", "3.2", "3.3", "3.4", "3.5"]
 {% endmacro %}
 
 {% macro validate(version) %}
-{% set input_additional = "false" if version >= "3.0" else "true" %}
 {% set stream_name_pattern = "^[A-Za-z0-9_-]+$" if version >= "3.4" else "^[A-Za-z0-9_]+$" %}
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -92,10 +91,6 @@
     },
     "type": "object",
     "required": [
-{% if version < "3.0" %}
-        "inputs",
-        "config",
-{% endif %}
         "outputs",
         "version"
     ],
@@ -109,7 +104,6 @@
                     "type": "object",
                     "required": ["type", "url"],
                     "properties": {
-{% if version >= "3.0" %}
                         "type": {
                             "enum": [
 {% if version >= "3.1" %}
@@ -121,9 +115,6 @@
                                 "cam.http"
                             ]
                         },
-{% else %}
-                        "type": {"$ref": "#/definitions/stream_type"},
-{% endif %}
                         "url": {"type": "string", "format": "uri"},
                         "src_streams": {"$ref": "#/definitions/src_streams"}
                     },
@@ -140,7 +131,7 @@
                                     "band": {"type": "string"},
                                     "antenna": {"type": "string"}
                                 },
-                                "additionalProperties": {{ input_additional }},
+                                "additionalProperties": false,
                                 "required": ["adc_sample_rate", "centre_frequency", "band", "antenna"]
                             }
                         },
@@ -156,27 +147,11 @@
                                         "minItems": 1,
                                         "items": {"type": "string"}
                                     },
-{% if version < "3.0" %}
-                                    "n_chans": {"$ref": "#/definitions/nonneg_integer"},
-                                    "n_samples_between_spectra": {
-                                        "$ref": "#/definitions/nonneg_integer"
-                                    },
-                                    "n_pols": {"type": "integer", "enum": [1, 2]},
-                                    "adc_sample_rate": {"$ref": "#/definitions/positive_number"},
-                                    "bandwidth": {"$ref": "#/definitions/positive_number"},
-{% endif %}
                                     "instrument_dev_name": {"type": "string"}
                                 },
-                                "additionalProperties": {{ input_additional }},
+                                "additionalProperties": false,
                                 "required": [
                                     "antennas",
-{% if version < "3.0" %}
-                                    "n_chans",
-                                    "n_samples_between_spectra",
-                                    "n_pols",
-                                    "adc_sample_rate",
-                                    "bandwidth",
-{% endif %}
                                     "instrument_dev_name"
                                 ]
                             }
@@ -188,26 +163,11 @@
                                     "type": {},
                                     "url": {},
                                     "src_streams": {"$ref": "#/definitions/singleton"},
-{% if version < "3.0" %}
-                                    "int_time": {"type": "number"},
-                                    "n_bls": {"$ref": "#/definitions/nonneg_integer"},
-                                    "xeng_out_bits_per_sample": {"const": 32},
-                                    "n_chans_per_substream": {
-                                        "$ref": "#/definitions/nonneg_integer"
-                                    },
-                                    "simulate": {"$ref": "#/definitions/simulate"},
-{% endif %}
                                     "instrument_dev_name": {"type": "string"}
                                 },
-                                "additionalProperties": {{ input_additional }},
+                                "additionalProperties": false,
                                 "required": [
                                     "src_streams",
-{% if version < "3.0" %}
-                                    "int_time",
-                                    "n_bls",
-                                    "xeng_out_bits_per_sample",
-                                    "n_chans_per_substream",
-{% endif %}
                                     "instrument_dev_name"
                                 ]
                             }
@@ -219,26 +179,11 @@
                                     "type": {},
                                     "url": {},
                                     "src_streams": {"$ref": "#/definitions/singleton"},
-{% if version < "3.0" %}
-                                    "beng_out_bits_per_sample": {"const": 8},
-                                    "spectra_per_heap": {
-                                        "$ref": "#/definitions/nonneg_integer"
-                                    },
-                                    "n_chans_per_substream": {
-                                        "$ref": "#/definitions/nonneg_integer"
-                                    },
-                                    "simulate": {"$ref": "#/definitions/simulate"},
-{% endif %}
                                     "instrument_dev_name": {"type": "string"}
                                 },
-                                "additionalProperties": {{ input_additional }},
+                                "additionalProperties": false,
                                 "required": [
                                     "src_streams",
-{% if version < "3.0" %}
-                                    "beng_out_bits_per_sample",
-                                    "spectra_per_heap",
-                                    "n_chans_per_substream",
-{% endif %}
                                     "instrument_dev_name"
                                 ]
                             }
@@ -250,7 +195,7 @@
                                     "type": {},
                                     "url": {}
                                 },
-                                "additionalProperties": {{ input_additional }},
+                                "additionalProperties": false,
                                 "required": []
                             }
                         }
@@ -268,11 +213,9 @@
                     "properties": {
                         "type": {
                             "enum": [
-{% if version >= "3.0" %}
                                 "sim.cbf.antenna_channelised_voltage",
                                 "sim.cbf.baseline_correlation_products",
                                 "sim.cbf.tied_array_channelised_voltage",
-{% endif %}
 {% if version >= "3.1" %}
                                 "sim.dig.baseband_voltage",
                                 "gpucbf.antenna_channelised_voltage",
@@ -381,12 +324,6 @@
                                         },
                                         "additionalProperties": false
                                     },
-{% if version < "3.0" %}
-                                    "models": {
-                                        "type": "object",
-                                        "additionalProperties": {"type": "string"}
-                                    },
-{% endif %}
                                     "max_scans": {"$ref": "#/definitions/positive_integer"},
                                     "buffer_time": {"$ref": "#/definitions/positive_number"}
                                 },
@@ -399,12 +336,7 @@
                             "then": {
                                 "properties": {
                                     "type": {},
-{% if version < "3.0" %}
-                                    "src_streams": {"$ref": "#/definitions/singleton"},
-                                    "calibration": {"$ref": "#/definitions/singleton"},
-{% else %}
                                     "src_streams": {"%ref": "#/definitions/pair"},
-{% endif %}
                                     "rate_ratio": {
                                         "type": "number",
                                         "exclusiveMinimum": 1.0
@@ -413,9 +345,6 @@
                                 },
                                 "required": [
                                     "src_streams",
-{% if version < "3.0" %}
-                                    "calibration",
-{% endif %}
                                     "archive"
                                 ],
                                 "additionalProperties": false
@@ -429,9 +358,7 @@
                                     "src_streams": {"$ref": "#/definitions/singleton"},
                                     "uvblavg_parameters": {"$ref": "#/definitions/continuum_parameters"},
                                     "mfimage_parameters": {"$ref": "#/definitions/continuum_parameters"},
-{% if version >= "2.5" %}
                                     "min_time": {"$ref": "#/definitions/positive_number"},
-{% endif %}
                                     "max_realtime": {"$ref": "#/definitions/nonneg_number"}
                                 },
                                 "required": ["src_streams"],
@@ -448,10 +375,7 @@
                                         "minItems": 1,
                                         "maxItems": 2
                                     },
-{% if version >= "2.5" %}
                                     "min_time": {"$ref": "#/definitions/positive_number"},
-{% endif %}
-{% if version >= "2.6" %}
                                     "parameters": {
                                         "type": "object",
                                         "properties": {
@@ -478,7 +402,6 @@
                                         },
                                         "additionalProperties": false
                                     },
-{% endif %}
                                     "output_channels": {"$ref": "#/definitions/channel_range"}
                                 },
                                 "required": ["src_streams"],
@@ -670,7 +593,6 @@
                 }
             }
         },
-{% if version >= "3.0" %}
         "simulation": {
             "clock_ratio": {"$ref": "#/definitions/clock_ratio"},
             "start_time": {"$ref": "#/definitions/positive_number"},
@@ -683,7 +605,6 @@
                 "items": {"type": "string"}
             }
         },
-{% endif %}
         "version": {
             "type": "string",
             "const": "{{version}}"


### PR DESCRIPTION
We've been using version 3 for many years, and I want to get rid of version 2 before adding version 4 to keep the code reasonably maintainable.