### PR TITLE
Add GPU CBF B-engine telstate info

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1104,7 +1104,15 @@ def _make_xbgpu(
                 n_accs=n_accs,
             )
         elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
-            # TODO: NGC-1225
+            telstate_data.update(
+                # Had to keep mismatch in spelling as external users still use
+                # 'cent-e-r' spelling.
+                center_freq=stream.centre_frequency,
+                n_chans=stream.n_chans,
+                scale_factor_timestamp=stream.adc_sample_rate,
+                sync_time=sync_time,
+                ticks_between_spectra=stream.n_samples_between_spectra,
+            )
             pass
         for key, value in telstate_data.items():
             init_telstate[(stream.name, key)] = value

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1105,15 +1105,8 @@ def _make_xbgpu(
             )
         elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
             telstate_data.update(
-                # Had to keep mismatch in spelling as external users still use
-                # 'cent-e-r' spelling.
-                center_freq=stream.centre_frequency,
-                n_chans=stream.n_chans,
-                scale_factor_timestamp=stream.adc_sample_rate,
-                sync_time=sync_time,
-                ticks_between_spectra=stream.n_samples_between_spectra,
+                spectra_per_heap=stream.spectra_per_heap,
             )
-            pass
         for key, value in telstate_data.items():
             init_telstate[(stream.name, key)] = value
 


### PR DESCRIPTION
As mentioned on the ticket, I haven't added the `subarray_product_id` key/value in here.
1. Because I don't yet know how, but
2. Because it seems it wasn't mandatory for CBF to populate that.

Whenever you can, please and thank you.

Resolves: NGC-1225.