### PR TITLE
use harbor as source for base-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 ################################################################################
 
-ARG KATSDPDOCKERBASE_REGISTRY=quay.io/ska-sa
+ARG KATSDPDOCKERBASE_REGISTRY=harbor.sdp.kat.ac.za/dpp
 
 FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-build as build
 


### PR DESCRIPTION
Is there a good reason why controller has not been using harbor as the source for base-build?