### PR TITLE
Add shutdown_delay to the "config" dict in product-configure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
   hooks:
     - id: isort
 - repo: https://github.com/PyCQA/flake8
-  rev: "3.9.2"
+  rev: "7.0.0"
   hooks:
     - id: flake8
 # mypy is configured as a "local" repo so that it has access to the installed

--- a/src/katsdpcontroller/agent_mkconfig.py
+++ b/src/katsdpcontroller/agent_mkconfig.py
@@ -103,7 +103,7 @@ class GPU:
                 # Some of the attributes use Boost.Python's enum, which is
                 # derived from int but which leads to invalid JSON when passed
                 # to json.dumps.
-                if isinstance(value, int) and type(value) != int:
+                if isinstance(value, int) and type(value) is not int:
                     value = str(value)
                 self.device_attributes[str(key)] = value
 

--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -50,3 +50,5 @@ XBGPU_MAX_SRC_DATA_RATE = 5.45e9
 PFB_TAPS = 16
 #: Autotune fallback behaviour: "nearest" or "exact"
 KATSDPSIGPROC_TUNE_MATCH = "nearest"
+#: Time (in seconds) to sleep before exiting
+SHUTDOWN_DELAY = 10.0

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -265,6 +265,7 @@ class Options:
         image_tag: Optional[str] = None,
         image_overrides: Mapping[str, str] = {},
         service_overrides: Mapping[str, ServiceOverride] = {},
+        shutdown_delay: Optional[float] = None,
         interface_mode: bool = False,
     ) -> None:
         if isinstance(develop, bool):
@@ -275,6 +276,7 @@ class Options:
         self.image_tag = image_tag
         self.image_overrides = dict(image_overrides)
         self.service_overrides = dict(service_overrides)
+        self.shutdown_delay = shutdown_delay
         # Command line --interface mode - not set via config dict, but
         # convenient to pass together with other options.
         self.interface_mode = interface_mode
@@ -291,6 +293,7 @@ class Options:
             image_tag=config.get("image_tag"),
             image_overrides=config.get("image_overrides", {}),
             service_overrides=service_overrides,
+            shutdown_delay=config.get("shutdown_delay"),
         )
 
 

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -1,5 +1,5 @@
 {% macro versions() %}
-["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "4.0"]
+["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "4.0", "4.1"]
 {% endmacro %}
 
 {% macro validate(version) %}
@@ -592,6 +592,9 @@
                     "type": "object",
                     "additionalProperties": {"type": "string"}
                 },
+{% endif %}
+{% if version >= "4.1" %}
+                "shutdown_delay": {"$ref": "#/definitions/nonneg_number"},
 {% endif %}
                 "service_overrides": {
                     "type": "object",

--- a/src/katsdpcontroller/sensor_proxy.py
+++ b/src/katsdpcontroller/sensor_proxy.py
@@ -40,7 +40,7 @@ def _reading_to_float(reading: aiokatcp.Reading) -> float:
     value = reading.value
     if isinstance(value, enum.Enum):
         try:
-            values = list(type(value))  # type: List[enum.Enum]
+            values: List[enum.Enum] = list(type(value))
             idx = values.index(value)
         except ValueError:
             idx = -1

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -205,6 +205,7 @@ class TestOptions:
             "develop": {"disable_ibverbs": True, "less_resources": True},
             "wrapper": "http://test.invalid/wrapper.sh",
             "service_overrides": {"service1": {"host": "testhost"}},
+            "shutdown_delay": 5.0,
         }
         options = Options.from_config(config)
         assert options.develop.any_gpu is False
@@ -213,6 +214,7 @@ class TestOptions:
         assert options.wrapper == config["wrapper"]
         assert list(options.service_overrides.keys()) == ["service1"]
         assert options.service_overrides["service1"].host == "testhost"
+        assert options.shutdown_delay == 5.0
 
     def test_from_config_bool(self) -> None:
         config = {
@@ -235,6 +237,7 @@ class TestOptions:
         assert options.develop.less_resources is False
         assert options.wrapper is None
         assert options.service_overrides == {}
+        assert options.shutdown_delay is None
 
 
 class TestSimulation:
@@ -1432,7 +1435,7 @@ class TestSpectralImageStream:
 @pytest.fixture
 def config() -> Dict[str, Any]:
     return {
-        "version": "4.0",
+        "version": "4.1",
         "inputs": {
             "camdata": {"type": "cam.http", "url": "http://10.8.67.235/api/client/1"},
             "i0_antenna_channelised_voltage": {
@@ -1526,7 +1529,7 @@ def config_v3(config: Dict[str, Any]) -> Dict[str, Any]:
 @pytest.fixture
 def config_sim() -> Dict[str, Any]:
     return {
-        "version": "4.0",
+        "version": "4.1",
         "outputs": {
             "acv": {
                 "type": "sim.cbf.antenna_channelised_voltage",

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -287,7 +287,7 @@ class TestPollPorts:
         getaddrinfo = mocker.patch.object(asyncio.get_running_loop(), "getaddrinfo", autospec=True)
         test_address = socket.getaddrinfo("127.0.0.1", port)
         # create a legitimate return future for getaddrinfo
-        legit_future = asyncio.Future()  # type: asyncio.Future[Any]
+        legit_future: asyncio.Future[Any] = asyncio.Future()
         legit_future.set_result(test_address)
 
         # sequential calls to getaddrinfo produce failure and success

--- a/test/utils.py
+++ b/test/utils.py
@@ -44,7 +44,7 @@ _T = TypeVar("_T")
 # The "gpucbf" correlator components are not connected up to any SDP components.
 # They're there just as a smoke test for generator.py.
 CONFIG = """{
-    "version": "4.0",
+    "version": "4.1",
     "outputs": {
         "gpucbf_m900v": {
             "type": "sim.dig.baseband_voltage",
@@ -218,7 +218,7 @@ CONFIG = """{
 }"""  # noqa: E501
 
 CONFIG_CBF_ONLY = """{
-    "version": "4.0",
+    "version": "4.1",
     "outputs": {
         "gpucbf_m900v": {
             "type": "sim.dig.baseband_voltage",


### PR DESCRIPTION
This allows the default delay of 10s for be overridden, which is useful for NGC-1343.