### PR TITLE
Fix resource allocations for narrowband xbgpu

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -37,7 +37,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast,
 )
 
 import addict
@@ -1086,14 +1085,8 @@ def _make_xbgpu(
         for key, value in telstate_data.items():
             init_telstate[(stream.name, key)] = value
 
-    input_rate = (
-        sum(
-            cast(product_config.DigBasebandVoltageStreamBase, dig).adc_sample_rate
-            for dig in acv.src_streams
-        )
-        * acv.bits_per_sample
-        // 8
-    )
+    # Factor of 2 is because samples are complex
+    input_rate = acv.bandwidth * len(acv.src_streams) * acv.bits_per_sample / 8 * 2
     bw_scale = input_rate / (acv.n_substreams * defaults.XBGPU_MAX_SRC_DATA_RATE)
 
     # Compute how much memory to provide for input

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -1955,17 +1955,19 @@ class Agent:
 
         if logical_task.requests["cores"].amount:
             # For tasks requesting cores we activate NUMA awareness
+            message = "No suitable NUMA node found"
             for numa_node in range(len(self.numa)):
                 try:
                     return self._allocate_numa_node(numa_node, logical_task)
-                except InsufficientResourcesError:
+                except InsufficientResourcesError as exc:
                     logger.debug(
                         "Failed to allocate NUMA node %d on %s",
                         numa_node,
                         self.agent_id,
                         exc_info=True,
                     )
-            raise InsufficientResourcesError("No suitable NUMA node found")
+                    message += f" [{numa_node}: {exc}]"
+            raise InsufficientResourcesError(message)
         return self._allocate_numa_node(None, logical_task)
 
     def can_allocate(self, logical_task):

--- a/test/test_diagnose_insufficient.py
+++ b/test/test_diagnose_insufficient.py
@@ -27,6 +27,7 @@ from katsdpcontroller.diagnose_insufficient import (
     ResourceGroup,
     TaskInsufficientResourcesError,
     TaskNoAgentError,
+    TaskNoAgentErrorGeneric,
     TaskNoDeviceError,
     diagnose_insufficient,
 )
@@ -265,8 +266,12 @@ class TestDiagnoseInsufficient:
             diagnose_insufficient([self.cpus_agent, self.ports_agent], [self.physical_tasks[0]])
         assert cm.value.task is self.physical_tasks[0]
         # Make sure that it didn't incorrectly return a subclass
-        assert cm.type == TaskNoAgentError
-        assert str(cm.value) == "No agent was found suitable for physical0"
+        assert cm.type is TaskNoAgentErrorGeneric
+        assert str(cm.value) == (
+            "No agent was found suitable for physical0:\n"
+            "  agenthost0: Not enough ports (0 < 3)\n"
+            "  agenthost3: Not enough cpus (1.750 < 8.000)"
+        )
 
     def test_group_insufficient_scalar_resource(self):
         """A group of tasks require more of a scalar resource than available"""


### PR DESCRIPTION
The calculation of bw_scale didn't account for the narrowband factor. Rewrite it in terms of bandwidth rather than ADC sample rate.

Also add more details to error messages when a task can't be placed on any node, to make it clearer what the problem is.