### PR TITLE
Fix check for all engines receiving good data

### DIFF
--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -828,11 +828,10 @@ class SubarrayProduct:
         for task in self.physical_graph:
             if isinstance(task, tasks.ProductPhysicalTaskMixin):
                 sensor = self.sdp_controller.sensors.get(f"{task.name}.rx.device-status")
-                if sensor is not None:
+                if sensor is not None and sensor.status != Sensor.Status.NOMINAL:
                     sensors.append(sensor)
                     sensor.attach(observer)
-                    if sensor.status != Sensor.Status.NOMINAL:
-                        missing.add(task.name)
+                    missing.add(task.name)
         if not sensors:
             # Nothing to do
             return


### PR DESCRIPTION
If all the engines had already set their status to nominal before _wait_rx_device_status was called, it would time out and fail. That happened because the `sensors` list was still populated, and hence the "nothing to do" check did not take effect.

Fix it to only subscribe to sensors that aren't already nominal, so that the `if not sensors` check is effective (and also because it's pointless to subscribe to them).

Closes NGC-1033.