### PR TITLE
Improvements to sync epoch setting and querying

### DIFF
--- a/scripts/sdp_product_controller.py
+++ b/scripts/sdp_product_controller.py
@@ -72,7 +72,7 @@ def init_dashboard(controller, opts, dashboard_path):
 def parse_s3_config(value: str) -> dict:
     try:
         s3_config = load_json_dict(value)
-        schemas.S3_CONFIG.validate(s3_config)  # type: ignore
+        schemas.S3_CONFIG.validate(s3_config)
     except jsonschema.ValidationError as exc:
         raise ValueError(str(exc))
     return s3_config

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -395,6 +395,7 @@ def _make_dsim(
         "--prometheus-port",
         "{ports[prometheus]}",
     ]
+    dsim.sensor_renames["sync-time"] = [f"{stream.name}.sync-time" for stream in streams]
     # Allow dsim task to set a realtime scheduling priority itself
     dsim.taskinfo.container.docker.parameters = [{"key": "ulimit", "value": "rtprio=1"}]
     if configuration.options.develop.less_resources:

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -342,7 +342,6 @@ def _make_dsim(
     g: networkx.MultiDiGraph,
     configuration: Configuration,
     streams: Iterable[product_config.SimDigBasebandVoltageStream],
-    sync_time: int,
 ) -> scheduler.LogicalNode:
     """Create the dsim process for a single antenna.
 
@@ -355,6 +354,9 @@ def _make_dsim(
     # sort by reverse of name so that if the streams are, for example,
     # m012h and m012v then m012v comes first.
     streams = sorted(streams, key=lambda stream: stream.name, reverse=True)
+
+    if not all(stream.sync_epoch == streams[0].sync_epoch for stream in streams):
+        raise RuntimeError("inconsistent sync epochs for {streams[0].antenna_name}")
 
     n_endpoints = 8  # Matches MeerKAT digitisers
 
@@ -387,7 +389,7 @@ def _make_dsim(
         "--ttl",
         "4",
         "--sync-time",
-        str(sync_time),
+        str(streams[0].sync_epoch),
         "--katcp-port",
         "{ports[port]}",
         "--prometheus-port",
@@ -462,7 +464,6 @@ def _make_fgpu(
     g: networkx.MultiDiGraph,
     configuration: Configuration,
     streams: Iterable[product_config.GpucbfAntennaChannelisedVoltageStream],
-    sync_time: int,
 ) -> scheduler.LogicalNode:
     # streams needs to be a Sequence (not just an iterable that is consumed
     # once), which `sorted` achieves. Put wideband first for consistency.
@@ -470,6 +471,7 @@ def _make_fgpu(
     ibv = not configuration.options.develop.disable_ibverbs
     n_engines = len(streams[0].src_streams) // 2
     base_name = streams[0].name
+    sync_epoch = streams[0].sources(0)[0].sync_epoch
     fgpu_group = LogicalGroup(f"fgpu.{base_name}")
     g.add_node(fgpu_group)
 
@@ -549,7 +551,7 @@ def _make_fgpu(
                 f"{stream.name}.sync-time",
                 "The time at which the digitisers were synchronised. Seconds since the Unix Epoch.",
                 "s",
-                default=float(sync_time),
+                default=sync_epoch,
                 initial_status=Sensor.Status.NOMINAL,
             ),
             Sensor(
@@ -640,7 +642,7 @@ def _make_fgpu(
             "adc_sample_rate": stream.adc_sample_rate,
             "n_inputs": len(stream.src_streams),
             "scale_factor_timestamp": stream.adc_sample_rate,
-            "sync_time": float(sync_time),
+            "sync_time": sync_epoch,
             "ticks_between_spectra": stream.n_samples_between_spectra,
             "n_chans": stream.n_chans,
             "bandwidth": stream.bandwidth,
@@ -704,7 +706,7 @@ def _make_fgpu(
                 "--array-size",
                 str(n_engines),
                 "--sync-epoch",
-                str(sync_time),
+                str(srcs[0].sync_epoch),
                 "--katcp-port",
                 "{ports[port]}",
                 "--prometheus-port",
@@ -828,7 +830,6 @@ def _make_fgpu(
 def _make_xbgpu(
     g: networkx.MultiDiGraph,
     configuration: Configuration,
-    sync_time: int,
     sensors: SensorSet,
     streams: Iterable[GpucbfXBStream],
 ) -> scheduler.LogicalNode:
@@ -848,6 +849,7 @@ def _make_xbgpu(
     acv = streams[0].antenna_channelised_voltage
     n_engines = streams[0].n_substreams
     n_inputs = len(acv.src_streams)
+    sync_epoch = acv.sources(0)[0].sync_epoch
 
     # Input labels list `h` and `v` pols separately so the reshape is to
     # make the process a bit smoother.
@@ -893,7 +895,7 @@ def _make_xbgpu(
                 f"{stream.name}.sync-time",
                 "The time at which the digitisers were synchronised. Seconds since the Unix Epoch.",
                 "s",
-                default=float(sync_time),
+                default=sync_epoch,
                 initial_status=Sensor.Status.NOMINAL,
             ),
             Sensor(
@@ -1216,7 +1218,7 @@ def _make_xbgpu(
                 "--dst-interface",
                 "{interfaces[gpucbf].name}",
                 "--sync-epoch",
-                str(sync_time),
+                str(sync_epoch),
                 "--katcp-port",
                 "{ports[port]}",
                 "--prometheus-port",
@@ -2548,11 +2550,10 @@ def build_logical_graph(
         """Key for dsim streams that should be run in the same process."""
         return (stream.antenna.name, stream.adc_sample_rate)
 
-    sync_time = int(time.time())
     for dig_streams in _groupby(
         configuration.by_class(product_config.SimDigBasebandVoltageStream), key=dsim_key
     ):
-        _make_dsim(g, configuration, dig_streams, sync_time)
+        _make_dsim(g, configuration, dig_streams)
     for stream in configuration.by_class(product_config.SimBaselineCorrelationProductsStream):
         _make_cbf_simulator(g, configuration, stream)
     for stream in configuration.by_class(product_config.SimTiedArrayChannelisedVoltageStream):
@@ -2562,7 +2563,7 @@ def build_logical_graph(
     for fgpu_streams in _groupby(
         configuration.by_class(product_config.GpucbfAntennaChannelisedVoltageStream), key=_fgpu_key
     ):
-        _make_fgpu(g, configuration, fgpu_streams, sync_time)
+        _make_fgpu(g, configuration, fgpu_streams)
     for xbgpu_streams in _groupby(
         configuration.by_class(product_config.GpucbfTiedArrayChannelisedVoltageStream)
         + configuration.by_class(product_config.GpucbfBaselineCorrelationProductsStream),
@@ -2572,7 +2573,6 @@ def build_logical_graph(
             g,
             configuration,
             streams=xbgpu_streams,
-            sync_time=sync_time,
             sensors=sensors,
         )
 

--- a/src/katsdpcontroller/schemas/__init__.py
+++ b/src/katsdpcontroller/schemas/__init__.py
@@ -17,6 +17,7 @@
 """Makes packaged JSON schemas available."""
 
 import json
+from typing import TYPE_CHECKING, Union
 
 import importlib_resources
 import jinja2
@@ -26,12 +27,12 @@ from packaging.version import Version
 _env = jinja2.Environment(loader=jinja2.PackageLoader(__name__, "."))
 
 
-def _normalise_version(version):
+def _normalise_version(version: Union["ComparableVersion", str]) -> "ComparableVersion":
     """Coerce strings to ComparableVersion."""
     return ComparableVersion(version) if isinstance(version, str) else version
 
 
-def _make_validator(schema):
+def _make_validator(schema) -> jsonschema.protocols.Validator:
     """Check a schema document and create a validator from it"""
     validator_cls = jsonschema.validators.validator_for(schema)
     validator_cls.check_schema(schema)
@@ -108,3 +109,15 @@ for entry in importlib_resources.files(__name__).iterdir():
         globals()[name[:-5].upper()] = _make_validator(schema)
     elif name.endswith(".json.j2"):
         globals()[name[:-8].upper()] = MultiVersionValidator(name)
+
+if TYPE_CHECKING:
+    # Let type checkers know about the defined schemas
+    GPUS: jsonschema.protocols.Validator
+    INFINIBAND_DEVICES: jsonschema.protocols.Validator
+    INTERFACES: jsonschema.protocols.Validator
+    NUMA: jsonschema.protocols.Validator
+    PRODUCT_CONFIG: MultiVersionValidator
+    S3_CONFIG: jsonschema.protocols.Validator
+    STREAMS: jsonschema.protocols.Validator
+    SUBSYSTEMS: jsonschema.protocols.Validator
+    VOLUMES: jsonschema.protocols.Validator

--- a/src/katsdpcontroller/schemas/nvidia_container_runtime.json
+++ b/src/katsdpcontroller/schemas/nvidia_container_runtime.json
@@ -1,4 +1,0 @@
-{
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "boolean"
-}

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -1,5 +1,5 @@
 {% macro versions() %}
-["3.0", "3.1", "3.2", "3.3", "3.4", "3.5"]
+["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "4.0"]
 {% endmacro %}
 
 {% macro validate(version) %}
@@ -126,13 +126,24 @@
                                 "properties": {
                                     "type": {},
                                     "url": {},
+{% if version >= "4.0" %}
+                                    "sync_epoch": {"type": "number"},
+{% endif %}
                                     "adc_sample_rate": {"$ref": "#/definitions/positive_number"},
                                     "centre_frequency": {"$ref": "#/definitions/positive_number"},
                                     "band": {"type": "string"},
                                     "antenna": {"type": "string"}
                                 },
                                 "additionalProperties": false,
-                                "required": ["adc_sample_rate", "centre_frequency", "band", "antenna"]
+                                "required": [
+{% if version >= "4.0" %}
+                                    "sync_epoch",
+{% endif %}
+                                    "adc_sample_rate",
+                                    "centre_frequency",
+                                    "band",
+                                    "antenna"
+                                ]
                             }
                         },
 {% endif %}
@@ -461,6 +472,9 @@
                             "then": {
                                 "properties": {
                                     "type": {},
+{% if version >= "4.0" %}
+                                    "sync_epoch": {"type": "number"},
+{% endif %}
                                     "adc_sample_rate": {"$ref": "#/definitions/positive_number"},
                                     "centre_frequency": {"$ref": "#/definitions/positive_number"},
                                     "band": {"type": "string"},

--- a/test/test_master_controller.py
+++ b/test/test_master_controller.py
@@ -53,7 +53,7 @@ from katsdpcontroller.master_controller import (
     SingularityProductManager,
     parse_args,
 )
-from katsdpcontroller.schemas import PRODUCT_CONFIG  # type: ignore
+from katsdpcontroller.schemas import PRODUCT_CONFIG
 
 from . import fake_singularity, fake_zk
 from .utils import (

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -27,7 +27,7 @@ import katportalclient
 import pytest
 import yarl
 
-from katsdpcontroller import defaults, product_config
+from katsdpcontroller import defaults, product_config, schemas
 from katsdpcontroller.product_config import (
     STREAM_CLASSES,
     AntennaChannelisedVoltageStream,
@@ -286,6 +286,7 @@ class TestDigBasebandVoltageStream:
         return {
             "type": "sim.dig.baseband_voltage",
             "url": "spead://239.0.0.0+7:7148",
+            "sync_epoch": 1234567890.5,
             "adc_sample_rate": 1712000000.0,
             "centre_frequency": 1284000000.0,
             "band": "l",
@@ -295,6 +296,7 @@ class TestDigBasebandVoltageStream:
     def test_from_config(self, config: Dict[str, Any]) -> None:
         dig = DigBasebandVoltageStream.from_config(Options(), "m000h", config, [], {})
         assert dig.url == yarl.URL(config["url"])
+        assert dig.sync_epoch == config["sync_epoch"]
         assert dig.adc_sample_rate == config["adc_sample_rate"]
         assert dig.centre_frequency == config["centre_frequency"]
         assert dig.band == config["band"]
@@ -310,6 +312,7 @@ class TestSimDigBasebandVoltageStream:
     def config(self) -> Dict[str, Any]:
         return {
             "type": "sim.dig.baseband_voltage",
+            "sync_epoch": 1234567890.5,
             "adc_sample_rate": 1712000000.0,
             "centre_frequency": 1284000000.0,
             "band": "l",
@@ -318,6 +321,7 @@ class TestSimDigBasebandVoltageStream:
 
     def test_from_config(self, config: Dict[str, Any]) -> None:
         dig = SimDigBasebandVoltageStream.from_config(Options(), "m000h", config, [], {})
+        assert dig.sync_epoch == config["sync_epoch"]
         assert dig.adc_sample_rate == config["adc_sample_rate"]
         assert dig.centre_frequency == config["centre_frequency"]
         assert dig.band == config["band"]
@@ -383,6 +387,7 @@ def make_dig_baseband_voltage(name: str) -> DigBasebandVoltageStream:
         name,
         [],
         url=yarl.URL(urls[name]),
+        sync_epoch=1234567890.5,
         adc_sample_rate=1712000000.0,
         centre_frequency=1284000000.0,
         band="l",
@@ -394,6 +399,7 @@ def make_sim_dig_baseband_voltage(name: str) -> SimDigBasebandVoltageStream:
     return SimDigBasebandVoltageStream(
         name,
         [],
+        sync_epoch=1234567890.5,
         adc_sample_rate=1712000000.0,
         centre_frequency=1284000000.0,
         band="l",
@@ -1597,6 +1603,7 @@ class TestUpgrade:
 
     def test_upgrade_v3(self, config: Dict[str, Any]) -> None:
         upgraded = product_config._upgrade(config)
+        config["version"] = str(max(schemas.PRODUCT_CONFIG.versions))
         assert upgraded == config
 
 

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -712,7 +712,7 @@ class TestControllerInterface(BaseTestController):
         await assert_sensor_value(
             client,
             "gpucbf_antenna_channelised_voltage.sync-time",
-            123456789.0,  # Just to detect any change in sync time logic in generator.py
+            123456789.0,  # Just to detect any change in sync time logic in product_config.py
         )
         await client.request(
             "delays",

--- a/test/utils.py
+++ b/test/utils.py
@@ -44,7 +44,7 @@ _T = TypeVar("_T")
 # The "gpucbf" correlator components are not connected up to any SDP components.
 # They're there just as a smoke test for generator.py.
 CONFIG = """{
-    "version": "3.5",
+    "version": "4.0",
     "outputs": {
         "gpucbf_m900v": {
             "type": "sim.dig.baseband_voltage",
@@ -218,7 +218,7 @@ CONFIG = """{
 }"""  # noqa: E501
 
 CONFIG_CBF_ONLY = """{
-    "version": "3.5",
+    "version": "4.0",
     "outputs": {
         "gpucbf_m900v": {
             "type": "sim.dig.baseband_voltage",


### PR DESCRIPTION
NB: this needs to be merged together with https://github.com/ska-sa/katgpucbf/pull/737. Without it, things will break.

This implements versions 4 of the product-configure schema (see the [changelog](https://docs.google.com/document/d/15ZIyuBf4Vk4ESIEdKsQxdSBoLEwh85eyKeDJouLRAZY/edit#heading=h.bxv6wohps6p4) and SPR1-3072). It also adds support for sync-time sensors exported from the dsims (coming in that mentioned PR).