### PR TITLE
Fix some warnings from 'docker build'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 
 ARG KATSDPDOCKERBASE_REGISTRY=quay.io/ska-sa
 
-FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-build as build
+FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-build AS build
 
 # Switch to Python 3 environment
 ENV PATH="$PATH_PYTHON3" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON3"
@@ -40,12 +40,12 @@ LABEL maintainer="sdpdev+katsdpcontroller@ska.ac.za"
 # Label the image with a list of images it uses
 ARG dependencies
 RUN test -n "$dependencies" || (echo "Please build with scripts/docker_build.sh" 1>&2; exit 1)
-LABEL za.ac.kat.sdp.image-depends $dependencies
+LABEL za.ac.kat.sdp.image-depends=$dependencies
 
 # Label the image with a list of supported product-configure schema versions
 ARG product_configure_versions
 RUN test -n "$product_configure_versions" || (echo "Please build with scripts/docker_build.sh" 1>&2; exit 1)
-LABEL za.ac.kat.sdp.katsdpcontroller.product-configure-versions $product_configure_versions
+LABEL za.ac.kat.sdp.katsdpcontroller.product-configure-versions=$product_configure_versions
 
 # Install haproxy for --haproxy support and graphviz for --write-graphs
 USER root


### PR DESCRIPTION
This fixes the following warnings:
```
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 19)
 - LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 43)
 - LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 48)
```