### PR TITLE
Remove quantisation of narrowband centre frequency

### DIFF
--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -704,11 +704,6 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
             max_cf = dig_bandwidth - bandwidth / 2
             # katgpucbf quantises the centre frequency. Perform the matching
             # quantisation here so that we have the true value.
-            narrowband = copy.copy(narrowband)  # Don't modify the caller's copy
-            cf_resolution = bandwidth / 2**32
-            narrowband.centre_frequency = (
-                round(narrowband.centre_frequency / cf_resolution) * cf_resolution
-            )
             if not (min_cf <= narrowband.centre_frequency <= max_cf):
                 raise ValueError(
                     f"Narrowband centre frequency {narrowband.centre_frequency}"

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -480,8 +480,7 @@ class TestGpucbfAntennaChanneliseVoltageStream:
         assert acv.band == src_streams[0].band
         assert acv.n_chans == narrowband_config["n_chans"]
         assert acv.bandwidth == src_streams[0].adc_sample_rate / 2 / 8
-        # It won't be exact because of quantisation of the narrowband centre frequency
-        assert acv.centre_frequency == pytest.approx(1056e6, abs=1e-2)
+        assert acv.centre_frequency == 1056e6
         assert acv.adc_sample_rate == src_streams[0].adc_sample_rate
         assert (
             acv.n_samples_between_spectra
@@ -631,10 +630,9 @@ class TestGpucbfAntennaChanneliseVoltageStream:
         self, narrowband_config: Dict[str, Any], src_streams: List[DigBasebandVoltageStreamBase]
     ) -> None:
         narrowband_config["narrowband"]["centre_frequency"] = 50e6
-        # The error reports the quantised centre frequency
         with pytest.raises(
             ValueError,
-            match=r"50000000.01117587 is outside the range \[53500000\.0, 802500000\.0\]",
+            match=r"50000000.0 is outside the range \[53500000\.0, 802500000\.0\]",
         ):
             GpucbfAntennaChannelisedVoltageStream.from_config(
                 Options(), "narrow1_acv", narrowband_config, src_streams, {}


### PR DESCRIPTION
ska-sa/katgpucbf#902 removed the quantisation from katgpucbf. Remove the corresponding code from the controller, which was in place to accurately report the centre frequency.

Closes NGC-1557