### PR TITLE
Update aiohttp to the latest version (for dependabot)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ aioconsole==0.7.0
     # via aiomonitor
 aiohappyeyeballs==2.3.7
     # via aiohttp
-aiohttp==3.10.4
+aiohttp==3.10.11
     # via
     #   aiohttp-jinja2
     #   aiohttp-retry
@@ -224,6 +224,8 @@ prometheus-client==0.3.1
     #   prometheus-async
 prompt-toolkit==3.0.43
     # via aiomonitor
+propcache==0.2.0
+    # via yarl
 pydot==2.0.0
     # via katsdpcontroller (setup.cfg)
 pyerfa==2.0.0.3
@@ -309,7 +311,7 @@ wrapt==1.16.0
     # via prometheus-async
 www-authenticate==0.9.2
     # via katsdpcontroller (setup.cfg)
-yarl==1.9.4
+yarl==1.15.2
     # via
     #   aiohttp
     #   katsdpcontroller (setup.cfg)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,7 +8,7 @@ aiohappyeyeballs==2.3.7
     # via
     #   -c requirements.txt
     #   aiohttp
-aiohttp==3.10.4
+aiohttp==3.10.11
     # via
     #   -c requirements.txt
     #   aioresponses
@@ -62,6 +62,10 @@ packaging==23.2
     #   pytest
 pluggy==1.4.0
     # via pytest
+propcache==0.2.0
+    # via
+    #   -c requirements.txt
+    #   yarl
 psutil==5.9.8
     # via -r test-requirements.in
 pyfakefs==5.3.5
@@ -94,7 +98,7 @@ typing-extensions==4.9.0
     # via
     #   -c requirements.txt
     #   mypy
-yarl==1.9.4
+yarl==1.15.2
     # via
     #   -c requirements.txt
     #   aiohttp

--- a/test/fake_singularity.py
+++ b/test/fake_singularity.py
@@ -206,7 +206,10 @@ async def default_lifecycle(
 
 class SingularityServer:
     def __init__(self, *, aiohttp_server_kwargs: Mapping = {}) -> None:
-        app = aiohttp.web.Application()
+        # We increase the keepalive_timeout to work around
+        # https://github.com/aio-libs/aiohttp/issues/10149 in aiohttp 3.10.11.
+        # This new value is the default since aiohttp 3.11.
+        app = aiohttp.web.Application(handler_args=dict(keepalive_timeout=3630))
         app.add_routes(
             [
                 aiohttp.web.get("/api/requests/request/{request_id}", self._get_request),


### PR DESCRIPTION
Also tweak the keepalive timeout for the fake Singularity server, to work around an issue in this version of aiohttp when async-solipsism is used.

Closes NGC-1575.