### PR TITLE
Add ?dsim-time request

### DIFF
--- a/src/katsdpcontroller/fake_servers.py
+++ b/src/katsdpcontroller/fake_servers.py
@@ -19,6 +19,7 @@
 import asyncio
 import json
 import numbers
+import time
 from typing import Dict, Optional, Tuple
 
 import numpy as np
@@ -135,6 +136,10 @@ class FakeDsimDeviceServer(FakeDeviceServer):
     async def request_signals(self, ctx, signals: str, period: Optional[int] = None) -> int:
         """Update the signals that are generated."""
         return 0
+
+    async def request_time(self, ctx) -> float:
+        """Return the current UNIX timestamp."""
+        return time.time()
 
 
 class FakeFgpuDeviceServer(FakeDeviceServer):

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -1500,6 +1500,11 @@ class SubarrayProduct:
     def _get_dsim_katcp(self, dsim: str) -> aiokatcp.Client:
         """Get the katcp client for connecting to a dsim.
 
+        Parameters
+        ----------
+        dsim
+            The task name for the dsim
+
         Raises
         ------
         FailReply

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -121,6 +121,7 @@ EXPECTED_REQUEST_LIST = [
     "capture-stop",
     "delays",
     "dsim-signals",
+    "dsim-time",
     "gain",
     "gain-all",
     "product-configure",

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -833,6 +833,18 @@ class TestControllerInterface(BaseTestController):
             await client.request("dsim-signals", "spam", "1;2;")
         await client.request("product-deconfigure")
 
+    async def test_dsim_time(self, client: aiokatcp.Client) -> None:
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        reply, _ = await client.request("dsim-time", "sim.m900.1712000000.0")
+        assert reply == [b"123456789.5"]
+        await client.request("product-deconfigure")
+
+    async def test_dsim_time_bad_dsim(self, client: aiokatcp.Client) -> None:
+        await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
+        with pytest.raises(FailReply, match="No dsim named spam"):
+            await client.request("dsim-time", "spam")
+        await client.request("product-deconfigure")
+
     async def test_input_data_suspect(self, client: aiokatcp.Client, server: DeviceServer) -> None:
         await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
         await assert_sensor_value(


### PR DESCRIPTION
This relates to NGC-1542: it allows CBF qualification tests to query the dsim for time without having a direct katcp connection.