### PR TITLE
Bump requests to the latest version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
         # --strip-extras makes the output usable as a constraint file
         - --strip-extras
         - setup.cfg
+      language_version: python3.8
       files: '^(requirements\.txt|setup\.cfg)$'
     - id: pip-compile
       name: pip-compile test-requirements.in
@@ -44,4 +45,5 @@ repos:
         - --output-file=test-requirements.txt
         - --strip-extras
         - test-requirements.in
+      language_version: python3.8
       files: '^((test-)?requirements\.(in|txt)|setup\.cfg)$'

--- a/requirements.txt
+++ b/requirements.txt
@@ -250,7 +250,7 @@ referencing==0.33.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.31.0
+requests==2.32.2
     # via
     #   dash
     #   docker


### PR DESCRIPTION
To keep dependabot happy. Also updated .pre-commit-config.yaml to explicitly run pip-compile under Python 3.8, because otherwise it was changing the requirements file to be compiled with my current Python version.