### PR TITLE
Add filter-group-delay and ddc-group-delay sensors

### DIFF
--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -48,6 +48,9 @@ GPUCBF_JONES_PER_BATCH = 2**20
 XBGPU_MAX_SRC_DATA_RATE = 5.45e9
 #: Number of polyphase filter-bank taps for gpucbf F-engines
 PFB_TAPS = 16
+#: Multiply by decimation factor to get digitiser down-conversion taps
+#: for gpucbf F-engines.
+DDC_TAPS_RATIO = 12
 #: Default payload size for gpucbf data products. Bigger is better to
 #: minimise the number of packets/second to process.
 GPUCBF_PACKET_PAYLOAD_BYTES = 8192

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -500,9 +500,10 @@ def _make_fgpu(
 
         if stream.narrowband is not None:
             ddc_group_delay = -(stream.narrowband.ddc_taps - 1) / 2
-            subsampling = stream.narrowband.decimation_factor * 2
-            # Complex-to-complex PFB
-            pfb_group_delay = -(stream.n_chans * stream.pfb_taps - 1) / 2 * subsampling
+            # Complex-to-complex PFB, but katgpucbf first channelises to
+            # 2N channels then discards N of them.
+            subsampling = stream.narrowband.decimation_factor
+            pfb_group_delay = -(2 * stream.n_chans * stream.pfb_taps - 1) / 2 * subsampling
         else:
             ddc_group_delay = 0.0
             # Real-to-complex PFB

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -499,10 +499,12 @@ def _make_fgpu(
         data_suspect_sensors.append(data_suspect_sensor)
 
         if stream.narrowband is not None:
+            ddc_group_delay = -(stream.narrowband.ddc_taps - 1) / 2
             subsampling = stream.narrowband.decimation_factor * 2
             # Complex-to-complex PFB
             pfb_group_delay = -(stream.n_chans * stream.pfb_taps - 1) / 2 * subsampling
         else:
+            ddc_group_delay = 0.0
             # Real-to-complex PFB
             pfb_group_delay = -(2 * stream.n_chans * stream.pfb_taps - 1) / 2
 
@@ -609,6 +611,21 @@ def _make_fgpu(
                 f"{stream.name}.pfb-group-delay",
                 "PFB group delay, specified in number of samples",
                 default=pfb_group_delay,
+                initial_status=Sensor.Status.NOMINAL,
+            ),
+            Sensor(
+                float,
+                f"{stream.name}.ddc-group-delay",
+                "DDC group delay, specified in number of samples",
+                default=ddc_group_delay,
+                initial_status=Sensor.Status.NOMINAL,
+            ),
+            Sensor(
+                float,
+                f"{stream.name}.filter-group-delay",
+                "Total group delay of all filters in the signal chain, "
+                "specified in number of samples.",
+                default=pfb_group_delay + ddc_group_delay,
                 initial_status=Sensor.Status.NOMINAL,
             ),
             Sensor(
@@ -739,6 +756,7 @@ def _make_fgpu(
             if stream.narrowband is not None:
                 output_config["decimation"] = stream.narrowband.decimation_factor
                 output_config["centre_frequency"] = stream.narrowband.centre_frequency
+                output_config["ddc_taps"] = stream.narrowband.ddc_taps
                 output_arg_name = "narrowband"
             else:
                 output_arg_name = "wideband"

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -612,6 +612,7 @@ class GpucbfNarrowbandConfig:
     def __init__(self, *, decimation_factor: int, centre_frequency: float) -> None:
         self.decimation_factor = decimation_factor
         self.centre_frequency = centre_frequency
+        self.ddc_taps = decimation_factor * defaults.DDC_TAPS_RATIO
 
     @classmethod
     def from_config(cls, config: dict) -> "GpucbfNarrowbandConfig":


### PR DESCRIPTION
Computing these requires knowing the number of DDC filter taps, which is
done by deciding it, using the same formula that fgpu uses to compute
the default.

Also fix the calculation of pfb-group-delay for narrowband.

See NGC-1464.