### PR TITLE
Implement product-configure schema version 4.9

### DIFF
--- a/src/katsdpcontroller/defaults.py
+++ b/src/katsdpcontroller/defaults.py
@@ -39,6 +39,10 @@ CAL_BUFFER_TIME = 25 * 60.0  # 25 minutes (allows a single batch of 15 minutes)
 CAL_MAX_SCANS = 1000
 #: Speed at which flags are transmitted, relative to real time
 FLAGS_RATE_RATIO = 8.0
+#: Default bits_per_sample for dig.baseband_voltage streams
+DIG_BITS_PER_SAMPLE = 10
+#: Default samples_per_heap for dig.baseband_voltage streams
+DIG_SAMPLES_PER_HEAP = 4096
 #: Alignment constraint for `int_time` in katcbfsim
 KATCBFSIM_SPECTRA_PER_HEAP = 256
 #: Alignment constraint for `int_time` in xgpu

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -412,18 +412,14 @@ def _make_dsim(
     dsim.interfaces[0].bandwidth_out = sum(stream.data_rate() for stream in streams)
     dsim.command = [
         "dsim",
-        "--interface",
-        "{interfaces[gpucbf].name}",
-        "--adc-sample-rate",
-        str(streams[0].adc_sample_rate),
-        "--ttl",
-        "4",
-        "--sync-time",
-        str(streams[0].sync_time),
-        "--katcp-port",
-        "{ports[port]}",
-        "--prometheus-port",
-        "{ports[prometheus]}",
+        "--interface={interfaces[gpucbf].name}",
+        f"--adc-sample-rate={streams[0].adc_sample_rate}",
+        "--ttl=4",
+        f"--sample-bits={streams[0].bits_per_sample}",
+        f"--heap-samples={streams[0].samples_per_heap}",
+        f"--sync-time={streams[0].sync_time}",
+        "--katcp-port={ports[port]}",
+        "--prometheus-port={ports[prometheus]}",
     ]
     dsim.sensor_renames["sync-time"] = [f"{stream.name}.sync-time" for stream in streams]
     # Allow dsim task to set a realtime scheduling priority itself
@@ -442,12 +438,9 @@ def _make_dsim(
         # of signals.
         dsim.cores = ["main", "send", None, None]
         dsim.command = dsim.command + [
-            "--affinity",
-            "{cores[send]}",
-            "--comp-vector",
-            "{cores[send]}",
-            "--main-affinity",
-            "{cores[main]}",
+            "--affinity={cores[send]}",
+            "--comp-vector={cores[send]}",
+            "--main-affinity={cores[main]}",
         ]
     if ibv:
         dsim.capabilities.append("NET_RAW")  # For ibverbs raw QPs
@@ -814,6 +807,8 @@ def _make_fgpu(
                 "--send-interface={interfaces[gpucbf].name}",
                 f"--send-packet-payload={GPUCBF_PACKET_PAYLOAD_BYTES}",
                 f"--adc-sample-rate={srcs[0].adc_sample_rate}",
+                f"--dig-sample-bits={srcs[0].bits_per_sample}",
+                f"--recv-packet-samples={srcs[0].samples_per_heap}",
                 f"--feng-id={i}",
                 f"--array-size={n_engines}",
                 f"--sync-time={srcs[0].sync_time}",
@@ -2938,9 +2933,14 @@ def build_logical_graph(
         cam2telstate = _make_cam2telstate(g, configuration, cam_http[0])
 
     # Simulators
-    def dsim_key(stream: product_config.SimDigBasebandVoltageStream) -> Tuple[str, float]:
+    def dsim_key(stream: product_config.SimDigBasebandVoltageStream) -> Tuple[str, float, int, int]:
         """Key for dsim streams that should be run in the same process."""
-        return (stream.antenna.name, stream.adc_sample_rate)
+        return (
+            stream.antenna.name,
+            stream.adc_sample_rate,
+            stream.bits_per_sample,
+            stream.samples_per_heap,
+        )
 
     for dig_streams in _groupby(
         configuration.by_class(product_config.SimDigBasebandVoltageStream), key=dsim_key

--- a/src/katsdpcontroller/product_config.py
+++ b/src/katsdpcontroller/product_config.py
@@ -69,6 +69,10 @@ BYTES_PER_WEIGHT = 1
 BYTES_PER_VFW = BYTES_PER_VIS + BYTES_PER_FLAG + BYTES_PER_WEIGHT
 
 
+def _is_power_two(x: int) -> bool:
+    return x > 0 and (x & (x - 1)) == 0
+
+
 def _url_n_endpoints(url: Union[str, yarl.URL]) -> int:
     """Return the number of endpoints in a ``spead://`` URL.
 
@@ -435,15 +439,19 @@ class DigBasebandVoltageStreamBase(Stream):
         centre_frequency: float,
         band: str,
         antenna_name: str,
+        bits_per_sample: int,
+        samples_per_heap: int,
     ) -> None:
+        if not _is_power_two(samples_per_heap):
+            raise ValueError("samples_per_heap is not a power of 2")
         super().__init__(name, [])
         self.sync_time = sync_time
         self.adc_sample_rate = adc_sample_rate
         self.centre_frequency = centre_frequency
         self.band = band
         self.antenna_name = antenna_name
-        self.bits_per_sample = 10
-        self.samples_per_heap = 4096
+        self.bits_per_sample = bits_per_sample
+        self.samples_per_heap = samples_per_heap
 
     def data_rate(self, ratio: float = 1.05, overhead: int = 128) -> float:
         """Network bandwidth in bits per second."""
@@ -467,6 +475,8 @@ class DigBasebandVoltageStream(DigBasebandVoltageStreamBase):
         band: str,
         antenna_name: str,
         antenna: Optional[katpoint.Antenna] = None,
+        bits_per_sample: int,
+        samples_per_heap: int,
     ) -> None:
         super().__init__(
             name,
@@ -476,6 +486,8 @@ class DigBasebandVoltageStream(DigBasebandVoltageStreamBase):
             centre_frequency=centre_frequency,
             band=band,
             antenna_name=antenna_name,
+            bits_per_sample=bits_per_sample,
+            samples_per_heap=samples_per_heap,
         )
         self.antenna = antenna
         self.url = url
@@ -508,6 +520,8 @@ class DigBasebandVoltageStream(DigBasebandVoltageStreamBase):
             band=config["band"],
             antenna_name=antenna_name,
             antenna=antenna,
+            bits_per_sample=config.get("bits_per_sample", defaults.DIG_BITS_PER_SAMPLE),
+            samples_per_heap=config.get("samples_per_heap", defaults.DIG_SAMPLES_PER_HEAP),
         )
 
 
@@ -524,6 +538,8 @@ class SimDigBasebandVoltageStream(DigBasebandVoltageStreamBase):
         centre_frequency: float,
         band: str,
         antenna: katpoint.Antenna,
+        bits_per_sample: int,
+        samples_per_heap: int,
         command_line_extra: Iterable[str] = (),
     ) -> None:
         super().__init__(
@@ -534,6 +550,8 @@ class SimDigBasebandVoltageStream(DigBasebandVoltageStreamBase):
             centre_frequency=centre_frequency,
             band=band,
             antenna_name=antenna.name,
+            bits_per_sample=bits_per_sample,
+            samples_per_heap=samples_per_heap,
         )
         self.antenna = antenna
         self.command_line_extra = list(command_line_extra)
@@ -557,6 +575,8 @@ class SimDigBasebandVoltageStream(DigBasebandVoltageStreamBase):
             centre_frequency=config["centre_frequency"],
             band=config["band"],
             antenna=_make_antenna(config["antenna"]),
+            bits_per_sample=config.get("bits_per_sample", defaults.DIG_BITS_PER_SAMPLE),
+            samples_per_heap=config.get("samples_per_heap", defaults.DIG_SAMPLES_PER_HEAP),
             command_line_extra=config.get("command_line_extra", []),
         )
 
@@ -721,7 +741,7 @@ class GpucbfAntennaChannelisedVoltageStream(AntennaChannelisedVoltageStreamBase)
         dither: Optional[str] = None,
         command_line_extra: Iterable[str] = (),
     ) -> None:
-        if n_chans < 1 or (n_chans & (n_chans - 1)) != 0:
+        if not _is_power_two(n_chans):
             raise ValueError("n_chans is not a power of 2")
         if len(src_streams) % 2 != 0:
             raise ValueError("src_streams does not have an even number of elements")

--- a/src/katsdpcontroller/schemas/product_config.yaml.j2
+++ b/src/katsdpcontroller/schemas/product_config.yaml.j2
@@ -13,6 +13,7 @@
 - "4.5"
 - "4.6"
 - "4.7"
+- "4.9"
 {% endmacro %}
 
 {% macro validate(version) %}
@@ -139,14 +140,22 @@ properties:
                 sync_time:
                   type: number
 {% endif %}
-                adc_sample_rate: 
+                adc_sample_rate:
                   $ref: "#/definitions/positive_number"
-                centre_frequency: 
+                centre_frequency:
                   $ref: "#/definitions/positive_number"
                 band:
                   type: string
                 antenna:
                   type: string
+{% if version >= "4.9" %}
+                bits_per_sample:
+                  $ref: "#/definitions/positive_integer"
+                  default: 10
+                samples_per_heap:
+                  $ref: "#/definitions/positive_integer"
+                  default: 4096
+{% endif %}
               additionalProperties: false
               required:
 {% if version >= "4.0" %}
@@ -562,6 +571,14 @@ properties:
                   type: string
                 antenna:
                   type: string
+{% if version >= "4.9" %}
+                bits_per_sample:
+                  $ref: "#/definitions/positive_integer"
+                  default: 10
+                samples_per_heap:
+                  $ref: "#/definitions/positive_integer"
+                  default: 4096
+{% endif %}
                 command_line_extra:
                   type: array
                   items:

--- a/test/test_product_config.py
+++ b/test/test_product_config.py
@@ -312,7 +312,8 @@ class TestDigBasebandVoltageStream:
         assert dig.band == config["band"]
         assert dig.antenna_name == config["antenna"]
         assert dig.antenna is None
-        assert dig.bits_per_sample == 10
+        assert dig.bits_per_sample == defaults.DIG_BITS_PER_SAMPLE
+        assert dig.samples_per_heap == defaults.DIG_SAMPLES_PER_HEAP
         assert dig.data_rate(1.0, 0) == 1712e7
 
     def test_from_config_description(self, config: Dict[str, Any]) -> None:
@@ -321,6 +322,20 @@ class TestDigBasebandVoltageStream:
         dig = DigBasebandVoltageStream.from_config(Options(), "m000h", config, [], {})
         assert dig.antenna_name == "m000"
         assert dig.antenna == _M000
+
+    def test_from_config_non_default(self, config: Dict[str, Any]) -> None:
+        """Test with default values being overridden."""
+        config["bits_per_sample"] = 6
+        config["samples_per_heap"] = 8192
+        dig = DigBasebandVoltageStream.from_config(Options(), "m000h", config, [], {})
+        assert dig.bits_per_sample == 6
+        assert dig.samples_per_heap == 8192
+
+    def test_samples_per_heap_npot(self, config: Dict[str, Any]) -> None:
+        """Test with a non-power-of-two samples_per_heap."""
+        config["samples_per_heap"] = 1234
+        with pytest.raises(ValueError, match="samples_per_heap is not a power of 2"):
+            DigBasebandVoltageStream.from_config(Options(), "m000h", config, [], {})
 
 
 class TestSimDigBasebandVoltageStream:
@@ -345,7 +360,8 @@ class TestSimDigBasebandVoltageStream:
         assert dig.band == config["band"]
         assert dig.antenna == _M000
         assert dig.antenna_name == "m000"
-        assert dig.bits_per_sample == 10
+        assert dig.bits_per_sample == defaults.DIG_BITS_PER_SAMPLE
+        assert dig.samples_per_heap == defaults.DIG_SAMPLES_PER_HEAP
         assert dig.data_rate(1.0, 0) == 1712e7
         assert dig.command_line_extra == []
 
@@ -358,6 +374,20 @@ class TestSimDigBasebandVoltageStream:
         config["command_line_extra"] = ["--extra-arg"]
         dig = SimDigBasebandVoltageStream.from_config(Options(), "m000h", config, [], {})
         assert dig.command_line_extra == config["command_line_extra"]
+
+    def test_from_config_non_default(self, config: Dict[str, Any]) -> None:
+        """Test with default values being overridden."""
+        config["bits_per_sample"] = 6
+        config["samples_per_heap"] = 8192
+        dig = SimDigBasebandVoltageStream.from_config(Options(), "m000h", config, [], {})
+        assert dig.bits_per_sample == 6
+        assert dig.samples_per_heap == 8192
+
+    def test_samples_per_heap_npot(self, config: Dict[str, Any]) -> None:
+        """Test with a non-power-of-two samples_per_heap."""
+        config["samples_per_heap"] = 1234
+        with pytest.raises(ValueError, match="samples_per_heap is not a power of 2"):
+            SimDigBasebandVoltageStream.from_config(Options(), "m000h", config, [], {})
 
 
 class TestAntennaChannelisedVoltageStream:
@@ -410,6 +440,8 @@ def make_dig_baseband_voltage(name: str) -> DigBasebandVoltageStream:
         centre_frequency=1284000000.0,
         band="l",
         antenna_name=name[:-1],
+        bits_per_sample=10,
+        samples_per_heap=4096,
     )
 
 
@@ -422,6 +454,8 @@ def make_sim_dig_baseband_voltage(name: str) -> SimDigBasebandVoltageStream:
         centre_frequency=1284000000.0,
         band="l",
         antenna=_M000 if name.startswith("m000") else _M002,
+        bits_per_sample=10,
+        samples_per_heap=4096,
     )
 
 
@@ -1662,7 +1696,7 @@ class TestSpectralImageStream:
 @pytest.fixture
 def config() -> Dict[str, Any]:
     return {
-        "version": "4.7",
+        "version": "4.9",
         "inputs": {
             "camdata": {"type": "cam.http", "url": "http://10.8.67.235/api/client/1"},
             "i0_antenna_channelised_voltage": {

--- a/test/utils.py
+++ b/test/utils.py
@@ -44,7 +44,7 @@ _T = TypeVar("_T")
 # The "gpucbf" correlator components are not connected up to any SDP components.
 # They're there just as a smoke test for generator.py.
 CONFIG = """{
-    "version": "4.7",
+    "version": "4.9",
     "outputs": {
         "gpucbf_m900v": {
             "type": "sim.dig.baseband_voltage",
@@ -254,7 +254,7 @@ CONFIG = """{
 }"""  # noqa: E501
 
 CONFIG_CBF_ONLY = """{
-    "version": "4.7",
+    "version": "4.9",
     "outputs": {
         "gpucbf_m900v": {
             "type": "sim.dig.baseband_voltage",


### PR DESCRIPTION
This should NOT be merged as is, as it doesn't implement version 4.8 and does not support the 4.8 features in 4.9 documents. That will come from #843.

See NGC-1779 and NGC-1992.