### PR TITLE
Do DNS resolution on Mesos offers

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -188,7 +188,11 @@ class PhysicalMulticast(scheduler.PhysicalExternal):
         else:
             self.host = await resolver.resources.get_multicast_groups(self.logical_node.n_addresses)
             self.ports = {"spead": await resolver.resources.get_port()}
-        self._endpoint_sensor.value = str(Endpoint(self.host, self.ports["spead"]))
+        # It should already be resolved. Note that it might NOT be a valid
+        # IP address if it represents multiple multicast groups in the form
+        # a.b.c.d+N.
+        self.address = self.host
+        self._endpoint_sensor.value = str(Endpoint(self.address, self.ports["spead"]))
 
 
 class TelstateTask(ProductPhysicalTask):

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -961,6 +961,7 @@ class DummyScheduler:
                     assert isinstance(node, scheduler.PhysicalTask)
                     node.allocation = mock.MagicMock()
                     node.allocation.agent.host = "host." + node.logical_node.name
+                    node.allocation.agent.address = "1.2.3.4"
                     node.allocation.agent.agent_id = "agent-id." + node.logical_node.name
                     node.allocation.agent.gpus[0].name = "GeForce GTX TITAN X"
                     for request in node.logical_node.interfaces:

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -2123,7 +2123,8 @@ class TestScheduler:
         launch, kill = await fix.transition_node0(TaskState.STARTING)
         offers = fix.make_offers()
         fix.sched.resourceOffers(fix.driver, offers)
-        await asyncio.sleep(6)  # Give it a chance to try multiple times
+        # Allow 5 retries at one second intervals
+        await asyncio.sleep(6)
         assert fix.sched._resolving_offers == {}  # Must clean up the tasks
         assert fix.nodes[0].state == TaskState.STARTING  # Must not start
         assert await fix.driver_calls() == [
@@ -2133,7 +2134,7 @@ class TestScheduler:
         launch.cancel()
 
     async def test_decline_unresolved_offers(self, fix: "TestScheduler.Fixture", mocker) -> None:
-        """Test that when an unresolved offer is no longer needed, it is declined and removed."""
+        """Test that when unresolved offers are no longer needed they are declined and removed."""
         mocker.patch.object(
             asyncio.get_running_loop(), "getaddrinfo", side_effect=getaddrinfo_never
         )


### PR DESCRIPTION
Resolve hostnames to IP addresses when offers are received, and do not use an offer until we have the IP address. This address can then be used in various other places that were doing their own DNS resolution.

This eliminates a number of failure modes. In particular, the endpoint sensors are now guaranteed to be nominal.

Closes NGC-1531.