### PR TITLE
Give dsim more memory

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -371,7 +371,7 @@ def _make_dsim(
     dsim = ProductLogicalTask(name, streams=streams)
     dsim.subsystem = "cbf"
     dsim.image = "katgpucbf"
-    dsim.mem = 4096
+    dsim.mem = 8192
     dsim.ports = ["port", "prometheus"]
     dsim.interfaces = [
         scheduler.InterfaceRequest(


### PR DESCRIPTION
The change to use FFT for MultiCW (ska-sa/katgpucbf#875) increases memory usage.