### PR TITLE
Add support for product schema version 4.4

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2013-2024, National Research Foundation (SARAO)
+# Copyright (c) 2013-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -753,6 +753,8 @@ def _make_fgpu(
                 "w_cutoff": stream.w_cutoff,
                 "jones_per_batch": stream.n_jones_per_batch,
                 "dst": f"{{endpoints[multicast.{stream.name}_spead]}}",
+                "dither": stream.dither,
+                "window_function": stream.window_function,
             }
             if stream.narrowband is not None:
                 output_config["decimation"] = stream.narrowband.decimation_factor
@@ -761,11 +763,11 @@ def _make_fgpu(
                 output_arg_name = "narrowband"
             else:
                 output_arg_name = "wideband"
-            if stream.dither is not None:
-                output_config["dither"] = stream.dither
             fgpu.command += [
                 f"--{output_arg_name}",
-                ",".join(f"{key}={value}" for (key, value) in output_config.items()),
+                ",".join(
+                    f"{key}={value}" for (key, value) in output_config.items() if value is not None
+                ),
             ]
 
         if not configuration.options.develop.less_resources:

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2013-2024, National Research Foundation (SARAO)
+# Copyright (c) 2013-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -651,6 +651,8 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
         n_chans: int,
         input_labels: Optional[Iterable[str]] = None,
         w_cutoff: float = 1.0,
+        window_function: Optional[str] = None,
+        taps: Optional[int] = None,
         narrowband: Optional[GpucbfNarrowbandConfig] = None,
         dither: Optional[str] = None,
         command_line_extra: Iterable[str] = (),
@@ -737,8 +739,9 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
         )
         self.n_substreams = n_substreams
         self.bits_per_sample = 8
-        self.pfb_taps = defaults.PFB_TAPS
+        self.pfb_taps = taps if taps is not None else defaults.PFB_TAPS
         self.w_cutoff = w_cutoff
+        self.window_function = window_function
         self.narrowband = narrowband
         self.dither = dither
         self.command_line_extra = list(command_line_extra)
@@ -791,6 +794,8 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
             n_chans=config["n_chans"],
             input_labels=config.get("input_labels"),
             w_cutoff=config.get("w_cutoff", 1.0),
+            window_function=config.get("window_function"),
+            taps=config.get("taps"),
             narrowband=(
                 GpucbfNarrowbandConfig.from_config(narrowband) if narrowband is not None else None
             ),

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -508,7 +508,7 @@
                                     },
                                     "w_cutoff": {"$ref": "#/definitions/nonneg_number", "default": 1.0},
 {% if version >= "4.4" %}
-                                    "window_function": {"$ref": "#/definitions/window_function"},
+                                    "window_function": {"$ref": "#/definitions/window_function", "default": "hann"},
                                     "taps": {"$ref": "#/definitions/positive_integer"},
 {% endif %}
 {% if version >= "3.3" %}

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -1,5 +1,5 @@
 {% macro versions() %}
-["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "4.0", "4.1", "4.2", "4.3"]
+["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "4.0", "4.1", "4.2", "4.3", "4.4"]
 {% endmacro %}
 
 {% macro validate(version) %}
@@ -90,6 +90,9 @@
         },
         "dither": {
             "enum": ["uniform", "none"]
+        },
+        "window_function": {
+            "enum": ["hann", "rect"]
         }
     },
     "type": "object",
@@ -503,7 +506,11 @@
                                         "items": {"$ref": "#/definitions/stream_name"},
                                         "uniqueItems": true
                                     },
-                                    "w_cutoff": {"$ref": "#/definitions/positive_number", "default": 1.0},
+                                    "w_cutoff": {"$ref": "#/definitions/nonneg_number", "default": 1.0},
+{% if version >= "4.4" %}
+                                    "window_function": {"$ref": "#/definitions/window_function"},
+                                    "taps": {"$ref": "#/definitions/positive_integer"},
+{% endif %}
 {% if version >= "3.3" %}
                                     "narrowband": {
                                         "type": "object",

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2013-2024, National Research Foundation (SARAO)
+# Copyright (c) 2013-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -464,6 +464,8 @@ class TestGpucbfAntennaChanneliseVoltageStream:
         assert acv.data_rate(1.0, 0) == 27392e6 * 2
         assert acv.input_labels == config["src_streams"]
         assert acv.w_cutoff == 1.0  # Default value
+        assert acv.window_function is None
+        assert acv.pfb_taps == defaults.PFB_TAPS
         assert acv.dither is None
         assert acv.command_line_extra == []
 
@@ -492,6 +494,8 @@ class TestGpucbfAntennaChanneliseVoltageStream:
         assert acv.data_rate(1.0, 0) == 27392e6 * 2 / 8
         assert acv.input_labels == narrowband_config["src_streams"]
         assert acv.w_cutoff == 1.0  # Default value
+        assert acv.window_function is None
+        assert acv.pfb_taps == defaults.PFB_TAPS
         assert acv.dither is None
         assert acv.command_line_extra == []
 
@@ -586,6 +590,24 @@ class TestGpucbfAntennaChanneliseVoltageStream:
             Options(), "wide1_acv", config, src_streams, {}
         )
         assert acv.w_cutoff == 0.9
+
+    def test_window_function(
+        self, config: Dict[str, Any], src_streams: List[DigBasebandVoltageStreamBase]
+    ) -> None:
+        config["window_function"] = "rect"
+        acv = GpucbfAntennaChannelisedVoltageStream.from_config(
+            Options(), "wide1_acv", config, src_streams, {}
+        )
+        assert acv.window_function == "rect"
+
+    def test_taps(
+        self, config: Dict[str, Any], src_streams: List[DigBasebandVoltageStreamBase]
+    ) -> None:
+        config["taps"] = 3
+        acv = GpucbfAntennaChannelisedVoltageStream.from_config(
+            Options(), "wide1_acv", config, src_streams, {}
+        )
+        assert acv.pfb_taps == 3
 
     def test_dither(
         self, config: Dict[str, Any], src_streams: List[DigBasebandVoltageStreamBase]
@@ -1457,7 +1479,7 @@ class TestSpectralImageStream:
 @pytest.fixture
 def config() -> Dict[str, Any]:
     return {
-        "version": "4.3",
+        "version": "4.4",
         "inputs": {
             "camdata": {"type": "cam.http", "url": "http://10.8.67.235/api/client/1"},
             "i0_antenna_channelised_voltage": {


### PR DESCRIPTION
This adds `taps` and `window_function` parameters to gpucbf.antenna_channelised_voltage. Pass them through to katgpucbf. The latter requires an update to katgpucbf.

Also change w_cutoff from positive_number to nonneg_number, so that w_cutoff=0 is possible (which effectively disables the sinc in generate_pfb_weights. This is done retroactively for all schema versions, since the specification didn't say what the allowed range was.

Relates to NGC-1004.