### PR TITLE
Remove depends_ready links for fgpu/xbgpu

### DIFF
--- a/src/katsdpcontroller/dashboard.py
+++ b/src/katsdpcontroller/dashboard.py
@@ -29,7 +29,7 @@ from dash import Dash, Input, Output, dash_table, dcc, html
 from dash_dangerously_set_inner_html import DangerouslySetInnerHTML
 
 from . import scheduler
-from .tasks import ProductPhysicalTask
+from .tasks import DEPENDS_INIT, ProductPhysicalTask
 
 
 def timestamp_utc(timestamp):
@@ -87,7 +87,10 @@ def _get_tasks(product):
     # To do that, we perform a topological sort, breaking ties by
     # - first, maximising the number of components shared with the previous entry
     # - next, by the name
-    order_graph = scheduler.subgraph(product.physical_graph, scheduler.DEPENDS_READY)
+    order_graph = scheduler.subgraph(
+        product.physical_graph,
+        lambda data: bool(data.get(scheduler.DEPENDS_READY) or data.get(DEPENDS_INIT)),
+    )
     deg = {v: d for v, d in order_graph.out_degree()}
     ready = {v for v, d in deg.items() if d == 0}
     tasks = []

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -781,13 +781,14 @@ def _make_fgpu(
         src_strs = []
         for src in srcs:
             src_multicast = find_node(g, f"multicast.{src.name}")
+            # depends_init is included purely to ensure sensible ordering
+            # on the dashboard.
             g.add_edge(
                 fgpu,
                 src_multicast,
                 port="spead",
                 depends_resolve=True,
                 depends_init=True,
-                depends_ready=True,
             )
             src_strs.append(f"{{endpoints[multicast.{src.name}_spead]}}")
         fgpu.command.append(",".join(src_strs))
@@ -1289,13 +1290,14 @@ def _make_xbgpu(
 
         # Wire it up to the multicast streams
         src_multicast = find_node(g, f"multicast.{acv.name}")
+        # depends_init is included purely to ensure sensible ordering
+        # on the dashboard.
         g.add_edge(
             xbgpu,
             src_multicast,
             port="spead",
             depends_resolve=True,
             depends_init=True,
-            depends_ready=True,
         )
         for dst_multicast in dst_multicasts:
             g.add_edge(xbgpu, dst_multicast, port="spead", depends_resolve=True)


### PR DESCRIPTION
This allows the containers for dsim, fgpu and xbgpu to all start at the same time, instead of in phases, which should speed up correlator startup. This is safe because none of the processes communicates with the prior ones other than via the multicast groups.

The depends_init links are left in place. They don't affect operation (they're used by exec_transitions, which isn't applicable to CBF), but I modified the dashboard to take them into account for sorting purposes. This was easier than introducing yet another property and applying it all over the place.

See NGC-1343.