### PR TITLE
Allow mirroring of sensors to the master controller be disabled

### DIFF
--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -437,6 +437,7 @@ class ProductManagerBase(Generic[_P]):
     def _update_products_sensor(self) -> None:
         self._server.sensors["products"].value = json.dumps(sorted(self._products.keys()))
         self._update_device_status()
+        self._server.mass_inform("interface-changed", "sensor-list")
 
     def _add_product(self, product: _P) -> None:
         """Used by subclasses to add a newly-created product."""

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -185,11 +185,16 @@ class Product:
         hostname: str,
         host: _IPAddress,
         ports: Dict[str, int],
-    ) -> None:
+    ) -> bool:
         """Notify product of the location of the katcp interface.
 
         After calling this, :attr:`host`, :attr:`hostname`, :attr:`ports` and :attr:`katcp_conn`
         are all ready to use.
+
+        Returns
+        -------
+        mirror_sensors
+            Whether the connection is mirroring sensors to the `server`.
         """
         self.hostname = hostname
         self.host = host
@@ -202,17 +207,20 @@ class Product:
             except KeyError:
                 self.logger.warning("Sensor %s does not exist", sensor_name)
         self.katcp_conn = aiokatcp.Client(str(host), ports["katcp"])
-        self.katcp_conn.add_sensor_watcher(
-            sensor_proxy.SensorWatcher(
-                self.katcp_conn,
-                server,
-                f"{self.name}.",
-                rewrite_gui_urls=rewrite_gui_urls,
-                enum_types=(DeviceStatus,),
+        mirror_sensors = bool(self.config.get("config", {}).get("mirror_sensors", True))
+        if mirror_sensors:
+            self.katcp_conn.add_sensor_watcher(
+                sensor_proxy.SensorWatcher(
+                    self.katcp_conn,
+                    server,
+                    f"{self.name}.",
+                    rewrite_gui_urls=rewrite_gui_urls,
+                    enum_types=(DeviceStatus,),
+                )
             )
-        )
         self.katcp_conn.add_inform_callback("disconnect", self._disconnect_callback)
         # TODO: start a watchdog
+        return mirror_sensors
 
     def _disconnect_callback(self, *args: bytes) -> None:
         """Called when the remote katcp server tells us it is shutting down.
@@ -529,9 +537,12 @@ class ProductManagerBase(Generic[_P]):
         `ports` must contain at least ``katcp``, but subclasses may include
         additional ports.
         """
-        product.connect(self._server, self._rewrite_gui_urls, hostname, host, ports)
+        mirror_sensors = product.connect(
+            self._server, self._rewrite_gui_urls, hostname, host, ports
+        )
         assert product.katcp_conn is not None
-        product.katcp_conn.add_sensor_watcher(DeviceStatusWatcher(self._update_device_status))
+        if mirror_sensors:
+            product.katcp_conn.add_sensor_watcher(DeviceStatusWatcher(self._update_device_status))
 
     async def get_capture_block_id(self) -> str:
         """Generate a unique capture block ID"""
@@ -1205,7 +1216,8 @@ class DeviceServer(aiokatcp.DeviceServer):
             Sensor(
                 DeviceStatus,
                 "device-status",
-                "Combined (worst) status of all subarray product controllers",
+                "Combined (worst) status of all subarray product controllers, "
+                "excluding those with mirror_sensors=False",
                 default=DeviceStatus.OK,
                 status_func=device_status_to_sensor_status,
             )

--- a/src/katsdpcontroller/schemas/product_config.json.j2
+++ b/src/katsdpcontroller/schemas/product_config.json.j2
@@ -1,5 +1,5 @@
 {% macro versions() %}
-["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "4.0", "4.1", "4.2", "4.3", "4.4", "4.5"]
+["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "4.0", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6"]
 {% endmacro %}
 
 {% macro validate(version) %}
@@ -624,6 +624,9 @@
 {% endif %}
 {% if version >= "4.1" %}
                 "shutdown_delay": {"$ref": "#/definitions/nonneg_number"},
+{% endif %}
+{% if version >= "4.6" %}
+                "mirror_sensors": {"type": "boolean", "default": true},
 {% endif %}
                 "service_overrides": {
                     "type": "object",

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -1537,7 +1537,7 @@ class TestSpectralImageStream:
 @pytest.fixture
 def config() -> Dict[str, Any]:
     return {
-        "version": "4.5",
+        "version": "4.6",
         "inputs": {
             "camdata": {"type": "cam.http", "url": "http://10.8.67.235/api/client/1"},
             "i0_antenna_channelised_voltage": {
@@ -1616,7 +1616,9 @@ def config() -> Dict[str, Any]:
                 "min_time": 3600.0,
             },
         },
-        "config": {},
+        "config": {
+            "mirror_sensors": False,
+        },
     }
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -44,7 +44,7 @@ _T = TypeVar("_T")
 # The "gpucbf" correlator components are not connected up to any SDP components.
 # They're there just as a smoke test for generator.py.
 CONFIG = """{
-    "version": "4.5",
+    "version": "4.6",
     "outputs": {
         "gpucbf_m900v": {
             "type": "sim.dig.baseband_voltage",
@@ -218,7 +218,7 @@ CONFIG = """{
 }"""  # noqa: E501
 
 CONFIG_CBF_ONLY = """{
-    "version": "4.5",
+    "version": "4.6",
     "outputs": {
         "gpucbf_m900v": {
             "type": "sim.dig.baseband_voltage",


### PR DESCRIPTION
Changes to the product-configure schema are proposed edits in https://docs.google.com/document/d/15ZIyuBf4Vk4ESIEdKsQxdSBoLEwh85eyKeDJouLRAZY/edit?pli=1&tab=t.0#heading=h.v512w2fvji5f.

A side effect in the original case is that now product-configure will typically issue three `#interface-changed` mass informs instead of two:
1. Immediately in response to the request, which notified consumers that the `<product>.host` and `<product>.katcp-address` sensors have been added (with the address of the product controller).
2. After connecting to the product controller, and querying the sensors that it has so far.
3. After the product is fully configured.

The first is new, while the previous two already existed. When mirror_sensors is false, only the first one will be issued, because no sensors are proxied from the subarray product. I think this reasonable to add, since otherwise the `.host` and `.katcp-address` sensors might not get recorded if there was an issue connecting to the subarray product.

Similarly, there may be an additional `#interface-changed` mass inform when tearing down the array.