### PR TITLE
Prevent master controller being disconnected due to backlog

### DIFF
--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -64,3 +64,8 @@ KATSDPSIGPROC_TUNE_MATCH = "nearest"
 SHUTDOWN_DELAY = 10.0
 #: Time to wait for rx.device-status sensors to become nominal
 RX_DEVICE_STATUS_TIMEOUT = 30.0
+#: Maximum number of bytes in a connection backlog before disconnecting a
+#: katcp client. This is increased compared to the aiokatcp default because
+#: some sensors are large strings and a batch of sensor updates could
+#: temporarily cause a large backlog.
+CONNECTION_MAX_BACKLOG = 256 * 1024 * 1024

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -77,7 +77,7 @@ from .controller import (
     make_image_resolver_factory,
     time_request,
 )
-from .defaults import LOCALHOST
+from .defaults import CONNECTION_MAX_BACKLOG, LOCALHOST
 from .scheduler import decode_json_base64
 from .schemas import PRODUCT_CONFIG, SUBSYSTEMS, ZK_STATE  # type: ignore
 
@@ -1200,7 +1200,7 @@ class DeviceServer(aiokatcp.DeviceServer):
         self._override_dicts = {}
         self._interface_changed_callbacks = []
         self._args = args
-        super().__init__(args.host, args.port)
+        super().__init__(args.host, args.port, max_backlog=CONNECTION_MAX_BACKLOG)
         self.sensors.add(
             Sensor(
                 DeviceStatus,

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -61,7 +61,7 @@ from .controller import (
     load_json_dict,
     log_task_exceptions,
 )
-from .defaults import LOCALHOST, RX_DEVICE_STATUS_TIMEOUT, SHUTDOWN_DELAY
+from .defaults import CONNECTION_MAX_BACKLOG, LOCALHOST, RX_DEVICE_STATUS_TIMEOUT, SHUTDOWN_DELAY
 from .generator import TransmitState
 from .product_config import Configuration
 from .tasks import (
@@ -1758,7 +1758,7 @@ class DeviceServer(aiokatcp.DeviceServer):
         self.product: Optional[SubarrayProduct] = None
         self.shutdown_delay = shutdown_delay
 
-        super().__init__(host, port)
+        super().__init__(host, port, max_backlog=CONNECTION_MAX_BACKLOG)
         # setup sensors (note: ProductController adds other sensors)
         self.sensors.add(
             Sensor(

--- a/src/katsdpcontroller/sensor_proxy.py
+++ b/src/katsdpcontroller/sensor_proxy.py
@@ -181,7 +181,11 @@ class SensorWatcher(aiokatcp.SensorWatcher):
                 return
         reading = sensor.reading
         if reading.status != aiokatcp.Sensor.Status.UNREACHABLE:
-            sensor.set_value(reading.value, status=aiokatcp.Sensor.Status.UNREACHABLE)
+            # We could keep the last value, but that could be a large string and
+            # we don't want to spam clients with that (particularly since we're
+            # updating all the sensors at once).
+            default_value = aiokatcp.core.get_type(sensor.stype).default(sensor.stype)
+            sensor.set_value(default_value, status=aiokatcp.Sensor.Status.UNREACHABLE)
 
     def state_updated(self, state: aiokatcp.SyncState) -> None:
         super().state_updated(state)


### PR DESCRIPTION
There are two fixes here:
1. Reduce the amount of data burst to the master controller when the product controller shuts down.
2. Increase the maximum permitted backlog.

The first seems like it might be sufficient, but the second is added to ensure we don't have any issues when setting all the gains in parallel.

Closes NGC-1440.