### PR TITLE
Updates to agent_mkconfig

### DIFF
--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -27,7 +27,7 @@ Software-wise, you will need:
 - [katsdpcontroller](https://github.com/ska-sa/katsdpcontroller) checked out,
   but it doesn't need to be installed (unless you want to run your local copy
   instead of the Docker image)
-- Python packages `netifaces`, `psutil`, `py3nvml`, `pycuda`, `botocore`, `h5py`,
+- Python packages `netifaces`, `psutil`, `nvidia-ml-py`, `pycuda`, `botocore`, `h5py`,
   `astropy`, `numpy` and `katsdpmodels`.
 
 You'll also need certain ports to be available on your machine:

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ where = src
 [options.extras_require]
 agent =
     psutil
-    py3nvml
+    nvidia-ml-py
     pycuda
 
 test =

--- a/src/katsdpcontroller/agent_mkconfig.py
+++ b/src/katsdpcontroller/agent_mkconfig.py
@@ -24,6 +24,7 @@ See :mod:`katsdpcontroller.scheduler` for details.
 import argparse
 import base64
 import contextlib
+import enum
 import glob
 import json
 import numbers
@@ -32,7 +33,8 @@ import os.path
 import subprocess
 import sys
 import xml.etree.ElementTree
-from typing import Any, Dict, Generator, Iterable, List, Mapping, Tuple
+from typing import Any, Dict, Generator, Iterable, List, Mapping, Optional, Tuple
+from xml.etree.ElementTree import Element
 
 import netifaces
 import psutil
@@ -47,11 +49,16 @@ except ImportError:
     pycuda = None
 
 
+class DomainType(enum.Enum):
+    NUMA = 0
+    L3 = 1
+
+
 def _is_power_two(x: int) -> bool:
     return x > 0 and (x & (x - 1)) == 0
 
 
-def attr_get(elem: xml.etree.ElementTree.Element, attr: str) -> str:
+def attr_get(elem: Element, attr: str) -> str:
     """Get an attribute from an XML element, raising KeyError if not found."""
     value = elem.get(attr)
     if value is None:
@@ -74,17 +81,40 @@ def nvml_manager() -> Generator[Any, None, None]:
         pynvml.nvmlShutdown()
 
 
+class NUMANode:
+    """Encapsulates a NUMA node.
+
+    Parameters
+    ----------
+    element
+        The XML NUMANode element, or the XML root if there are no NUMANode elements
+    root
+        The highest ancestor of `element` that does not contain other NUMANode elements
+    """
+
+    def __init__(self, element: Element, root: Element) -> None:
+        self.element = element
+        self.root = root
+        self.pu_indices = _pu_indices(root)
+        self.os_index = int(element.get("os_index", 0))
+        self.domains: List[int] = []  # Indices of domains corresponding to this NUMA node
+
+
 class GPU:
-    def __init__(self, handle: "pynvml.c_nvmlDevice_t", cpu_to_node: Mapping[int, int]) -> None:
+    def __init__(self, handle: "pynvml.c_nvmlDevice_t", nodes: Mapping[int, NUMANode]) -> None:
         # TODO: use number of NUMA nodes to determine nodeset size
         # This is very hacky at the moment (assumes no more than 64
         # NUMA nodes).
-        affinity = int(pynvml.nvmlDeviceGetMemoryAffinity(handle, 1)[0])
+        affinity = int(
+            pynvml.nvmlDeviceGetMemoryAffinity(handle, 1, pynvml.NVML_AFFINITY_SCOPE_NODE)[0]
+        )
         if _is_power_two(affinity):
-            node = affinity.bit_length() - 1
+            self.node: Optional[NUMANode] = nodes[affinity.bit_length() - 1]
+            # TODO: extend the model to allow for multiple domains
+            self.domain: Optional[int] = self.node.domains[0]
         else:
-            node = None
-        self.node = node
+            self.node = None
+            self.domain = None
         self.mem = pynvml.nvmlDeviceGetMemoryInfo(handle).total
         self.name = pynvml.nvmlDeviceGetName(handle)
         # NVML doesn't report compute capability, so we need CUDA
@@ -106,58 +136,128 @@ class GPU:
                 self.device_attributes[str(key)] = value
 
 
