### PR TITLE
Reduce defaults.DDC_TAPS_RATIO

### DIFF
--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -50,7 +50,7 @@ XBGPU_MAX_SRC_DATA_RATE = 5.45e9
 PFB_TAPS = 16
 #: Multiply by subsampling factor to get digitiser down-conversion taps
 #: for gpucbf F-engines.
-DDC_TAPS_RATIO = 24
+DDC_TAPS_RATIO = 16
 #: Window function for non-VLBI antenna-channelised-voltage products
 WINDOW_FUNCTION = "hann"
 #: Window function for VLBI antenna-channelised-voltage products


### PR DESCRIPTION
After investigating the filter design, it looks like it's not necessary to use so many taps. Reduce it to save some processing power.

Relates to NGC-1399