### PR TITLE
Copy telstate address into postprocess telstate node

### DIFF
--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -933,6 +933,7 @@ class SubarrayProduct:
             nodes = {node.logical_node.name: node for node in physical_graph}
             telstate_node = nodes["telstate"]
             telstate_node.host = self.telstate_node.host
+            telstate_node.address = self.telstate_node.address
             telstate_node.ports = dict(self.telstate_node.ports)
             # This doesn't actually run anything, just marks the fake telstate node
             # as READY. It could block for a while behind real tasks in the batch


### PR DESCRIPTION
Fix continuum postprocessing in `katsdpcontroller` by copying the realtime telstate node's `address` onto the postprocess telstate external node.

The postprocess graph reuses telstate by creating a fake external node and copying over connection details from the realtime telstate task. It was copying `host` and `ports`, but not `address`. Batch endpoint resolution later expects `address`, and this left the telstate endpoint host as `None`, causing postprocessing task launch to fail while formatting task arguments.