### PR TITLE
Rename xengs-synchronised to rx-synchronised

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1013,7 +1013,7 @@ def _make_xbgpu(
                 ),
                 SyncSensor(
                     sensors,
-                    f"{stream.name}.xengs-synchronised",
+                    f"{stream.name}.rx.synchronised",
                     "For the latest accumulation, was data present from all F-Engines "
                     "for all X-Engines",
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.rx.synchronised"),


### PR DESCRIPTION
This sensor was originally introduced in 02ba772 and renamed from synchronised to xengs-synchronised in 450d34a. Both commits were attributed to NGC-665.

I can't quite see the logic for how we initially settled on this name but I suspect it was in honour of the `xeng-vaccs-synchronised` sensor present on MeerKAT.

The implementation doesn't currently agree with the ICD, which wants `<xeng_stream_name>.rx.synchronised`. This commit fixes that.

Closes NGC-1390