-def _pus(node: xml.etree.ElementTree.Element) -> List[xml.etree.ElementTree.Element]:
-    """Return all the processing units under `node`."""
-    return node.findall(".//object[@type='PU']")
+def _descendant_or_self_elements(element: Element, predicate: str) -> List[Element]:
+    """Find all descendants (including the element) matching an XPath predicate."""
+    # ElementTree only implements a small subset of XPath, so we can't use
+    # expressions like ./descendant-or-self::object[...].
+    out = element.findall(f".//object{predicate}")
+    if element.tag == "object":
+        out.extend(element.findall(f".{predicate}"))
+    return out
 
 
-def _numa_nodes(node: xml.etree.ElementTree.Element) -> List[xml.etree.ElementTree.Element]:
-    """Return all the NUMA nodes under `node`."""
-    return node.findall(".//object[@type='NUMANode']")
+def _pu_elements(element: Element) -> List[Element]:
+    """Return all the processing units under `element`."""
+    return _descendant_or_self_elements(element, "[@type='PU']")
+
+
+def _pu_indices(element: Element) -> List[int]:
+    """Return OS indices of all processing units under `element`."""
+    return sorted(int(attr_get(pu, "os_index")) for pu in _pu_elements(element))
+
+
+def _l3_elements(element: Element) -> List[Element]:
+    """Return all the L3 caches under `element`."""
+    return _descendant_or_self_elements(element, "[@type='L3Cache']")
+
+
+def _numa_node_elements(element: Element) -> List[Element]:
+    """Return all the NUMA nodes under `element`."""
+    return _descendant_or_self_elements(element, "[@type='NUMANode']")
+
+
+def _numa_nodes(tree: Element) -> Mapping[int, NUMANode]:
+    """Retrieve all NUMA nodes from the system.
+
+    The :attr`NUMANode.domains` field is not populated.
+    """
+    node_elements = _numa_node_elements(tree)
+    node_elements.sort(key=lambda element: int(attr_get(element, "os_index")))
+    # On single-socket machines, hwloc 1.x doesn't create NUMANode.
+    if not node_elements:
+        node_elements = [tree]
+
+    nodes: Dict[int, NUMANode] = {}  # NUMA nodes, indexed by os_index
+    # In hwloc 2.x, NUMANode is a leaf that doesn't contain the associated
+    # cores and devices. We need to ascend the tree to find the top-level
+    # container.
+    parent_map = {child: parent for parent in tree.iter() for child in parent}
+    for element in node_elements:
+        root = element
+        while root in parent_map and len(_numa_node_elements(parent_map[root])) <= 1:
+            root = parent_map[root]
+        node = NUMANode(element, root)
+        nodes[node.os_index] = node
+    return nodes
 
 
 class HWLocParser:
-    def __init__(self) -> None:
+    """Parse XML output from lstopo.
+
+    The CPUs and devices are associated with "domains". Normally a "domain"
+    is the same as a NUMA node. However, command-line options can change
+    the interpretation.
+
+    Parameters
+    ----------
+    domain_type
+        Control what domains correspond to.
+
+        If set to L3, domains will correspond to L3 caches rather than
+        NUMA nodes. This will raise an exception if the L3 caches do not
+        partition the CPU set of each NUMA node or if there are NUMA nodes
+        without L3 caches. Hardware devices will be associated with the first
+        domain of each NUMA node.
+    """
+
+    def __init__(self, domain_type: DomainType) -> None:
         cmd = ["lstopo", "--output-format", "xml"]
         result = subprocess.check_output(cmd).decode("ascii")
         self._tree = xml.etree.ElementTree.fromstring(result)
         self._nodes = _numa_nodes(self._tree)
-        # On single-socket machines, hwloc 1.x doesn't create NUMANode.
-        if not self._nodes:
-            self._nodes = [self._tree]
-        self._nodes.sort(key=lambda node: int(node.get("os_index", 0)))
-        # In hwloc 2.x, NUMANode is a leaf that doesn't contain the associated
-        # cores and devices. We need to ascend the tree to find the top-level
-        # container.
-        parent_map = {child: parent for parent in self._tree.iter() for child in parent}
-        for i in range(len(self._nodes)):
-            node = self._nodes[i]
-            if int(node.get("os_index", 0)) != i:
-                raise RuntimeError("NUMA nodes are not numbered contiguously by the OS")
-            while node in parent_map and len(_numa_nodes(parent_map[node])) <= 1:
-                node = parent_map[node]
-            self._nodes[i] = node
 
