### PR TITLE
Raise ValueError if LogicalTask.numa_nodes is out of range

### DIFF
--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -1606,6 +1606,16 @@ class LogicalTask(LogicalNode, ResourceRequestsContainer):
         self.taskinfo.command.shell = False
         self.physical_factory = PhysicalTask
 
+    @property
+    def numa_nodes(self) -> float:
+        return self._numa_nodes
+
+    @numa_nodes.setter
+    def numa_nodes(self, value: float) -> None:
+        if not 0.0 <= value <= 1.0:
+            raise ValueError("numa_nodes must be between 0 and 1")
+        self._numa_nodes = value
+
     def valid_agent(self, agent) -> bool:
         """Checks whether the attributes of an agent are suitable for running
         this task. Subclasses may override this to enforce constraints e.g.,

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -18,6 +18,7 @@ import asyncio
 import base64
 import ipaddress
 import logging
+import math
 import socket
 import time
 from collections import Counter
@@ -1248,6 +1249,24 @@ class TestAgent:
         assert agent.gpus[0].resources["mem"].available == 0.0
         assert agent.gpus[1].resources["compute"].available == 0.25
         assert agent.gpus[1].resources["mem"].available == 1024.0
+
+
+class TestLogicalTask:
+    """Tests for :class:`katsdpcontroller.scheduler.LogicalTask`"""
+
+    def test_numa_nodes(self):
+        """Test the :attr:`~katsdpcontroller.scheduler.LogicalTask.numa_nodes` property."""
+        task = scheduler.LogicalTask("task")
+        assert task.numa_nodes == 0.0
+        task.numa_nodes = 0.5
+        assert task.numa_nodes == 0.5
+        with pytest.raises(ValueError):
+            task.numa_nodes = 1.2
+        with pytest.raises(ValueError):
+            task.numa_nodes = -0.1
+        with pytest.raises(ValueError):
+            task.numa_nodes = math.nan
+        assert task.numa_nodes == 0.5  # Must not have been altered by failures
 
 
 class TestPhysicalTask:


### PR DESCRIPTION
A previous bug that left it greater than 1.0 prevented allocating a task anywhere, but with a confusing error message. This will help catch any future such bugs faster.

Closes NGC-1353.