### PR TITLE
Implement schema version 4.5

### DIFF
--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -48,7 +48,7 @@ GPUCBF_JONES_PER_BATCH = 2**20
 XBGPU_MAX_SRC_DATA_RATE = 5.45e9
 #: Number of polyphase filter-bank taps for gpucbf F-engines
 PFB_TAPS = 16
-#: Multiply by subsamplingfactor to get digitiser down-conversion taps
+#: Multiply by subsampling factor to get digitiser down-conversion taps
 #: for gpucbf F-engines.
 DDC_TAPS_RATIO = 24
 #: Window function for non-VLBI antenna-channelised-voltage products

--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2013-2023, National Research Foundation (SARAO)
+# Copyright (c) 2013-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -48,9 +48,13 @@ GPUCBF_JONES_PER_BATCH = 2**20
 XBGPU_MAX_SRC_DATA_RATE = 5.45e9
 #: Number of polyphase filter-bank taps for gpucbf F-engines
 PFB_TAPS = 16
-#: Multiply by decimation factor to get digitiser down-conversion taps
+#: Multiply by subsamplingfactor to get digitiser down-conversion taps
 #: for gpucbf F-engines.
-DDC_TAPS_RATIO = 12
+DDC_TAPS_RATIO = 24
+#: Window function for non-VLBI antenna-channelised-voltage products
+WINDOW_FUNCTION = "hann"
+#: Window function for VLBI antenna-channelised-voltage products
+WINDOW_FUNCTION_VLBI = "rect"
 #: Default payload size for gpucbf data products. Bigger is better to
 #: minimise the number of packets/second to process.
 GPUCBF_PACKET_PAYLOAD_BYTES = 8192

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -500,10 +500,11 @@ def _make_fgpu(
 
         if stream.narrowband is not None:
             ddc_group_delay = -(stream.narrowband.ddc_taps - 1) / 2
-            # Complex-to-complex PFB, but katgpucbf first channelises to
-            # 2N channels then discards N of them.
-            subsampling = stream.narrowband.decimation_factor
-            pfb_group_delay = -(2 * stream.n_chans * stream.pfb_taps - 1) / 2 * subsampling
+            subsampling = stream.narrowband.subsampling
+            internal_channels = stream.n_chans
+            if stream.narrowband.vlbi is not None:
+                internal_channels *= 2
+            pfb_group_delay = -(internal_channels * stream.pfb_taps - 1) / 2 * subsampling
         else:
             ddc_group_delay = 0.0
             # Real-to-complex PFB
@@ -760,6 +761,8 @@ def _make_fgpu(
                 output_config["decimation"] = stream.narrowband.decimation_factor
                 output_config["centre_frequency"] = stream.narrowband.centre_frequency
                 output_config["ddc_taps"] = stream.narrowband.ddc_taps
+                if stream.narrowband.vlbi is not None:
+                    output_config["pass_bandwidth"] = stream.narrowband.vlbi.pass_bandwidth
                 output_arg_name = "narrowband"
             else:
                 output_arg_name = "wideband"

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -502,7 +502,7 @@ def _make_fgpu(
             ddc_group_delay = -(stream.narrowband.ddc_taps - 1) / 2
             subsampling = stream.narrowband.subsampling
             internal_channels = stream.n_chans
-            if stream.narrowband.vlbi is not None:
+            if stream.narrowband.vlbi is None:
                 internal_channels *= 2
             pfb_group_delay = -(internal_channels * stream.pfb_taps - 1) / 2 * subsampling
         else:

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -704,11 +704,6 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
             max_cf = dig_bandwidth - bandwidth / 2
             # katgpucbf quantises the centre frequency. Perform the matching
             # quantisation here so that we have the true value.
-            narrowband = copy.copy(narrowband)  # Don't modify the caller's copy
-            cf_resolution = bandwidth / 2**32
-            narrowband.centre_frequency = (
-                round(narrowband.centre_frequency / cf_resolution) * cf_resolution
-            )
             if not (min_cf <= narrowband.centre_frequency <= max_cf):
                 raise ValueError(
                     f"Narrowband centre frequency {narrowband.centre_frequency}"

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -1,5 +1,5 @@
 {% macro versions() %}
-["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "4.0", "4.1", "4.2", "4.3", "4.4"]
+["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "4.0", "4.1", "4.2", "4.3", "4.4", "4.5"]
 {% endmacro %}
 
 {% macro validate(version) %}
@@ -506,15 +506,25 @@
                                         "items": {"$ref": "#/definitions/stream_name"},
                                         "uniqueItems": true
                                     },
-                                    "w_cutoff": {"$ref": "#/definitions/nonneg_number", "default": 1.0},
+                                    "w_cutoff": {"$ref": "#/definitions/nonneg_number"},
 {% if version >= "4.4" %}
-                                    "window_function": {"$ref": "#/definitions/window_function", "default": "hann"},
+                                    "window_function": {"$ref": "#/definitions/window_function"},
                                     "taps": {"$ref": "#/definitions/positive_integer"},
 {% endif %}
 {% if version >= "3.3" %}
                                     "narrowband": {
                                         "type": "object",
                                         "properties": {
+{% if version >= "4.5" %}
+                                            "vlbi": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "pass_bandwidth": {"$ref": "#/definitions/nonneg_number"}
+                                                },
+                                                "additionalProperties": false,
+                                                "required": ["pass_bandwidth"]
+                                            },
+{% endif %}
                                             "decimation_factor": {"$ref": "#/definitions/positive_integer"},
                                             "centre_frequency": {"$ref": "#/definitions/positive_number"}
                                         },

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -540,8 +540,10 @@ class TestGpucbfAntennaChanneliseVoltageStream:
         narrowband_vlbi_config["narrowband"]["vlbi"]["pass_bandwidth"] = pass_bandwidth
         with pytest.raises(
             ValueError,
-            match=rf"pass_bandwidth \({pass_bandwidth}\) must be strictly less than "
-            rf"bandwidth \({bandwidth}\)",
+            match=re.escape(
+                f"pass_bandwidth ({pass_bandwidth}) must be strictly less than "
+                f"bandwidth ({bandwidth})"
+            ),
         ):
             GpucbfAntennaChannelisedVoltageStream.from_config(
                 Options(), "vlbi1_acv", narrowband_vlbi_config, src_streams, {}
@@ -835,7 +837,7 @@ class TestBaselineCorrelationProductsStream:
         with pytest.raises(
             ValueError,
             match=re.escape(
-                r"channels per endpoint (128) is not a multiple of channels per substream (2048)"
+                "channels per endpoint (128) is not a multiple of channels per substream (2048)"
             ),
         ):
             BaselineCorrelationProductsStream.from_config(
@@ -1158,7 +1160,7 @@ class TestVisStream:
         with pytest.raises(
             ValueError,
             match=re.escape(
-                rf"n_chans ({bcp.n_chans}) is not a multiple of required alignment ({alignment})"
+                f"n_chans ({bcp.n_chans}) is not a multiple of required alignment ({alignment})"
             ),
         ):
             VisStream.from_config(Options(), "sdp_l0", config, [bcp], {})

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -480,8 +480,7 @@ class TestGpucbfAntennaChanneliseVoltageStream:
         assert acv.band == src_streams[0].band
         assert acv.n_chans == narrowband_config["n_chans"]
         assert acv.bandwidth == src_streams[0].adc_sample_rate / 2 / 8
-        # It won't be exact because of quantisation of the narrowband centre frequency
-        assert acv.centre_frequency == pytest.approx(1056e6, abs=1e-2)
+        assert acv.centre_frequency == 1056e6
         assert acv.adc_sample_rate == src_streams[0].adc_sample_rate
         assert (
             acv.n_samples_between_spectra
@@ -631,10 +630,9 @@ class TestGpucbfAntennaChanneliseVoltageStream:
         self, narrowband_config: Dict[str, Any], src_streams: List[DigBasebandVoltageStreamBase]
     ) -> None:
         narrowband_config["narrowband"]["centre_frequency"] = 50e6
-        # The error reports the quantised centre frequency
         with pytest.raises(
             ValueError,
-            match=r"50000000.01117587 is outside the range \[53500000\.0, 802500000\.0\]",
+            match=r"50000000.0 is outside the range \[53500000\.0, 802500000\.0\]",
         ):
             GpucbfAntennaChannelisedVoltageStream.from_config(
                 Options(), "narrow1_acv", narrowband_config, src_streams, {}

--- a/test/utils.py
+++ b/test/utils.py
@@ -44,7 +44,7 @@ _T = TypeVar("_T")
 # The "gpucbf" correlator components are not connected up to any SDP components.
 # They're there just as a smoke test for generator.py.
 CONFIG = """{
-    "version": "4.3",
+    "version": "4.5",
     "outputs": {
         "gpucbf_m900v": {
             "type": "sim.dig.baseband_voltage",
@@ -218,7 +218,7 @@ CONFIG = """{
 }"""  # noqa: E501
 
 CONFIG_CBF_ONLY = """{
-    "version": "4.3",
+    "version": "4.5",
     "outputs": {
         "gpucbf_m900v": {
             "type": "sim.dig.baseband_voltage",
@@ -252,6 +252,27 @@ CONFIG_CBF_ONLY = """{
             "type": "gpucbf.antenna_channelised_voltage",
             "src_streams": ["gpucbf_m900v", "gpucbf_m900h", "gpucbf_m901v", "gpucbf_m901h"],
             "n_chans": 4096
+        },
+        "gpucbf_antenna_channelised_voltage_narrowband": {
+            "type": "gpucbf.antenna_channelised_voltage",
+            "src_streams": ["gpucbf_m900v", "gpucbf_m900h", "gpucbf_m901v", "gpucbf_m901h"],
+            "n_chans": 4096,
+            "narrowband": {
+                "decimation_factor": 8,
+                "centre_frequency": 300e6
+            }
+        },
+        "gpucbf_antenna_channelised_voltage_narrowband_vlbi": {
+            "type": "gpucbf.antenna_channelised_voltage",
+            "src_streams": ["gpucbf_m900v", "gpucbf_m900h", "gpucbf_m901v", "gpucbf_m901h"],
+            "n_chans": 4096,
+            "narrowband": {
+                "decimation_factor": 8,
+                "centre_frequency": 300e6,
+                "vlbi": {
+                    "pass_bandwidth": 64e6
+                }
+            }
         },
         "gpucbf_baseline_correlation_products": {
             "type": "gpucbf.baseline_correlation_products",


### PR DESCRIPTION
This adds the 'vlbi' attribute to 'narrowband', and passes on the
'pass_bandwidth' to katgpucbf.

Also increases the DDC_TAPS_RATIO to 24 to get better filter response.
A functional change is that the window_function will now always be
passed to katgpucbf - in practice that's harder to avoid now that the
default depends on whether 'vlbi' is specified (although it could be
done if necessary).

Closes NGC-1561.