### PR TITLE
Update Aggregate Sensor Sampling Strategy

### DIFF
--- a/src/katsdpcontroller/aggregate_sensors.py
+++ b/src/katsdpcontroller/aggregate_sensors.py
@@ -152,8 +152,11 @@ class SyncSensor(SimpleAggregateSensor[bool]):
     ) -> Optional[Reading[bool]]:
         updated_reading = super().update_aggregate(updated_sensor, reading, old_reading)
         if updated_reading is not None and updated_reading.value == self.value:
-            # Value hasn't changed, no need to update the sensor
-            return None
+            # Value hasn't changed, just check if the status has
+            if updated_reading.status == self.status:
+                return None
+            else:
+                return updated_reading
         else:
             return updated_reading
 

--- a/src/katsdpcontroller/aggregate_sensors.py
+++ b/src/katsdpcontroller/aggregate_sensors.py
@@ -205,8 +205,7 @@ class LatestSensor(AggregateSensor[_T]):
             return None  # It's not valid
         if self.status.valid_value() and self.timestamp > reading.timestamp:
             return None  # It's older than what we already have
-        if reading is not None and old_reading is not None:
-            if reading.value == old_reading.value:
-                # If it's the same as what we already have, no need to update
-                return None
+        if reading is not None and reading.value == self.value:
+            # If it's the same as what we already have, no need to update
+            return None
         return reading

--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -51,6 +51,9 @@ PFB_TAPS = 16
 #: Default payload size for gpucbf data products. Bigger is better to
 #: minimise the number of packets/second to process.
 GPUCBF_PACKET_PAYLOAD_BYTES = 8192
+#: Minimum update period (in seconds) for katcp sensors where the underlying
+#: value may update extremely rapidly.
+GPUCBF_MIN_SENSOR_UPDATE_PERIOD = 5.0
 #: Autotune fallback behaviour: "nearest" or "exact"
 KATSDPSIGPROC_TUNE_MATCH = "nearest"
 #: Time (in seconds) to sleep before exiting

--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -53,7 +53,7 @@ PFB_TAPS = 16
 GPUCBF_PACKET_PAYLOAD_BYTES = 8192
 #: Minimum update period (in seconds) for katcp sensors where the underlying
 #: value may update extremely rapidly.
-GPUCBF_MIN_SENSOR_UPDATE_PERIOD = 1.0
+FAST_SENSOR_UPDATE_PERIOD = 1.0
 #: Autotune fallback behaviour: "nearest" or "exact"
 KATSDPSIGPROC_TUNE_MATCH = "nearest"
 #: Time (in seconds) to sleep before exiting

--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -53,7 +53,7 @@ PFB_TAPS = 16
 GPUCBF_PACKET_PAYLOAD_BYTES = 8192
 #: Minimum update period (in seconds) for katcp sensors where the underlying
 #: value may update extremely rapidly.
-FAST_SENSOR_UPDATE_PERIOD = 1.0
+FAST_SENSOR_UPDATE_PERIOD = 10.0
 #: Autotune fallback behaviour: "nearest" or "exact"
 KATSDPSIGPROC_TUNE_MATCH = "nearest"
 #: Time (in seconds) to sleep before exiting

--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -51,8 +51,9 @@ PFB_TAPS = 16
 #: Default payload size for gpucbf data products. Bigger is better to
 #: minimise the number of packets/second to process.
 GPUCBF_PACKET_PAYLOAD_BYTES = 8192
-#: Minimum update period (in seconds) for katcp sensors where the underlying
-#: value may update extremely rapidly.
+#: Minimum update period (in seconds) for katcp sensors which aggregate many
+#: underlying sensors and hence may be updated much more often than any one
+#: of the underlying sensors.
 FAST_SENSOR_UPDATE_PERIOD = 1.0
 #: Autotune fallback behaviour: "nearest" or "exact"
 KATSDPSIGPROC_TUNE_MATCH = "nearest"

--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -53,7 +53,7 @@ PFB_TAPS = 16
 GPUCBF_PACKET_PAYLOAD_BYTES = 8192
 #: Minimum update period (in seconds) for katcp sensors where the underlying
 #: value may update extremely rapidly.
-FAST_SENSOR_UPDATE_PERIOD = 10.0
+FAST_SENSOR_UPDATE_PERIOD = 1.0
 #: Autotune fallback behaviour: "nearest" or "exact"
 KATSDPSIGPROC_TUNE_MATCH = "nearest"
 #: Time (in seconds) to sleep before exiting

