### PR TITLE
Fix TimeoutError

### DIFF
--- a/scripts/sdp_product_controller.py
+++ b/scripts/sdp_product_controller.py
@@ -20,6 +20,7 @@
 
 import argparse
 import asyncio
+import concurrent.futures
 import json
 import logging
 import os
@@ -210,6 +211,10 @@ def main() -> None:
     framework_info.capabilities = [{"type": "MULTI_ROLE"}, {"type": "TASK_KILLING_STATE"}]
 
     loop = asyncio.get_event_loop()
+    # The default executor is used for DNS lookups, which are I/O-bound.
+    # We would like to use lots of threads for this to parallelise the
+    # lookups.
+    loop.set_default_executor(concurrent.futures.ThreadPoolExecutor(max_workers=100))
     sched = scheduler.Scheduler(
         args.realtime_role,
         args.host,

--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -73,3 +73,10 @@ SHUTDOWN_DELAY = 10.0
 #: some sensors are large strings and a batch of sensor updates could
 #: temporarily cause a large backlog.
 CONNECTION_MAX_BACKLOG = 256 * 1024 * 1024
+#: Seconds to wait for DNS resolution. The DNS server should be local and
+#: hence fast.
+DNS_TIMEOUT = 0.1
+#: Seconds to wait between attempts to contact the DNS server.
+DNS_RETRY_TIME = 0.5
+#: Number of attempts to make at DNS resolution
+DNS_ATTEMPTS = 5

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -3996,7 +3996,12 @@ class Scheduler(SchedulerBase, pymesos.Scheduler):
         if offer_id.value in self._resolving_offers:
             resolving_offer = self._resolving_offers.pop(offer_id.value)
             resolving_offer.rescinded.add(offer_id.value)
-            resolving_offer.task.cancel()
+            # Note: we can't cancel the whole _resolving_offer task, because
+            # it may involve other offers that haven't been rescinded. We
+            # could track the individual tasks doing the per-offer resolution,
+            # but that would add complexity, and those tasks have bounded
+            # lifetimes anyway due to timeouts, so it's not critical to
+            # cancel them.
             return  # No point checking self._offers if we haven't resolved it yet
         # TODO: this is not very efficient. A secondary lookup from offer id to
         # the relevant offer info would speed it up.

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -3841,8 +3841,8 @@ class Scheduler(SchedulerBase, pymesos.Scheduler):
     async def _resolve_offers(self, offers):
         """Resolve the hostnames of offers to IP address and record the offers.
 
-        Note that each offers is modified *in place* to create an `address`
-        element.
+        Note that each offer in offers is modified *in place* to create an
+        `address` element.
         """
 
         async def resolve_offer(offer):

--- a/src/katsdpcontroller/scheduler.py
+++ b/src/katsdpcontroller/scheduler.py
@@ -3148,6 +3148,15 @@ class SchedulerBase:
             else:
                 try:
                     # At this point we have a sufficient set of offers.
+                    if group.resources_future.cancelled():
+                        # We can get here only with a race condition where:
+                        # 1. wait_for (in launch) timed out and cancelled
+                        #    resources_futures.
+                        # 2. We get here.
+                        # 3. wait_for returns control, and the group is
+                        #    removed from the queue.
+                        logger.debug("Group had resources to launch but timed out")
+                        continue
                     group.last_insufficient = None
                     if not group.resources_future.done():
                         group.resources_future.set_result(None)

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -66,6 +66,16 @@ async def getaddrinfo_never(*args, **kwargs):
     await asyncio.Future()
 
 
+async def getaddrinfo_one(host, port, *args, **kwargs):
+    """Return immediately for lookup of agenthost0, otherwise block forever.
+
+    This is intended to be used as a getaddrinfo mock implementation.
+    """
+    if host == "agenthost0":
+        return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("192.0.2.0", port))]
+    return await asyncio.Future()
+
+
 async def getaddrinfo_fail(*args, **kwargs):
     """Raise socket.gaierror.
 
@@ -2117,6 +2127,21 @@ class TestScheduler:
         assert await fix.driver_calls() == []
         launch.cancel()
 
+    async def test_resolved_offer_rescinded(self, fix: "TestScheduler.Fixture", mocker) -> None:
+        """Test offerRescinded for an offer that has been resolved but whose batch has not."""
+        mocker.patch.object(asyncio.get_running_loop(), "getaddrinfo", side_effect=getaddrinfo_one)
+        launch, kill = await fix.transition_node0(TaskState.STARTING)
+        offers = fix.make_offers()
+        fix.sched.resourceOffers(fix.driver, offers)
+        await exhaust_callbacks()
+        assert len(fix.sched._resolving_offers) == 2
+        assert fix.nodes[0].state == TaskState.STARTING
+        fix.sched.offerRescinded(fix.driver, offers[0].id)
+        await exhaust_callbacks()
+        assert fix.sched._resolving_offers == {}
+        assert await fix.driver_calls() == [mock.call.declineOffer([offers[1].id])]
+        launch.cancel()
+
     async def test_offer_resolve_fail(self, fix: "TestScheduler.Fixture", mocker) -> None:
         """Test receiving an offer that cannot be resolved with getaddrinfo."""
         mocker.patch.object(asyncio.get_running_loop(), "getaddrinfo", side_effect=getaddrinfo_fail)
@@ -2128,8 +2153,7 @@ class TestScheduler:
         assert fix.sched._resolving_offers == {}  # Must clean up the tasks
         assert fix.nodes[0].state == TaskState.STARTING  # Must not start
         assert await fix.driver_calls() == [
-            mock.call.declineOffer([offers[0].id]),
-            mock.call.declineOffer([offers[1].id]),
+            mock.call.declineOffer([offers[0].id, offers[1].id]),
         ]
         launch.cancel()
 
@@ -2147,8 +2171,22 @@ class TestScheduler:
         assert len(fix.sched._resolving_offers) == 0
         assert await fix.driver_calls() == [
             mock.call.suppressOffers({"default"}),
-            mock.call.declineOffer([offers[0].id]),
-            mock.call.declineOffer([offers[1].id]),
+            mock.call.declineOffer([offers[0].id, offers[1].id]),
+        ]
+
+    async def test_decline_resolved_offers(self, fix: "TestScheduler.Fixture", mocker) -> None:
+        """Test declining of resolved offers from an unresolved batch."""
+        mocker.patch.object(asyncio.get_running_loop(), "getaddrinfo", side_effect=getaddrinfo_one)
+        launch, kill = await fix.transition_node0(TaskState.STARTING)
+        offers = fix.make_offers()
+        fix.sched.resourceOffers(fix.driver, offers)
+        await exhaust_callbacks()
+        launch.cancel()
+        await exhaust_callbacks()
+        assert len(fix.sched._resolving_offers) == 0
+        assert await fix.driver_calls() == [
+            mock.call.suppressOffers({"default"}),
+            mock.call.declineOffer([offers[0].id, offers[1].id]),
         ]
 
     async def test_decline_unneeded_offers(self, fix: "TestScheduler.Fixture") -> None:


### PR DESCRIPTION
Fixes NGC-1678. There are two parts to this:

1. Fix a race condition that led to a cryptic TimeoutError under some circumstances with insufficient resources, instead of a more useful diagnosis of why the resources were insufficient.
2. Perform DNS resolution on a batch of offers as a batch and only pass the results to the main offer pool once the whole batch has been resolved (or has failed to resolve). To make this robust and avoid holding up good DNS results if one offer is failing, add a timeout to DNS resolution, and reduce the time between attempts. This avoids repeatedly trying to launch on a subset of offers as DNS results dribble in, which is both slow and risks suboptimal placement.

The batch of offers is split up by role, because we may need to cancel offers for a specific role but don't want to cancel the rest of the batch at the same time.