### PR TITLE
Add payload-len sensor for GPU CBF

### DIFF
--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -49,7 +49,7 @@ XBGPU_MAX_SRC_DATA_RATE = 5.45e9
 #: Number of polyphase filter-bank taps for gpucbf F-engines
 PFB_TAPS = 16
 #: Default payload size for gpucbf data products. Bigger is better to
-#  minimise the number of packets/second to process.
+#: minimise the number of packets/second to process.
 GPUCBF_PACKET_PAYLOAD_BYTES = 8192
 #: Autotune fallback behaviour: "nearest" or "exact"
 KATSDPSIGPROC_TUNE_MATCH = "nearest"

--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -48,6 +48,9 @@ GPUCBF_JONES_PER_BATCH = 2**20
 XBGPU_MAX_SRC_DATA_RATE = 5.45e9
 #: Number of polyphase filter-bank taps for gpucbf F-engines
 PFB_TAPS = 16
+#: Default payload size for gpucbf data products. Bigger is better to
+#  minimise the number of packets/second to process.
+GPUCBF_PACKET_PAYLOAD_BYTES = 8192
 #: Autotune fallback behaviour: "nearest" or "exact"
 KATSDPSIGPROC_TUNE_MATCH = "nearest"
 #: Time (in seconds) to sleep before exiting

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -593,7 +593,7 @@ def _make_fgpu(
             Sensor(
                 int,
                 f"{stream.name}.n-chans-per-substream",
-                "Number of channels in each substream for this f-engine stream",
+                "Number of channels in each substream for this F-engine stream",
                 default=stream.n_chans_per_substream,
                 initial_status=Sensor.Status.NOMINAL,
             ),
@@ -632,7 +632,7 @@ def _make_fgpu(
             Sensor(
                 int,
                 f"{stream.name}.payload-len",
-                "The payload size of the F-engine data stream packets",
+                "The payload size, in bytes, of the F-engine data stream packets",
                 default=GPUCBF_PACKET_PAYLOAD_BYTES,
                 initial_status=Sensor.Status.NOMINAL,
             ),
@@ -1000,7 +1000,7 @@ def _make_xbgpu(
                 Sensor(
                     int,
                     f"{stream.name}.payload-len",
-                    "The payload size of the X-engine data stream packets",
+                    "The payload size, in bytes, of the X-engine data stream packets",
                     default=GPUCBF_PACKET_PAYLOAD_BYTES,
                     initial_status=Sensor.Status.NOMINAL,
                 ),
@@ -1049,7 +1049,7 @@ def _make_xbgpu(
                 Sensor(
                     int,
                     f"{stream.name}.payload-len",
-                    "The payload size of the B-engine data stream packets",
+                    "The payload size, in bytes, of the B-engine data stream packets",
                     default=GPUCBF_PACKET_PAYLOAD_BYTES,
                     initial_status=Sensor.Status.NOMINAL,
                 ),

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -55,7 +55,7 @@ from katsdptelstate.endpoint import Endpoint
 
 from . import defaults, product_config, scheduler
 from .aggregate_sensors import LatestSensor, SumSensor, SyncSensor
-from .defaults import LOCALHOST
+from .defaults import GPUCBF_PACKET_PAYLOAD_BYTES, LOCALHOST
 from .fake_servers import (
     FakeCalDeviceServer,
     FakeFgpuDeviceServer,
@@ -629,6 +629,13 @@ def _make_fgpu(
                 else stream.bandwidth / 2,
                 initial_status=Sensor.Status.NOMINAL,
             ),
+            Sensor(
+                int,
+                f"{stream.name}-payload-len",
+                "The payload size of the F-engine data stream packets",
+                default=GPUCBF_PACKET_PAYLOAD_BYTES,
+                initial_status=Sensor.Status.NOMINAL,
+            ),
             data_suspect_sensor,
         ]
         for ss in stream_sensors:
@@ -698,7 +705,7 @@ def _make_fgpu(
                 "--send-interface",
                 "{interfaces[gpucbf].name}",
                 "--send-packet-payload",
-                "8192",
+                str(GPUCBF_PACKET_PAYLOAD_BYTES),
                 "--adc-sample-rate",
                 str(srcs[0].adc_sample_rate),
                 "--feng-id",
@@ -990,6 +997,13 @@ def _make_xbgpu(
                     default=stream.n_baselines,
                     initial_status=Sensor.Status.NOMINAL,
                 ),
+                Sensor(
+                    int,
+                    f"{stream.name}-payload-len",
+                    "The payload size of the X-engine data stream packets",
+                    default=GPUCBF_PACKET_PAYLOAD_BYTES,
+                    initial_status=Sensor.Status.NOMINAL,
+                ),
                 SumSensor(
                     sensors,
                     f"{stream.name}.xeng-clip-cnt",
@@ -1030,6 +1044,13 @@ def _make_xbgpu(
                     f"{stream.name}.source-indices",
                     "The global input indices of the sources summed in this beam",
                     default=f"{source_indices}",
+                    initial_status=Sensor.Status.NOMINAL,
+                ),
+                Sensor(
+                    int,
+                    f"{stream.name}-payload-len",
+                    "The payload size of the B-engine data stream packets",
+                    default=GPUCBF_PACKET_PAYLOAD_BYTES,
                     initial_status=Sensor.Status.NOMINAL,
                 ),
                 SumSensor(
@@ -1212,6 +1233,8 @@ def _make_xbgpu(
                 "{interfaces[gpucbf].name}",
                 "--send-interface",
                 "{interfaces[gpucbf].name}",
+                "--send-packet-payload",
+                str(GPUCBF_PACKET_PAYLOAD_BYTES),
                 "--sync-time",
                 str(sync_time),
                 "--katcp-port",

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -631,7 +631,7 @@ def _make_fgpu(
             ),
             Sensor(
                 int,
-                f"{stream.name}-payload-len",
+                f"{stream.name}.payload-len",
                 "The payload size of the F-engine data stream packets",
                 default=GPUCBF_PACKET_PAYLOAD_BYTES,
                 initial_status=Sensor.Status.NOMINAL,
@@ -999,7 +999,7 @@ def _make_xbgpu(
                 ),
                 Sensor(
                     int,
-                    f"{stream.name}-payload-len",
+                    f"{stream.name}.payload-len",
                     "The payload size of the X-engine data stream packets",
                     default=GPUCBF_PACKET_PAYLOAD_BYTES,
                     initial_status=Sensor.Status.NOMINAL,
@@ -1048,7 +1048,7 @@ def _make_xbgpu(
                 ),
                 Sensor(
                     int,
-                    f"{stream.name}-payload-len",
+                    f"{stream.name}.payload-len",
                     "The payload size of the B-engine data stream packets",
                     default=GPUCBF_PACKET_PAYLOAD_BYTES,
                     initial_status=Sensor.Status.NOMINAL,


### PR DESCRIPTION
See ticket for further detail/discussion. This is as per Version 7 of the MK CBF-CAM ICD (M1000-0001-002),
tweaked to conform to the MK+ CBF sensor name convention.

I still have an outstanding question on the ticket regarding whether I/we should explicitly state
the value is in **bytes**.

A screenshot below of the `?sensor-value` queries for a 4A correlator with 4 `--beams`.
![image](https://github.com/ska-sa/katsdpcontroller/assets/25218138/3b68639a-2047-4df6-984f-43128bd1f308)

Resolves: NGC-962.