--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -53,7 +53,7 @@ PFB_TAPS = 16
 GPUCBF_PACKET_PAYLOAD_BYTES = 8192
 #: Minimum update period (in seconds) for katcp sensors where the underlying
 #: value may update extremely rapidly.
-GPUCBF_MIN_SENSOR_UPDATE_PERIOD = 5.0
+GPUCBF_MIN_SENSOR_UPDATE_PERIOD = 1.0
 #: Autotune fallback behaviour: "nearest" or "exact"
 KATSDPSIGPROC_TUNE_MATCH = "nearest"
 #: Time (in seconds) to sleep before exiting

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -48,14 +48,14 @@ import katsdpmodels.fetch.aiohttp
 import katsdptelstate.aio
 import networkx
 import numpy as np
-from aiokatcp import Sensor, SensorSet
+from aiokatcp import Sensor, SensorSampler, SensorSet
 from katsdpmodels.band_mask import BandMask, SpectralWindow
 from katsdpmodels.rfi_mask import RFIMask
 from katsdptelstate.endpoint import Endpoint
 
 from . import defaults, product_config, scheduler
 from .aggregate_sensors import LatestSensor, SumSensor, SyncSensor
-from .defaults import GPUCBF_PACKET_PAYLOAD_BYTES, LOCALHOST
+from .defaults import GPUCBF_MIN_SENSOR_UPDATE_PERIOD, GPUCBF_PACKET_PAYLOAD_BYTES, LOCALHOST
 from .fake_servers import (
     FakeCalDeviceServer,
     FakeFgpuDeviceServer,
@@ -1010,6 +1010,8 @@ def _make_xbgpu(
                     "Number of visibilities that saturated",
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.xeng-clip-cnt"),
                     n_children=stream.n_substreams,
+                    auto_strategy=SensorSampler.Strategy.EVENT_RATE,
+                    auto_strategy_parameters=(GPUCBF_MIN_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
                 SyncSensor(
                     sensors,
@@ -1018,6 +1020,8 @@ def _make_xbgpu(
                     "for all X-Engines",
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.rx.synchronised"),
                     n_children=stream.n_substreams,
+                    auto_strategy=SensorSampler.Strategy.EVENT_RATE,
+                    auto_strategy_parameters=(GPUCBF_MIN_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
             ]
             stream_sensors.extend(xstream_sensors)
@@ -1057,8 +1061,11 @@ def _make_xbgpu(
                     sensors,
                     f"{stream.name}.beng-clip-cnt",
                     "Number of complex samples that saturated",
+                    # Update this to honour sampling intervals and strategies
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.beng-clip-cnt"),
                     n_children=stream.n_substreams,
+                    auto_strategy=SensorSampler.Strategy.EVENT_RATE,
+                    auto_strategy_parameters=(GPUCBF_MIN_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
                 LatestSensor(
                     sensors,
@@ -1066,6 +1073,8 @@ def _make_xbgpu(
                     f"{stream.name}.quantiser-gain",
                     "Non-complex post-summation quantiser gain applied to this beam",
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.quantiser-gain"),
+                    auto_strategy=SensorSampler.Strategy.EVENT_RATE,
+                    auto_strategy_parameters=(GPUCBF_MIN_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
                 LatestSensor(
                     sensors,
@@ -1073,6 +1082,8 @@ def _make_xbgpu(
                     f"{stream.name}.delay",
                     "The delay settings of the inputs for this beam",
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.delay"),
+                    auto_strategy=SensorSampler.Strategy.EVENT_RATE,
+                    auto_strategy_parameters=(GPUCBF_MIN_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
                 LatestSensor(
                     sensors,
@@ -1080,6 +1091,8 @@ def _make_xbgpu(
                     f"{stream.name}.weight",
                     "The summing weights applied to all the inputs of this beam",
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.weight"),
+                    auto_strategy=SensorSampler.Strategy.EVENT_RATE,
+                    auto_strategy_parameters=(GPUCBF_MIN_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
             ]
             stream_sensors.extend(bstream_sensors)

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -55,7 +55,7 @@ from katsdptelstate.endpoint import Endpoint
 
 from . import defaults, product_config, scheduler
 from .aggregate_sensors import LatestSensor, SumSensor, SyncSensor
-from .defaults import GPUCBF_MIN_SENSOR_UPDATE_PERIOD, GPUCBF_PACKET_PAYLOAD_BYTES, LOCALHOST
+from .defaults import FAST_SENSOR_UPDATE_PERIOD, GPUCBF_PACKET_PAYLOAD_BYTES, LOCALHOST
 from .fake_servers import (
     FakeCalDeviceServer,
     FakeFgpuDeviceServer,
@@ -1011,7 +1011,7 @@ def _make_xbgpu(
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.xeng-clip-cnt"),
                     n_children=stream.n_substreams,
                     auto_strategy=SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(GPUCBF_MIN_SENSOR_UPDATE_PERIOD, math.inf),
+                    auto_strategy_parameters=(FAST_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
                 SyncSensor(
                     sensors,
@@ -1021,7 +1021,7 @@ def _make_xbgpu(
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.rx.synchronised"),
                     n_children=stream.n_substreams,
                     auto_strategy=SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(GPUCBF_MIN_SENSOR_UPDATE_PERIOD, math.inf),
+                    auto_strategy_parameters=(FAST_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
             ]
             stream_sensors.extend(xstream_sensors)
@@ -1061,11 +1061,10 @@ def _make_xbgpu(
                     sensors,
                     f"{stream.name}.beng-clip-cnt",
                     "Number of complex samples that saturated",
-                    # Update this to honour sampling intervals and strategies
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.beng-clip-cnt"),
                     n_children=stream.n_substreams,
                     auto_strategy=SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(GPUCBF_MIN_SENSOR_UPDATE_PERIOD, math.inf),
+                    auto_strategy_parameters=(FAST_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
                 LatestSensor(
                     sensors,
@@ -1074,7 +1073,7 @@ def _make_xbgpu(
                     "Non-complex post-summation quantiser gain applied to this beam",
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.quantiser-gain"),
                     auto_strategy=SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(GPUCBF_MIN_SENSOR_UPDATE_PERIOD, math.inf),
+                    auto_strategy_parameters=(FAST_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
                 LatestSensor(
                     sensors,
@@ -1083,7 +1082,7 @@ def _make_xbgpu(
                     "The delay settings of the inputs for this beam",
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.delay"),
                     auto_strategy=SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(GPUCBF_MIN_SENSOR_UPDATE_PERIOD, math.inf),
+                    auto_strategy_parameters=(FAST_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
                 LatestSensor(
                     sensors,
@@ -1092,7 +1091,7 @@ def _make_xbgpu(
                     "The summing weights applied to all the inputs of this beam",
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.weight"),
                     auto_strategy=SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(GPUCBF_MIN_SENSOR_UPDATE_PERIOD, math.inf),
+                    auto_strategy_parameters=(FAST_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
             ]
             stream_sensors.extend(bstream_sensors)

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1020,8 +1020,6 @@ def _make_xbgpu(
                     "for all X-Engines",
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.rx.synchronised"),
                     n_children=stream.n_substreams,
-                    auto_strategy=SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(FAST_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
             ]
             stream_sensors.extend(xstream_sensors)
@@ -1072,8 +1070,6 @@ def _make_xbgpu(
                     f"{stream.name}.quantiser-gain",
                     "Non-complex post-summation quantiser gain applied to this beam",
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.quantiser-gain"),
-                    auto_strategy=SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(FAST_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
                 LatestSensor(
                     sensors,
@@ -1081,8 +1077,6 @@ def _make_xbgpu(
                     f"{stream.name}.delay",
                     "The delay settings of the inputs for this beam",
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.delay"),
-                    auto_strategy=SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(FAST_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
                 LatestSensor(
                     sensors,
@@ -1090,8 +1084,6 @@ def _make_xbgpu(
                     f"{stream.name}.weight",
                     "The summing weights applied to all the inputs of this beam",
                     name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.weight"),
-                    auto_strategy=SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(FAST_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
             ]
             stream_sensors.extend(bstream_sensors)


### PR DESCRIPTION
Originally in #762, I made the unintentional mistake of renaming the branch to correspond to the new Jira ticket.

Something we noticed when debugging the greater NGC-938,
* even though the constituent sensors in the Engines were obeying their sampling intervals,
* the stream-level AggregateSensor was updating as often as each constituent sensor update. 

This update aims to alleviate some of the sensor update spam, and uses the same update interval
from katgpucbf.

Contributes to: NGC-1459.