### PR TITLE
Handle consul timeouts better

### DIFF
--- a/src/katsdpcontroller/consul.py
+++ b/src/katsdpcontroller/consul.py
@@ -28,10 +28,10 @@ from .defaults import LOCALHOST
 
 CONSUL_PORT = 8500
 CONSUL_URL = yarl.URL.build(scheme="http", host=LOCALHOST, port=CONSUL_PORT)
-# Usually needs must less than this, but registering a service requires
+# Usually needs much less than this, but registering a service requires
 # storing the record on disk in the consul catalogue, and things like VM
 # backups can make that unusually slow.
-CONSUL_TIMEOUT = 20
+CONSUL_TIMEOUT = 15
 logger = logging.getLogger(__name__)
 
 

--- a/test/test_consul.py
+++ b/test/test_consul.py
@@ -46,6 +46,11 @@ class TestConsulService:
         service = await ConsulService.register(self.service_data)
         assert service.service_id is None
 
+    async def test_register_timeout(self, m) -> None:
+        m.put(self.register_url, timeout=True)
+        service = await ConsulService.register(self.service_data)
+        assert service.service_id is None
+
     async def test_register_success(self, m) -> None:
         m.put(self.register_url)
         service = await ConsulService.register(self.service_data)
@@ -66,6 +71,13 @@ class TestConsulService:
         service_id = "test-id"
         service = ConsulService(service_id)
         m.put(CONSUL_URL / f"v1/agent/service/deregister/{service_id}", status=500)
+        assert not await service.deregister()
+        assert service.service_id == service_id
+
+    async def test_deregister_timeout(self, m) -> None:
+        service_id = "test-id"
+        service = ConsulService(service_id)
+        m.put(CONSUL_URL / f"v1/agent/service/deregister/{service_id}", timeout=True)
         assert not await service.deregister()
         assert service.service_id == service_id
 


### PR DESCRIPTION
- Catch, log and ignore the exception (so that the subarray product
  continues), as for connection errors.
- Increase the timeout from 5 to 15s to make timing out less likely even
  if the consul master is undergoing a backup.

Closes NGC-1674.