### PR TITLE
Make ?product-configure log exceptions

### DIFF
--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -1608,7 +1608,7 @@ class DeviceServer(aiokatcp.DeviceServer):
         except Exception as exc:
             logger.error(
                 f"Failed to configure product {name}: {exc}",
-                exc_info=exc,
+                exc_info=True,
                 extra=dict(subarray_product_id=name),
             )
             raise FailReply(f"Failed to configure product {name}: {exc}") from exc

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -1608,7 +1608,7 @@ class DeviceServer(aiokatcp.DeviceServer):
         except Exception as exc:
             logger.error(
                 f"Failed to configure product {name}: {exc}",
-                exc_info=True,
+                exc_info=exc,
                 extra=dict(subarray_product_id=name),
             )
             raise FailReply(f"Failed to configure product {name}: {exc}") from exc

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -1603,7 +1603,15 @@ class DeviceServer(aiokatcp.DeviceServer):
             config_dict = load_json_dict(config)
         except ValueError as exc:
             raise FailReply(f"Config is not valid JSON: {exc}") from None
-        product = await self.product_configure(name, config_dict)
+        try:
+            product = await self.product_configure(name, config_dict)
+        except Exception as exc:
+            logger.error(
+                f"Failed to configure product {name}: {exc}",
+                exc_info=True,
+                extra=dict(subarray_product_id=name),
+            )
+            raise FailReply(f"Failed to configure product {name}: {exc}") from exc
         assert product.host is not None and product.ports
         return product.name, str(product.host), product.ports["katcp"]
 

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -1606,12 +1606,13 @@ class DeviceServer(aiokatcp.DeviceServer):
         try:
             product = await self.product_configure(name, config_dict)
         except Exception as exc:
-            logger.error(
-                f"Failed to configure product {name}: {exc}",
-                exc_info=True,
+            logger.exception(
+                "Failed to configure product %s: %s",
+                name,
+                exc,
                 extra=dict(subarray_product_id=name),
             )
-            raise FailReply(f"Failed to configure product {name}: {exc}") from exc
+            raise
         assert product.host is not None and product.ports
         return product.name, str(product.host), product.ports["katcp"]
 


### PR DESCRIPTION
This was specifically intended to capture the "Failed to configure within _timeout_ ",
but it will catch anything within `product_configure`.

I manually built an image with a reduced timeout of 10s to obtain the screenshot below.
- http://cbf-mc.cbf.mkat.karoo.kat.ac.za:5601/app/logtrail#/?q=*&h=All&t=15:30:20&i=logstash-*&_g=()
<img width="1810" height="665" alt="image" src="https://github.com/user-attachments/assets/11c33ba9-640a-442a-93f3-0a47329c0995" />

Apologies for the untidy commit history...
- I realised I didn't need to explicitly pass the exception to the logger.error call

Resolves: NGC-1892.