### PR TITLE
Rework approach to rx.device-status sensors

### DIFF
--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -55,3 +55,5 @@ GPUCBF_PACKET_PAYLOAD_BYTES = 8192
 KATSDPSIGPROC_TUNE_MATCH = "nearest"
 #: Time (in seconds) to sleep before exiting
 SHUTDOWN_DELAY = 10.0
+#: Time to wait for rx.device-status sensors to become nominal
+RX_DEVICE_STATUS_TIMEOUT = 30.0

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -334,24 +334,6 @@ class DeviceStatusObserver:
         self.sensor.detach(self)
 
 
-async def wait_status(sensor: Sensor, status: Sensor.Status):
-    """Wait until a sensor has a given status."""
-    if sensor.status == status:
-        return
-
-    future = asyncio.get_running_loop().create_future()
-
-    def observer(sensor, reading):
-        if not future.done() and reading.status == Sensor.Status.NOMINAL:
-            future.set_result(None)
-
-    sensor.attach(observer)
-    try:
-        await future
-    finally:
-        sensor.detach(observer)
-
-
 class _ElidedArgs:
     """Reports request arguments elided from a log message."""
 
@@ -563,12 +545,6 @@ class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
                     # Sleep for a bit to avoid hammering the port if there
                     # is a quick failure, before trying again.
                     await asyncio.sleep(1.0)
-            rx_device_status = self.sdp_controller.sensors.get(prefix + "rx.device-status")
-            if rx_device_status is not None and rx_device_status.status != Sensor.Status.NOMINAL:
-                self.logger.info("Waiting for device status on %s to become nominal", self.name)
-                await wait_status(rx_device_status, Sensor.Status.NOMINAL)
-                self.logger.info("Device status on %s is nominal", self.name)
-
         return True
 
     def mark_suspect(self):


### PR DESCRIPTION
Under the old approach, if a task never reached nominal rx.device-status, the configuration would just stall until the 300s timeout, then fail with a generic timeout error.

In the new approach:
- We use a lower timeout (30s) for rx.device-status, to fail faster (ideally before the 300s timeout fires).
- We separate waiting for rx.device-status from waiting for tasks to be in READY state: that means we don't start the 30s clock until all tasks are READY.
- If things fail, we report what failed and which tasks.

Closes NGC-1033.