### PR TITLE
Implement schema version 4.2

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -742,6 +742,13 @@ def _make_fgpu(
                 output_arg_name = "narrowband"
             else:
                 output_arg_name = "wideband"
+            if stream.dither is not None:
+                if stream.dither == "none":
+                    output_config["dither"] = "false"
+                elif stream.dither == "uniform":
+                    output_config["dither"] = "true"
+                else:
+                    raise ValueError(f"unsupported dither value {stream.dither!r}")
             fgpu.command += [
                 f"--{output_arg_name}",
                 ",".join(f"{key}={value}" for (key, value) in output_config.items()),
@@ -1268,6 +1275,13 @@ def _make_xbgpu(
                     "dst": f"{{endpoints_vector[multicast.{stream.name}_spead][{i}]}}",
                     "pol": stream.src_pol,
                 }
+                if stream.dither is not None:
+                    if stream.dither == "none":
+                        output_config["dither"] = "false"
+                    elif stream.dither == "uniform":
+                        output_config["dither"] = "true"
+                    else:
+                        raise ValueError(f"unsupported dither value {stream.dither!r}")
                 xbgpu.command += [
                     "--beam",
                     ",".join(f"{key}={value}" for (key, value) in output_config.items()),

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -743,12 +743,7 @@ def _make_fgpu(
             else:
                 output_arg_name = "wideband"
             if stream.dither is not None:
-                if stream.dither == "none":
-                    output_config["dither"] = "false"
-                elif stream.dither == "uniform":
-                    output_config["dither"] = "true"
-                else:
-                    raise ValueError(f"unsupported dither value {stream.dither!r}")
+                output_config["dither"] = stream.dither
             fgpu.command += [
                 f"--{output_arg_name}",
                 ",".join(f"{key}={value}" for (key, value) in output_config.items()),
@@ -1276,12 +1271,7 @@ def _make_xbgpu(
                     "pol": stream.src_pol,
                 }
                 if stream.dither is not None:
-                    if stream.dither == "none":
-                        output_config["dither"] = "false"
-                    elif stream.dither == "uniform":
-                        output_config["dither"] = "true"
-                    else:
-                        raise ValueError(f"unsupported dither value {stream.dither!r}")
+                    output_config["dither"] = stream.dither
                 xbgpu.command += [
                     "--beam",
                     ",".join(f"{key}={value}" for (key, value) in output_config.items()),

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -639,6 +639,7 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
         input_labels: Optional[Iterable[str]] = None,
         w_cutoff: float = 1.0,
         narrowband: Optional[GpucbfNarrowbandConfig] = None,
+        dither: Optional[str] = None,
         command_line_extra: Iterable[str] = (),
     ) -> None:
         if n_chans < 1 or (n_chans & (n_chans - 1)) != 0:
@@ -726,6 +727,7 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
         self.pfb_taps = defaults.PFB_TAPS
         self.w_cutoff = w_cutoff
         self.narrowband = narrowband
+        self.dither = dither
         self.command_line_extra = list(command_line_extra)
 
     @property
@@ -779,6 +781,7 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
             narrowband=(
                 GpucbfNarrowbandConfig.from_config(narrowband) if narrowband is not None else None
             ),
+            dither=config.get("dither"),
             command_line_extra=config.get("command_line_extra", []),
         )
 
@@ -1260,6 +1263,7 @@ class GpucbfTiedArrayChannelisedVoltageStream(TiedArrayChannelisedVoltageStreamB
         src_streams: Sequence[Stream],
         *,
         src_pol: int,
+        dither: Optional[str] = None,
         command_line_extra: Iterable[str] = (),
     ) -> None:
         acv = src_streams[0]
@@ -1273,6 +1277,7 @@ class GpucbfTiedArrayChannelisedVoltageStream(TiedArrayChannelisedVoltageStreamB
             bits_per_sample=8,
         )
         self.src_pol = src_pol
+        self.dither = dither
         self.command_line_extra = list(command_line_extra)
 
     if TYPE_CHECKING:  # pragma: nocover
@@ -1294,6 +1299,7 @@ class GpucbfTiedArrayChannelisedVoltageStream(TiedArrayChannelisedVoltageStreamB
             name,
             src_streams,
             src_pol=config["src_pol"],
+            dither=config.get("dither"),
             command_line_extra=config.get("command_line_extra", []),
         )
 

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -1,5 +1,5 @@
 {% macro versions() %}
-["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "4.0", "4.1"]
+["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "4.0", "4.1", "4.2"]
 {% endmacro %}
 
 {% macro validate(version) %}
@@ -87,6 +87,9 @@
         "simulate_bool": {
             "type": "boolean",
             "default": false
+        },
+        "dither": {
+            "enum": ["uniform", "none"]
         }
     },
     "type": "object",
@@ -512,6 +515,9 @@
                                         "required": ["decimation_factor", "centre_frequency"]
                                     },
 {% endif %}
+{% if version >= "4.2" %}
+                                    "dither": {"$ref": "#/definitions/dither"},
+{% endif %}
                                     "command_line_extra": {
                                         "type": "array",
                                         "items": {"type": "string"}
@@ -551,6 +557,9 @@
                                     "type": {},
                                     "src_streams": {"$ref": "#/definitions/singleton"},
                                     "src_pol": {"type": "integer", "enum": [0, 1]},
+{% if version >= "4.2" %}
+                                    "dither": {"$ref": "#/definitions/dither"},
+{% endif %}
                                     "command_line_extra": {
                                         "type": "array",
                                         "items": {"type": "string"}

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -462,6 +462,7 @@ class TestGpucbfAntennaChanneliseVoltageStream:
         assert acv.data_rate(1.0, 0) == 27392e6 * 2
         assert acv.input_labels == config["src_streams"]
         assert acv.w_cutoff == 1.0  # Default value
+        assert acv.dither is None
         assert acv.command_line_extra == []
 
     def test_from_config_narrowband(
@@ -489,6 +490,7 @@ class TestGpucbfAntennaChanneliseVoltageStream:
         assert acv.data_rate(1.0, 0) == 27392e6 * 2 / 8
         assert acv.input_labels == narrowband_config["src_streams"]
         assert acv.w_cutoff == 1.0  # Default value
+        assert acv.dither is None
         assert acv.command_line_extra == []
 
     def test_n_chans_not_power_of_two(
@@ -582,6 +584,15 @@ class TestGpucbfAntennaChanneliseVoltageStream:
             Options(), "wide1_acv", config, src_streams, {}
         )
         assert acv.w_cutoff == 0.9
+
+    def test_dither(
+        self, config: Dict[str, Any], src_streams: List[DigBasebandVoltageStreamBase]
+    ) -> None:
+        config["dither"] = "uniform"
+        acv = GpucbfAntennaChannelisedVoltageStream.from_config(
+            Options(), "wide1_acv", config, src_streams, {}
+        )
+        assert acv.dither == "uniform"
 
     def test_command_line_extra(
         self, config: Dict[str, Any], src_streams: List[DigBasebandVoltageStreamBase]
@@ -919,6 +930,15 @@ class TestGpucbfTiedArrayChannelisedVoltageStream:
         assert tacv.n_chans_per_substream == 1024
         assert tacv.src_pol == 0
         assert tacv.command_line_extra == []
+
+    def test_dither(
+        self, acv: GpucbfAntennaChannelisedVoltageStream, config: Dict[str, Any]
+    ) -> None:
+        config["dither"] = "uniform"
+        tacv = GpucbfTiedArrayChannelisedVoltageStream.from_config(
+            Options(), "wide2_tacv", config, [acv], {}
+        )
+        assert tacv.dither == "uniform"
 
     def test_command_line_extra(
         self, acv: GpucbfAntennaChannelisedVoltageStream, config: Dict[str, Any]
@@ -1435,7 +1455,7 @@ class TestSpectralImageStream:
 @pytest.fixture
 def config() -> Dict[str, Any]:
     return {
-        "version": "4.1",
+        "version": "4.2",
         "inputs": {
             "camdata": {"type": "cam.http", "url": "http://10.8.67.235/api/client/1"},
             "i0_antenna_channelised_voltage": {
@@ -1529,7 +1549,7 @@ def config_v3(config: Dict[str, Any]) -> Dict[str, Any]:
 @pytest.fixture
 def config_sim() -> Dict[str, Any]:
     return {
-        "version": "4.1",
+        "version": "4.2",
         "outputs": {
             "acv": {
                 "type": "sim.cbf.antenna_channelised_voltage",

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -934,11 +934,11 @@ class TestGpucbfTiedArrayChannelisedVoltageStream:
     def test_dither(
         self, acv: GpucbfAntennaChannelisedVoltageStream, config: Dict[str, Any]
     ) -> None:
-        config["dither"] = "uniform"
+        config["dither"] = "none"
         tacv = GpucbfTiedArrayChannelisedVoltageStream.from_config(
             Options(), "wide2_tacv", config, [acv], {}
         )
-        assert tacv.dither == "uniform"
+        assert tacv.dither == "none"
 
     def test_command_line_extra(
         self, acv: GpucbfAntennaChannelisedVoltageStream, config: Dict[str, Any]

--- a/test/utils.py
+++ b/test/utils.py
@@ -44,7 +44,7 @@ _T = TypeVar("_T")
 # The "gpucbf" correlator components are not connected up to any SDP components.
 # They're there just as a smoke test for generator.py.
 CONFIG = """{
-    "version": "4.1",
+    "version": "4.2",
     "outputs": {
         "gpucbf_m900v": {
             "type": "sim.dig.baseband_voltage",


### PR DESCRIPTION
This adds a 'dither' option to gpucbf.tied_array_channelised_voltage and gpucbf.baseline_correlation_products streams, and passes on a suitable config option to the engines.

The engines don't yet support the option, although for fgpu there is a PR: ska-sa/katgpucbf#841.

Relates to NGC-1429.