### PR TITLE
Revive CBF-SDP integration testing

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -722,7 +722,7 @@ def _make_fgpu(
             "center_freq": stream.centre_frequency,
         }
         for key, value in telstate_data.items():
-            init_telstate[(stream.name, key)] = value
+            init_telstate[(stream.name.replace("-", "_"), key)] = value
 
     for i in range(0, n_engines):
         srcs = streams[0].sources(i)
@@ -1183,7 +1183,7 @@ def _make_xbgpu(
 
         init_telstate: Dict[Union[str, Tuple[str, ...]], Any] = g.graph["init_telstate"]
         telstate_data = {
-            "src_streams": [stream.antenna_channelised_voltage.name],
+            "src_streams": [stream.antenna_channelised_voltage.name.replace("-", "_")],
             "instrument_dev_name": "gpucbf",  # Made-up instrument name
             "bandwidth": acv.bandwidth,
             "n_chans_per_substream": stream.n_chans_per_substream,
@@ -1199,7 +1199,7 @@ def _make_xbgpu(
                 spectra_per_heap=stream.spectra_per_heap,
             )
         for key, value in telstate_data.items():
-            init_telstate[(stream.name, key)] = value
+            init_telstate[(stream.name.replace("-", "_"), key)] = value
 
     # Factor of 2 is because samples are complex
     input_rate = acv.bandwidth * len(acv.src_streams) * acv.bits_per_sample / 8 * 2

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -458,6 +458,7 @@ class DigBasebandVoltageStream(DigBasebandVoltageStreamBase):
         centre_frequency: float,
         band: str,
         antenna_name: str,
+        antenna: Optional[katpoint.Antenna] = None,
     ) -> None:
         super().__init__(
             name,
@@ -468,6 +469,7 @@ class DigBasebandVoltageStream(DigBasebandVoltageStreamBase):
             band=band,
             antenna_name=antenna_name,
         )
+        self.antenna = antenna
         self.url = url
 
     @classmethod
@@ -479,6 +481,15 @@ class DigBasebandVoltageStream(DigBasebandVoltageStreamBase):
         src_streams: Sequence[Stream],
         sensors: Mapping[str, Any],
     ) -> "DigBasebandVoltageStream":
+        # The schema says this is the antenna name, but as a testing backdoor
+        # we allow it to be a katpoint antenna description, in which case it
+        # can be populated into telstate as <name>_observer.
+        if "," in config["antenna"]:
+            antenna = katpoint.Antenna(config["antenna"])
+            antenna_name = antenna.name
+        else:
+            antenna = None
+            antenna_name = config["antenna"]
         return cls(
             name,
             src_streams,
@@ -487,7 +498,8 @@ class DigBasebandVoltageStream(DigBasebandVoltageStreamBase):
             adc_sample_rate=config["adc_sample_rate"],
             centre_frequency=config["centre_frequency"],
             band=config["band"],
-            antenna_name=config["antenna"],
+            antenna_name=antenna_name,
+            antenna=antenna,
         )
 
 

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -308,8 +308,16 @@ class TestDigBasebandVoltageStream:
         assert dig.centre_frequency == config["centre_frequency"]
         assert dig.band == config["band"]
         assert dig.antenna_name == config["antenna"]
+        assert dig.antenna is None
         assert dig.bits_per_sample == 10
         assert dig.data_rate(1.0, 0) == 1712e7
+
+    def test_from_config_description(self, config: Dict[str, Any]) -> None:
+        """Test with an antenna description instead of just a name."""
+        config["antenna"] = _M000.description
+        dig = DigBasebandVoltageStream.from_config(Options(), "m000h", config, [], {})
+        assert dig.antenna_name == "m000"
+        assert dig.antenna == _M000
 
 
 class TestSimDigBasebandVoltageStream:


### PR DESCRIPTION
Allow SDP and CBF to run in a single subarray product while using real antennas (or antennas produced by external dsims). The main challenge is that ingest requires mXXX_observer telstate entries to determine the lengths of baselines, and the antenna positions would not normally be available in such a configuration. Allow it to be smuggled in by providing antenna descriptions instead of just names in dig.baseband_voltage streams.

Relates to NGC-1551.