-    def cpus_by_node(self) -> List[List[int]]:
-        out = []
-        for node in self._nodes:
-            pus = _pus(node)
-            out.append(sorted([int(attr_get(pu, "os_index")) for pu in pus]))
-        return out
+        # Each domain is a list of CPU indices
+        self._domains: List[List[int]] = []
+        if domain_type == DomainType.NUMA:
+            for node in self._nodes.values():
+                node.domains = [len(self._domains)]
+                self._domains.append(node.pu_indices)
+        elif domain_type == DomainType.L3:
+            for node in self._nodes.values():
+                node_cpuset = set(node.pu_indices)  # We'll remove from this as we go
+                orig_node_cpuset = frozenset(node_cpuset)
+                for l3 in _l3_elements(node.root):
+                    l3_cpuset = set(_pu_indices(l3))
+                    if not l3_cpuset.issubset(orig_node_cpuset):
+                        raise RuntimeError("L3 cache PUs not a subset of the NUMA node's")
+                    if not l3_cpuset.issubset(node_cpuset):
+                        raise RuntimeError("L3 caches contain overlapping PUs")
+                    node_cpuset -= l3_cpuset
+                    node.domains.append(len(self._domains))
+                    self._domains.append(sorted(l3_cpuset))
+                if node_cpuset:
+                    raise RuntimeError("NUMA node contains PUs not covered by any L3 cache")
+        else:
+            raise RuntimeError(f"Unhandled domain type {domain_type}")
 
-    def cpu_nodes(self) -> Mapping[int, int]:
+    def cpus_by_domain(self) -> List[List[int]]:
+        return self._domains
+
+    def cpu_domains(self) -> Mapping[int, int]:
         out = {}
-        for i, node in enumerate(self.cpus_by_node()):
-            for cpu in node:
+        for i, domain in enumerate(self._domains):
+            for cpu in domain:
                 out[cpu] = i
         return out
 
-    def interface_nodes(self) -> Mapping[str, int]:
+    def interface_domains(self) -> Mapping[str, int]:
         out = {}
-        for i, node in enumerate(self._nodes):
+        for node in self._nodes.values():
+            # TODO: need to change the module to allow for multiple domains
+            domain = node.domains[0]
             # hwloc uses type 2 for network devices
-            for device in node.iterfind(".//object[@type='OSDev'][@osdev_type='2']"):
-                out[attr_get(device, "name")] = i
+            for device in node.root.iterfind(".//object[@type='OSDev'][@osdev_type='2']"):
+                out[attr_get(device, "name")] = domain
         return out
 
     def gpus(self) -> List[GPU]:
@@ -165,17 +265,17 @@ class HWLocParser:
         with nvml_manager():
             if not pynvml:
                 return out
-            cpu_to_node = self.cpu_nodes()
             n_devices = pynvml.nvmlDeviceGetCount()
             for i in range(n_devices):
                 handle = pynvml.nvmlDeviceGetHandleByIndex(i)
-                out.append(GPU(handle, cpu_to_node))
+                out.append(GPU(handle, self._nodes))
         return out
 
 
 def infiniband_devices(interface: str) -> List[str]:
-    """Return a list of device paths associated with a kernel network
-    interface, or an empty list if not an Infiniband device.
+    """Return a list of device paths associated with a kernel network interface.
+
+    Return an empty list if `interface` is not an Infiniband device.
 
     This is based on ibdev2netdev (installed with MLNX OFED) plus inspection of
     /sys.
@@ -218,11 +318,11 @@ def collapse_ranges(values: Iterable[int]) -> str:
 
 
 def attributes_resources(args: argparse.Namespace) -> Tuple[Mapping[str, Any], Mapping[str, Any]]:
-    hwloc = HWLocParser()
+    hwloc = HWLocParser(DomainType[args.domains.upper()])
     attributes: Dict[str, Any] = {}
     resources: Dict[str, Any] = {}
 
