### PR TITLE
Allow for per-output send-enabled in xbgpu

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1438,10 +1438,26 @@ def _make_xbgpu(
                     "name": escape_format(stream.name),
                     "dst": f"{{endpoints_vector[multicast.{stream.name}_spead][{i}]}}",
                     "pol": stream.src_pol,
-                    "send_enabled": _has_downstream_dependencies(
-                        stream, vgpu_streams, check_by_name=True
-                    ),
                 }
+                if _has_downstream_dependencies(stream, vgpu_streams, check_by_name=True):
+                    output_config["send_enabled"] = True
+                    gpucbf_tacv_dst_mcast = list(
+                        filter(
+                            lambda dst_mcast: dst_mcast.name == f"multicast.{stream.name}",
+                            dst_multicasts,
+                        )
+                    )
+                    if len(gpucbf_tacv_dst_mcast) == 1:
+                        gpucbf_tacv_dst_mcast[0].initial_transmit_state = TransmitState.UP
+                    else:
+                        # Found more than one or none, which is unexpected
+                        raise ValueError(
+                            f"Expected exactly one multicast for stream {stream.name}, "
+                            "found {len(gpucbf_tacv_dst_mcast)}"
+                        )
+                else:
+                    output_config["send_enabled"] = False
+
                 if stream.dither is not None:
                     output_config["dither"] = stream.dither
                 xbgpu.command += [

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -963,6 +963,22 @@ def _make_fgpu(
     return fgpu_group
 
 
+def _has_downstream_dependencies(
+    src_stream: product_config.Stream,
+    dst_streams: Sequence[product_config.Stream],
+    check_by_name: bool = False,
+) -> bool:
+    """Check if `src_stream` is used by any of the `dst_streams`."""
+    for dst_stream in dst_streams:
+        if check_by_name:
+            if src_stream.name in [stream.name for stream in dst_stream.src_streams]:
+                return True
+        else:
+            if src_stream in dst_stream.src_streams:
+                return True
+    return False
+
+
 def _make_xbgpu(
     g: networkx.MultiDiGraph,
     configuration: Configuration,
@@ -1284,6 +1300,8 @@ def _make_xbgpu(
     recv_buffer = free_chunks * chunk_size
 
     task_names = []
+    # Needed for send_enabled command-line arg for beam data streams
+    vgpu_streams = configuration.by_class(product_config.GpucbfTiedArrayResampledVoltageStream)
     for i in range(n_engines):
         # One engine per section of the band
         xbgpu = ProductLogicalTask(f"xb.{base_name}.{i}", streams=streams, index=i)
@@ -1420,6 +1438,9 @@ def _make_xbgpu(
                     "name": escape_format(stream.name),
                     "dst": f"{{endpoints_vector[multicast.{stream.name}_spead][{i}]}}",
                     "pol": stream.src_pol,
+                    "send_enabled": _has_downstream_dependencies(
+                        stream, vgpu_streams, check_by_name=True
+                    ),
                 }
                 if stream.dither is not None:
                     output_config["dither"] = stream.dither

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -966,16 +966,11 @@ def _make_fgpu(
 def _has_downstream_dependencies(
     src_stream: product_config.Stream,
     dst_streams: Sequence[product_config.Stream],
-    check_by_name: bool = False,
 ) -> bool:
     """Check if `src_stream` is used by any of the `dst_streams`."""
     for dst_stream in dst_streams:
-        if check_by_name:
-            if src_stream.name in [stream.name for stream in dst_stream.src_streams]:
-                return True
-        else:
-            if src_stream in dst_stream.src_streams:
-                return True
+        if src_stream in dst_stream.src_streams:
+            return True
     return False
 
 
@@ -1422,7 +1417,7 @@ def _make_xbgpu(
             ]
         )
 
-        for stream in streams:
+        for stream, dst_multicast in zip(streams, dst_multicasts):
             if isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
                 output_config = {
                     "name": escape_format(stream.name),
@@ -1439,24 +1434,12 @@ def _make_xbgpu(
                     "dst": f"{{endpoints_vector[multicast.{stream.name}_spead][{i}]}}",
                     "pol": stream.src_pol,
                 }
-                if _has_downstream_dependencies(stream, vgpu_streams, check_by_name=True):
+                if _has_downstream_dependencies(stream, vgpu_streams):
                     output_config["send_enabled"] = True
-                    gpucbf_tacv_dst_mcast = list(
-                        filter(
-                            lambda dst_mcast: dst_mcast.name == f"multicast.{stream.name}",
-                            dst_multicasts,
-                        )
-                    )
-                    if len(gpucbf_tacv_dst_mcast) == 1:
-                        gpucbf_tacv_dst_mcast[0].initial_transmit_state = TransmitState.UP
-                    else:
-                        # Found more than one or none, which is unexpected
-                        raise ValueError(
-                            f"Expected exactly one multicast for stream {stream.name}, "
-                            "found {len(gpucbf_tacv_dst_mcast)}"
-                        )
+                    dst_multicast.initial_transmit_state = TransmitState.UP
                 else:
                     output_config["send_enabled"] = False
+                    # initial_transmit_state is already initialised to TransmitState.DOWN
 
                 if stream.dither is not None:
                     output_config["dither"] = stream.dither

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -63,7 +63,7 @@ from .controller import (
     log_task_exceptions,
 )
 from .defaults import CONNECTION_MAX_BACKLOG, LOCALHOST, SHUTDOWN_DELAY
-from .generator import TransmitState
+from .generator import TransmitState, _has_downstream_dependencies
 from .product_config import Configuration
 from .tasks import (
     DEPENDS_INIT,
@@ -1625,6 +1625,11 @@ class SubarrayProduct:
                     product_config.GpucbfTiedArrayChannelisedVoltageStream,
                 ),
             ):
+                # NOTE: GpucbfTACV streams cannot be stopped if they feed a GpucbfTARV stream.
+                if _has_downstream_dependencies(stream, self.configuration.streams):
+                    raise FailReply(
+                        f"Cannot stop stream {stream_name!r} because it has downstream dependents"
+                    )
                 args += [stream_name]
             # The V-engine does not require the stream name for this request
             await self._multi_request(nodes, itertools.repeat(("capture-stop", *args)))

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -63,7 +63,7 @@ from .controller import (
     log_task_exceptions,
 )
 from .defaults import CONNECTION_MAX_BACKLOG, LOCALHOST, SHUTDOWN_DELAY
-from .generator import TransmitState, _has_downstream_dependencies
+from .generator import TransmitState
 from .product_config import Configuration
 from .tasks import (
     DEPENDS_INIT,
@@ -1597,6 +1597,15 @@ class SubarrayProduct:
 
         nodes = list(self.find_nodes(streams=[stream]))
         args: List[Any] = []
+
+        node = self.find_multicast_node(stream_name)
+        if node.logical_node.initial_transmit_state == TransmitState.UP:
+            # NOTE: MeerKAT Extension CBF-CAM ICD outlines criteria for this. Additionally,
+            # GpucbfTACV streams cannot be stopped if they are required by GpucbfTARV streams.
+            raise FailReply(
+                f"Cannot stop stream {stream_name!r} because it is required by another stream"
+            )
+
         if start:
             start_timestamp = 0
             for sensor in self.sdp_controller.sensors.values():
@@ -1625,16 +1634,10 @@ class SubarrayProduct:
                     product_config.GpucbfTiedArrayChannelisedVoltageStream,
                 ),
             ):
-                # NOTE: GpucbfTACV streams cannot be stopped if they feed a GpucbfTARV stream.
-                if _has_downstream_dependencies(stream, self.configuration.streams):
-                    raise FailReply(
-                        f"Cannot stop stream {stream_name!r} because it has downstream dependents"
-                    )
                 args += [stream_name]
             # The V-engine does not require the stream name for this request
             await self._multi_request(nodes, itertools.repeat(("capture-stop", *args)))
 
-        node = self.find_multicast_node(stream_name)
         node.transmit_state = TransmitState.UP if start else TransmitState.DOWN
 
     def capture_list(self) -> Sequence[generator.PhysicalMulticast]:

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -1602,8 +1602,9 @@ class SubarrayProduct:
         if node.logical_node.initial_transmit_state == TransmitState.UP:
             # NOTE: MeerKAT Extension CBF-CAM ICD outlines criteria for this. Additionally,
             # GpucbfTACV streams cannot be stopped if they are required by GpucbfTARV streams.
+            action = "start" if start else "stop"
             raise FailReply(
-                f"Cannot stop stream {stream_name!r} because it is required by another stream"
+                f"Cannot {action} stream {stream_name!r} because it is required by another stream"
             )
 
         if start:

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -2099,6 +2099,15 @@ class TestController(BaseTestController):
         # Note: most of the code for capture-stop is shared with capture-start,
         # so the testing does not need to be as thorough.
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
+
+        gpucbf_tarv_src_stream_name = "gpucbf_tied_array_channelised_voltage_0x_narrowband_vlbi"
+        with pytest.raises(
+            FailReply,
+            match=f"Cannot stop stream {gpucbf_tarv_src_stream_name!r} "
+            "because it has downstream dependents",
+        ):
+            await client.request("capture-stop", gpucbf_tarv_src_stream_name)
+
         await client.request("capture-stop", "gpucbf_baseline_correlation_products")
         await client.request("capture-stop", "gpucbf_tied_array_resampled_voltage")
         katcp_client = sensor_proxy_client

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -1962,6 +1962,8 @@ class TestController(BaseTestController):
             ("capture-start", "gpucbf_antenna_channelised_voltage"),
             # stream has wrong type
             ("capture-list", "sdp_l0"),
+            # stream cannot be stopped
+            ("capture-stop", "gpucbf_tied_array_channelised_voltage_0x_narrowband_vlbi"),
         ],
     )
     async def test_request_fails(self, client: aiokatcp.Client, katcp_request: tuple) -> None:
@@ -2099,14 +2101,6 @@ class TestController(BaseTestController):
         # Note: most of the code for capture-stop is shared with capture-start,
         # so the testing does not need to be as thorough.
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
-
-        gpucbf_tarv_src_stream_name = "gpucbf_tied_array_channelised_voltage_0x_narrowband_vlbi"
-        with pytest.raises(
-            FailReply,
-            match=f"Cannot stop stream {gpucbf_tarv_src_stream_name!r} "
-            "because it has downstream dependents",
-        ):
-            await client.request("capture-stop", gpucbf_tarv_src_stream_name)
 
         await client.request("capture-stop", "gpucbf_baseline_correlation_products")
         await client.request("capture-stop", "gpucbf_tied_array_resampled_voltage")

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -104,12 +104,12 @@ GPUCBF_DATA_STREAMS: List[Tuple[bytes, bytes, bytes]] = [
     (
         b"gpucbf_tied_array_channelised_voltage_0x_narrowband_vlbi",
         rb"239\.192\.\d+\.\d+\+3:7148",
-        b"down",
+        b"up",
     ),
     (
         b"gpucbf_tied_array_channelised_voltage_0y_narrowband_vlbi",
         rb"239\.192\.\d+\.\d+\+3:7148",
-        b"down",
+        b"up",
     ),
     (b"gpucbf_tied_array_resampled_voltage", rb"239\.192\.\d+\.\d+\:7148", b"down"),
 ]

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -2101,7 +2101,6 @@ class TestController(BaseTestController):
         # Note: most of the code for capture-stop is shared with capture-start,
         # so the testing does not need to be as thorough.
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
-
         await client.request("capture-stop", "gpucbf_baseline_correlation_products")
         await client.request("capture-stop", "gpucbf_tied_array_resampled_voltage")
         katcp_client = sensor_proxy_client


### PR DESCRIPTION
As per https://github.com/ska-sa/katgpucbf/pull/1061

Admittedly, I have **not yet** added logic for the `isinstance(stream, GpucbfBaselineCorrelationProductsStream)` (`--corrprod`) branch of logic. I figured that was not part of this ticket - and it can be done with a `?capture-start` (?).

Also, 
- Updated the product controller's `capture_start_stop` method to **not** allow V-engine src-streams to be disabled, and
- Tweaked a unit test or two to check this updated `?capture-stop` logic.

Contributes to: NGC-1990.