### PR TITLE
Add dither-seed sensors for MK+ CBF

### DIFF
--- a/src/katsdpcontroller/fake_servers.py
+++ b/src/katsdpcontroller/fake_servers.py
@@ -164,6 +164,8 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
                     str,
                     f"{output}.dither-seed",
                     "Random seed used in dithering for quantisation",
+                    # This is the largest value that katgpucbf can return,
+                    # which is also the most likely to break something.
                     default=f"{2**64 - 1}",
                     initial_status=Sensor.Status.NOMINAL,
                 )
@@ -339,6 +341,8 @@ class FakeXbgpuDeviceServer(FakeDeviceServer):
                     str,
                     f"{beam_name}.dither-seed",
                     "Random seed used in dithering for quantisation",
+                    # This is the largest value that katgpucbf can return,
+                    # which is also the most likely to break something.
                     default=f"{2**64 - 1}",
                     initial_status=Sensor.Status.NOMINAL,
                 )

--- a/src/katsdpcontroller/fake_servers.py
+++ b/src/katsdpcontroller/fake_servers.py
@@ -157,8 +157,18 @@ class FakeFgpuDeviceServer(FakeDeviceServer):
             output: [np.full((1,), self.DEFAULT_GAIN, np.complex64) for _ in range(self.N_POLS)]
             for output in self._output_names
         }
-        for pol in range(self.N_POLS):
-            for output in self._output_names:
+
+        for output in self._output_names:
+            self.sensors.add(
+                Sensor(
+                    str,
+                    f"{output}.dither-seed",
+                    "Random seed used in dithering for quantisation",
+                    default=f"{2**64 - 1}",
+                    initial_status=Sensor.Status.NOMINAL,
+                )
+            )
+            for pol in range(self.N_POLS):
                 self.sensors.add(
                     Sensor(
                         str,
@@ -321,6 +331,15 @@ class FakeXbgpuDeviceServer(FakeDeviceServer):
                     f"{beam_name}.chan-range",
                     "The range of channels processed by this B-engine, inclusive",
                     default=f"({channel_offset},{channel_offset + channels_per_substream - 1})",
+                    initial_status=Sensor.Status.NOMINAL,
+                )
+            )
+            self.sensors.add(
+                Sensor(
+                    str,
+                    f"{beam_name}.dither-seed",
+                    "Random seed used in dithering for quantisation",
+                    default=f"{2**64 - 1}",
                     initial_status=Sensor.Status.NOMINAL,
                 )
             )

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -916,6 +916,15 @@ def _make_fgpu(
                     fgpu.sensor_renames[
                         f"{stream.name}.input{j}.{name}"
                     ] = f"{stream.name}.{label}.{name}"
+                for name in [
+                    "dither-seed",
+                ]:
+                    # These engine-level sensors get replicated as well, but are not per-input
+                    orig_sensor_name = f"{stream.name}.{name}"
+                    renames = fgpu.sensor_renames.get(orig_sensor_name, [])
+                    renames.append(f"{stream.name}.{label}.{name}")
+                    fgpu.sensor_renames[orig_sensor_name] = renames
+
         # Prepare expected data rates etc
         fgpu.static_gauges["fgpu_expected_input_heaps_per_second"] = sum(
             src.adc_sample_rate / src.samples_per_heap for src in srcs
@@ -1464,6 +1473,7 @@ def _make_xbgpu(
                     "weight",
                     "beng-clip-cnt",
                     "tx.next-timestamp",
+                    "dither-seed",
                 ]
             for name in renames:
                 xbgpu.sensor_renames[f"{stream.name}.{name}"] = f"{stream.name}.{i}.{name}"

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -916,14 +916,14 @@ def _make_fgpu(
                     fgpu.sensor_renames[
                         f"{stream.name}.input{j}.{name}"
                     ] = f"{stream.name}.{label}.{name}"
-                for name in [
-                    "dither-seed",
-                ]:
-                    # These engine-level sensors get replicated as well, but are not per-input
-                    orig_sensor_name = f"{stream.name}.{name}"
-                    renames = fgpu.sensor_renames.get(orig_sensor_name, [])
-                    renames.append(f"{stream.name}.{label}.{name}")
-                    fgpu.sensor_renames[orig_sensor_name] = renames
+        for stream in streams:
+            for name in [
+                "dither-seed",
+            ]:
+                # These engine-level sensors get replicated as well, but are not per-input
+                fgpu.sensor_renames[f"{stream.name}.{name}"] = [
+                    f"{stream.name}.{label}.{name}" for label in input_labels
+                ]
 
         # Prepare expected data rates etc
         fgpu.static_gauges["fgpu_expected_input_heaps_per_second"] = sum(


### PR DESCRIPTION
This involved:
* Adding sensor-renames to generator.py, and
* Updating the corresponding fake servers.

The logic may seem odd in `generator.py::_make_fgpu`, but I decided to use the 
existing for-loops rather than re-spin the nesting for the `dither-seed` rename.

Contributes to: NGC-1418.