### PR TITLE
Add static Prometheus gauges for vgpu_expected_*

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1787,6 +1787,11 @@ def _make_vgpu(
                     f"{pol}{channel}.{perthread_name}"
                 ] = f"{stream.name}.{pol}{channel}.{perthread_name}"
 
+    vgpu.static_gauges["vgpu_expected_input_heaps_per_second"] = sum(
+        s.n_substreams / s.int_time for s in tacv
+    )
+    vgpu.static_gauges["vgpu_expected_engines"] = 1.0
+
     _add_task_sensors(g, [stream], [vgpu.name])
 
     return vgpu

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -103,6 +103,10 @@ STATIC_GAUGES = [
         "Number of heaps that should be received per second",
     ),
     Gauge("xbgpu_expected_engines", "Number of XB-engines that should be present"),
+    Gauge(
+        "vgpu_expected_input_heaps_per_second", "Number of heaps that should be received per second"
+    ),
+    Gauge("vgpu_expected_engines", "Number of V-engines that should be present"),
 ]
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This will allow the expected rate to be plotted on a Grafana dashboard (NGC-1924).