### PR TITLE
Add ability to suppress 30s good data timeout

### DIFF
--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -237,11 +237,17 @@ class ServiceOverride:
 
 class DevelopOptions:
     def __init__(
-        self, *, any_gpu: bool = False, disable_ibverbs: bool = False, less_resources: bool = False
+        self,
+        *,
+        any_gpu: bool = False,
+        disable_ibverbs: bool = False,
+        less_resources: bool = False,
+        disable_good_data_timeout: bool = False,
     ) -> None:
         self.any_gpu = any_gpu
         self.disable_ibverbs = disable_ibverbs
         self.less_resources = less_resources
+        self.disable_good_data_timeout: bool = False
 
     @classmethod
     def from_config(cls, config: Mapping[str, bool]) -> "DevelopOptions":
@@ -249,11 +255,14 @@ class DevelopOptions:
             any_gpu=config.get("any_gpu", False),
             disable_ibverbs=config.get("disable_ibverbs", False),
             less_resources=config.get("less_resources", False),
+            disable_good_data_timeout=config.get("disable_good_data_timeout", False),
         )
 
     @classmethod
     def from_bool(cls, opt: bool) -> "DevelopOptions":
-        return cls(any_gpu=opt, disable_ibverbs=opt, less_resources=opt)
+        return cls(
+            any_gpu=opt, disable_ibverbs=opt, less_resources=opt, disable_good_data_timeout=opt
+        )
 
 
 class Options:

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -586,6 +586,9 @@
                                 "any_gpu": {"type": "boolean", "default": false},
                                 "disable_ibverbs": {"type": "boolean", "default": false},
                                 "less_resources": {"type": "boolean", "default": false}
+{% if version >= "4.2" %}
+                                "disable_good_data_timeout": {"type": "boolean", "default": false}
+{% endif %}
                             },
                             "additionalProperties": false
                         },


### PR DESCRIPTION
Add an option to develop mode to suppress the 30s good data timeout.

The context for this is that one potential reason for a task not receiving good data within 30s of startup is a problem with the network. We probably wouldn't want to run operations under such circumstances, but if we're trying to debug network issues then having the product die after 30s doesn't give enough time.

The FailReply is replaced by an error message in the logger for traceability, but the product should not in fact just die.

Closes NGC-1571