### PR TITLE
Disable filebeat collection of container logs

### DIFF
--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -807,6 +807,8 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
             Singularity deploy ID
         """
         request_id = self._request_id_prefix + product_name
+        # Prevent logspout from collecting logs, because the product controller
+        # sends logs using GELF.
         environ = {"LOGSPOUT": "ignore"}
         for key in ["KATSDP_LOG_ONELINE", "KATSDP_LOG_LEVEL", "KATSDP_LOG_GELF_ADDRESS"]:
             if key in os.environ:
@@ -820,6 +822,7 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
         labels = {
             "za.ac.kat.sdp.katsdpcontroller.task": "product_controller",
             "za.ac.kat.sdp.katsdpcontroller.subarray_product_id": product_name,
+            "co.elastic.logs/enabled": "false",  # Prevent filebeat from collecting logs
         }
         docker_parameters = [
             {"key": "label", "value": f"{key}={value}"} for (key, value) in labels.items()

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -780,12 +780,6 @@ class ProductPhysicalTask(ConfigMixin, ProductPhysicalTaskMixin, scheduler.Physi
         }
         if self.capture_block_id is not None:
             labels["capture_block_id"] = self.capture_block_id
-        self.taskinfo.container.docker.setdefault("parameters", []).extend(
-            [
-                {"key": "label", "value": f"za.ac.kat.sdp.katsdpcontroller.{key}={value}"}
-                for (key, value) in labels.items()
-            ]
-        )
 
         # Set extra fields for katsdpservices-using services to log to logstash
         if self.logical_node.katsdpservices_logging and "KATSDP_LOG_GELF_ADDRESS" in os.environ:
@@ -803,6 +797,14 @@ class ProductPhysicalTask(ConfigMixin, ProductPhysicalTaskMixin, scheduler.Physi
             self.taskinfo.command.environment.setdefault("variables", []).extend(
                 [{"name": key, "value": value} for (key, value) in env.items()]
             )
+            labels["co.elastic.logs/enabled"] = "false"
+
+        self.taskinfo.container.docker.setdefault("parameters", []).extend(
+            [
+                {"key": "label", "value": f"za.ac.kat.sdp.katsdpcontroller.{key}={value}"}
+                for (key, value) in labels.items()
+            ]
+        )
 
         # Apply overrides to taskinfo given by the user
         overrides = resolver.service_overrides.get(

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -780,6 +780,9 @@ class ProductPhysicalTask(ConfigMixin, ProductPhysicalTaskMixin, scheduler.Physi
         }
         if self.capture_block_id is not None:
             labels["capture_block_id"] = self.capture_block_id
+        docker_labels = {
+            f"za.ac.kat.sdp.katsdpcontroller.{key}": value for key, value in labels.items()
+        }
 
         # Set extra fields for katsdpservices-using services to log to logstash
         if self.logical_node.katsdpservices_logging and "KATSDP_LOG_GELF_ADDRESS" in os.environ:
@@ -797,13 +800,10 @@ class ProductPhysicalTask(ConfigMixin, ProductPhysicalTaskMixin, scheduler.Physi
             self.taskinfo.command.environment.setdefault("variables", []).extend(
                 [{"name": key, "value": value} for (key, value) in env.items()]
             )
-            labels["co.elastic.logs/enabled"] = "false"
+            docker_labels["co.elastic.logs/enabled"] = "false"
 
         self.taskinfo.container.docker.setdefault("parameters", []).extend(
-            [
-                {"key": "label", "value": f"za.ac.kat.sdp.katsdpcontroller.{key}={value}"}
-                for (key, value) in labels.items()
-            ]
+            [{"key": "label", "value": f"{key}={value}"} for (key, value) in docker_labels.items()]
         )
 
         # Apply overrides to taskinfo given by the user


### PR DESCRIPTION
This mirrors the logic for preventing logspout from collecting logs (because they're already sent using GELF), but using the mechanism supported by filebeat:
https://www.elastic.co/docs/reference/beats/filebeat/configuration-autodiscover-hints

Relates to NGC-908.