### PR TITLE
Send inform count with ?capture-list reply

### DIFF
--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -2064,6 +2064,4 @@ class DeviceServer(aiokatcp.DeviceServer):
             )
         if stream is not None and not response:
             raise FailReply(f"Unknown stream {stream!r}")
-        # ctx.informs normally sends a count, but the ICD for ?capture-list
-        # does not include this.
-        ctx.informs(response, send_reply=False)
+        ctx.informs(response)


### PR DESCRIPTION
KATCP convention is, in response to a request that results in informs being sent, to send the count of informs with the reply.

Previously this was not done due to the MK+ CBF / CAM ICD not calling for it. We have since decided to update the ICD and follow the convention.

Contributes to NGC-1391.