-    interface_nodes = hwloc.interface_nodes()
+    interface_domains = hwloc.interface_domains()
     interfaces = []
     for i, network_spec in enumerate(args.networks):
         try:
@@ -270,7 +370,7 @@ def attributes_resources(args: argparse.Namespace) -> Tuple[Mapping[str, Any], M
         except (KeyError, IndexError):
             raise RuntimeError(f"Could not obtain IPv4 address for interface {interface}")
         try:
-            config["numa_node"] = interface_nodes[interface]
+            config["numa_node"] = interface_domains[interface]
         except KeyError:
             pass
         interfaces.append(config)
@@ -305,18 +405,19 @@ def attributes_resources(args: argparse.Namespace) -> Tuple[Mapping[str, Any], M
             name = fields[0]
             path = fields[1]
             if len(fields) >= 3:
-                numa_node = int(fields[2])
+                domain = int(fields[2])
             else:
-                numa_node = None
+                domain = None
         except (ValueError, IndexError):
             raise RuntimeError(
-                f"Error: --volume argument {volume_spec} does not have the format NAME:PATH"
+                f"Error: --volume argument {volume_spec} "
+                "does not have the format NAME:PATH[:DOMAIN]"
             )
         if not os.path.exists(path):
             raise RuntimeError(f"Path {path} does not exist")
         config = {"name": name, "host_path": path}
-        if numa_node is not None:
-            config["numa_node"] = numa_node
+        if domain is not None:
+            config["numa_node"] = domain
         volumes.append(config)
     attributes["katsdpcontroller.volumes"] = volumes
 
@@ -329,8 +430,8 @@ def attributes_resources(args: argparse.Namespace) -> Tuple[Mapping[str, Any], M
                 "device_attributes": gpu.device_attributes,
                 "uuid": gpu.uuid,
             }
-            if gpu.node is not None:
-                config["numa_node"] = gpu.node
+            if gpu.domain is not None:
+                config["numa_node"] = gpu.domain
             gpus.append(config)
             resources[f"katsdpcontroller.gpu.{i}.compute"] = 1.0
             # Convert memory to MiB, for consistency with Mesos' other resources
@@ -343,9 +444,9 @@ def attributes_resources(args: argparse.Namespace) -> Tuple[Mapping[str, Any], M
     if args.subsystems:
         attributes["katsdpcontroller.subsystems"] = args.subsystems
 
-    attributes["katsdpcontroller.numa"] = hwloc.cpus_by_node()
-    resources["cores"] = collapse_ranges(hwloc.cpu_nodes().keys())
-    resources["cpus"] = float(len(hwloc.cpu_nodes())) - args.reserve_cpu
+    attributes["katsdpcontroller.numa"] = hwloc.cpus_by_domain()
+    resources["cores"] = collapse_ranges(hwloc.cpu_domains().keys())
+    resources["cpus"] = float(len(hwloc.cpu_domains())) - args.reserve_cpu
     if resources["cpus"] < 0.1:
         raise RuntimeError(f"--reserve-cpu ({args.reserve_cpu}) is too high")
     resources["mem"] = psutil.virtual_memory().total // 2**20 - args.reserve_mem
@@ -489,6 +590,12 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         default=[],
         metavar="NAME:PATH[:NUMA]",
         help="Map host directory to a logical volume name",
+    )
+    parser.add_argument(
+        "--domains",
+        choices=[value.name.lower() for value in DomainType],
+        default="numa",
+        help="Domains by which to partition hardware [%(default)s]",
     )
     parser.add_argument("--priority", type=float, help="Set agent priority for placement")
     parser.add_argument(

--- a/test/lstopo-no-numa-multi-l3.xml
+++ b/test/lstopo-no-numa-multi-l3.xml
@@ -1,0 +1,378 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" allowed_cpuset="0x0000ffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" gp_index="1">
+    <info name="DMIProductName" value="Super Server"/>
+    <info name="DMIProductVersion" value="0123456789"/>
+    <info name="DMIBoardVendor" value="Supermicro"/>
+    <info name="DMIBoardName" value="H12SSL-i"/>
+    <info name="DMIBoardVersion" value="1.02"/>
+    <info name="DMIBoardAssetTag" value="To be filled by O.E.M."/>
+    <info name="DMIChassisVendor" value="Supermicro"/>
+    <info name="DMIChassisType" value="1"/>
+    <info name="DMIChassisVersion" value="0123456789"/>
+    <info name="DMIChassisAssetTag" value="To be filled by O.E.M."/>
+    <info name="DMIBIOSVendor" value="American Megatrends Inc."/>
+    <info name="DMIBIOSVersion" value="2.5"/>
+    <info name="DMIBIOSDate" value="09/08/2022"/>
+    <info name="DMISysVendor" value="Supermicro"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/user.slice"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="5.15.0-118-generic"/>
+    <info name="OSVersion" value="#128-Ubuntu SMP Fri Jul 5 09:28:59 UTC 2024"/>
+    <info name="HostName" value="cbfgpu009.cbf.mkat.karoo.kat.ac.za"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="2.7.0"/>
+    <info name="ProcessName" value="lstopo"/>
+    <object type="Package" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="3">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7313P 16-Core Processor               "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="87" local_memory="67202420736">
+        <page_type size="4096" count="16406841"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="0" cpuset="0x0000000f" complete_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="8" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="7" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="5" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="6" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2">
+                <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="4"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="13" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="11" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="12" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="9">
+                <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="10"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="18" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="16" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="17" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="14">
+                <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="15"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="23" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="21" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="22" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="19">
+                <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="20"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="1" cpuset="0x000000f0" complete_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="29" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="28" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="26" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="27" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="24">
+                <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="25"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="34" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="32" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="33" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="30">
+                <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="31"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="39" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="37" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="38" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="35">
+                <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="36"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="44" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="42" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="43" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="40">
+                <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="41"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="2" cpuset="0x00000f00" complete_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="50" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="49" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="47" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="48" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="45">
+                <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="46"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="55" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="53" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="54" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="51">
+                <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="52"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="60" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="58" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="59" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="56">
+                <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="57"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="65" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="63" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="64" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="61">
+                <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="62"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="3" cpuset="0x0000f000" complete_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="71" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="70" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="68" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="69" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="66">
+                <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="67"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="76" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="74" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="75" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="72">
+                <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="73"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="81" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="79" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="80" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="77">
+                <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="78"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="86" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="84" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="85" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="82">
+                <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="83"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Bridge" gp_index="154" bridge_type="0-1" depth="0" bridge_pci="0000:[40-49]">
+      <object type="Bridge" gp_index="121" bridge_type="1-1" depth="1" bridge_pci="0000:[42-43]" pci_busid="0000:40:03.4" pci_type="0604 [1022:1483] [1022:1453] 00" pci_link_speed="0.250000">
+        <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+        <info name="PCIDevice" value="Starship/Matisse GPP Bridge"/>
+        <object type="Bridge" gp_index="106" bridge_type="1-1" depth="2" bridge_pci="0000:[43-43]" pci_busid="0000:42:00.0" pci_type="0604 [1a03:1150] [1a03:1150] 04" pci_link_speed="0.250000">
+          <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+          <info name="PCIDevice" value="AST1150 PCI-to-PCI Bridge"/>
+          <object type="PCIDev" gp_index="96" pci_busid="0000:43:00.0" pci_type="0300 [1a03:2000] [15d9:1b95] 41" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+            <info name="PCIDevice" value="ASPEED Graphics Family"/>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="115" bridge_type="1-1" depth="1" bridge_pci="0000:[45-45]" pci_busid="0000:40:03.6" pci_type="0604 [1022:1483] [1022:1453] 00" pci_link_speed="1.230769">
+        <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+        <info name="PCIDevice" value="Starship/Matisse GPP Bridge"/>
+        <object type="PCIDev" gp_index="141" pci_busid="0000:45:00.0" pci_type="0200 [14e4:165f] [15d9:165f] 00" pci_link_speed="1.230769">
+          <info name="PCIVendor" value="Broadcom Inc. and subsidiaries"/>
+          <info name="PCIDevice" value="NetXtreme BCM5720 Gigabit Ethernet PCIe"/>
+          <object type="OSDev" gp_index="159" name="eno1" osdev_type="2">
+            <info name="Address" value="3c:ec:ef:98:63:9a"/>
+          </object>
+        </object>
+        <object type="PCIDev" gp_index="103" pci_busid="0000:45:00.1" pci_type="0200 [14e4:165f] [15d9:165f] 00" pci_link_speed="1.230769">
+          <info name="PCIVendor" value="Broadcom Inc. and subsidiaries"/>
+          <info name="PCIDevice" value="NetXtreme BCM5720 Gigabit Ethernet PCIe"/>
+          <object type="OSDev" gp_index="158" name="eno2" osdev_type="2">
+            <info name="Address" value="3c:ec:ef:98:63:9b"/>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="92" bridge_type="1-1" depth="1" bridge_pci="0000:[48-48]" pci_busid="0000:40:08.2" pci_type="0604 [1022:1484] [1022:1484] 00" pci_link_speed="31.507692">
+        <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+        <info name="PCIDevice" value="Starship/Matisse Internal PCIe GPP Bridge 0 to bus[E:B]"/>
+        <object type="PCIDev" gp_index="111" pci_busid="0000:48:00.0" pci_type="0106 [1022:7901] [15d9:7901] 51" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <info name="PCIDevice" value="FCH SATA Controller [AHCI mode]"/>
+          <object type="OSDev" gp_index="157" name="sda" subtype="Disk" osdev_type="0">
+            <info name="Size" value="468851544"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="8:0"/>
+            <info name="Model" value="Micron_5300_MTFD"/>
+            <info name="Revision" value="U001"/>
+            <info name="SerialNumber" value="23043DE3195A"/>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="125" bridge_type="1-1" depth="1" bridge_pci="0000:[49-49]" pci_busid="0000:40:08.3" pci_type="0604 [1022:1484] [1022:1484] 00" pci_link_speed="31.507692">
+        <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+        <info name="PCIDevice" value="Starship/Matisse Internal PCIe GPP Bridge 0 to bus[E:B]"/>
+        <object type="PCIDev" gp_index="100" pci_busid="0000:49:00.0" pci_type="0106 [1022:7901] [15d9:7901] 51" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <info name="PCIDevice" value="FCH SATA Controller [AHCI mode]"/>
+        </object>
+      </object>
+    </object>
+    <object type="Bridge" gp_index="155" bridge_type="0-1" depth="0" bridge_pci="0000:[80-83]">
+      <object type="Bridge" gp_index="143" bridge_type="1-1" depth="1" bridge_pci="0000:[81-81]" pci_busid="0000:80:01.1" pci_type="0604 [1022:1483] [1022:1453] 00" pci_link_speed="31.507692">
+        <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+        <info name="PCIDevice" value="Starship/Matisse GPP Bridge"/>
+        <object type="PCIDev" gp_index="127" pci_busid="0000:81:00.0" pci_type="0300 [10de:2482] [1458:408f] a1" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="NVIDIA Corporation"/>
+          <info name="PCIDevice" value="GA104 [GeForce RTX 3070 Ti]"/>
+          <object type="OSDev" gp_index="162" name="opencl0d0" subtype="OpenCL" osdev_type="5">
+            <info name="Backend" value="OpenCL"/>
+            <info name="OpenCLDeviceType" value="GPU"/>
+            <info name="GPUVendor" value="NVIDIA Corporation"/>
+            <info name="GPUModel" value="NVIDIA GeForce RTX 3070 Ti"/>
+            <info name="OpenCLPlatformIndex" value="0"/>
+            <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
+            <info name="OpenCLPlatformDeviceIndex" value="0"/>
+            <info name="OpenCLComputeUnits" value="48"/>
+            <info name="OpenCLGlobalMemorySize" value="8066816"/>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Bridge" gp_index="156" bridge_type="0-1" depth="0" bridge_pci="0000:[c0-c3]">
+      <object type="Bridge" gp_index="134" bridge_type="1-1" depth="1" bridge_pci="0000:[c1-c1]" pci_busid="0000:c0:01.1" pci_type="0604 [1022:1483] [1022:1453] 00" pci_link_speed="31.507692">
+        <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+        <info name="PCIDevice" value="Starship/Matisse GPP Bridge"/>
+        <object type="PCIDev" gp_index="110" pci_busid="0000:c1:00.0" pci_type="0200 [15b3:101d] [15b3:0018] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Mellanox Technologies"/>
+          <info name="PCIDevice" value="MT2892 Family [ConnectX-6 Dx]"/>
+          <object type="OSDev" gp_index="160" name="enp193s0np0" osdev_type="2">
+            <info name="Address" value="94:6d:ae:75:b6:ea"/>
+            <info name="Port" value="1"/>
+          </object>
+          <object type="OSDev" gp_index="161" name="mlx5_0" osdev_type="3">
+            <info name="NodeGUID" value="946d:ae03:0075:b6ea"/>
+            <info name="SysImageGUID" value="946d:ae03:0075:b6ea"/>
+            <info name="Port1State" value="4"/>
+            <info name="Port1LID" value="0x0"/>
+            <info name="Port1LMC" value="0"/>
+            <info name="Port1GID0" value="fe80:0000:0000:0000:966d:aeff:fe75:b6ea"/>
+            <info name="Port1GID1" value="fe80:0000:0000:0000:966d:aeff:fe75:b6ea"/>
+            <info name="Port1GID2" value="0000:0000:0000:0000:0000:ffff:0a68:0121"/>
+            <info name="Port1GID3" value="0000:0000:0000:0000:0000:ffff:0a68:0121"/>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+  <support name="discovery.pu"/>
+  <support name="discovery.numa"/>
+  <support name="discovery.numa_memory"/>
+  <support name="discovery.disallowed_pu"/>
+  <support name="discovery.disallowed_numa"/>
+  <support name="discovery.cpukind_efficiency"/>
+  <support name="cpubind.set_thisproc_cpubind"/>
+  <support name="cpubind.get_thisproc_cpubind"/>
+  <support name="cpubind.set_proc_cpubind"/>
+  <support name="cpubind.get_proc_cpubind"/>
+  <support name="cpubind.set_thisthread_cpubind"/>
+  <support name="cpubind.get_thisthread_cpubind"/>
+  <support name="cpubind.set_thread_cpubind"/>
+  <support name="cpubind.get_thread_cpubind"/>
+  <support name="cpubind.get_thisproc_last_cpu_location"/>
+  <support name="cpubind.get_proc_last_cpu_location"/>
+  <support name="cpubind.get_thisthread_last_cpu_location"/>
+  <support name="membind.set_thisthread_membind"/>
+  <support name="membind.get_thisthread_membind"/>
+  <support name="membind.set_area_membind"/>
+  <support name="membind.get_area_membind"/>
+  <support name="membind.alloc_membind"/>
+  <support name="membind.firsttouch_membind"/>
+  <support name="membind.bind_membind"/>
+  <support name="membind.interleave_membind"/>
+  <support name="membind.migrate_membind"/>
+  <support name="membind.get_area_memlocation"/>
+  <support name="custom.exported_support"/>
+  <cpukind cpuset="0x0000ffff">
+    <info name="FrequencyMaxMHz" value="3729"/>
+  </cpukind>
+</topology>

--- a/test/test_agent_mkconfig.py
+++ b/test/test_agent_mkconfig.py
@@ -33,7 +33,7 @@ from katsdpcontroller import agent_mkconfig
 def mock_gpu(mocker) -> None:
     pynvml = mocker.patch("katsdpcontroller.agent_mkconfig.pynvml")
     pynvml.nvmlDeviceGetCount.return_value = 1
-    pynvml.nvmlDeviceGetCpuAffinity.return_value = [0xF0]
+    pynvml.nvmlDeviceGetMemoryAffinity.return_value = [0x2]
     pynvml.nvmlDeviceGetMemoryInfo.return_value.total = 8589934592
     pynvml.nvmlDeviceGetName.return_value = "NVIDIA GeForce RTX 3070 Ti"
     pynvml.nvmlDeviceGetPciInfo.return_value.busId = b"0000:81:00.0"


### PR DESCRIPTION
The primary functional difference is the addition of the --domains
argument, the separation of OS NUMA nodes from abstract "domains",
and the option to use L3 Caches to define domains. The last is not yet
tested though.

For backwards compatibility, the output attributes still refer to NUMA
nodes, and only allow for each device to be associated with a single
NUMA node.

I also had to do a lot of refactoring to make the code clean enough for me to comprehend it enough, which is why there might seem to be more than the minimum necessary amount of changes.