### PR TITLE
Add n-bengs sensor

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1049,6 +1049,13 @@ def _make_xbgpu(
             bstream_sensors: List[Sensor] = [
                 Sensor(
                     int,
+                    f"{stream.name}.n-bengs",
+                    "The number of B-engines in the instrument",
+                    default=n_engines,
+                    initial_status=Sensor.Status.NOMINAL,
+                ),
+                Sensor(
+                    int,
                     f"{stream.name}.beng-out-bits-per-sample",
                     "B-engine output bits per sample. Per number, not complex pair- "
                     "Real and imaginary parts are both this wide",


### PR DESCRIPTION
This isn't (yet) in the ICD, but is needed for qualification tests.

Relates to NGC-1462.