### PR TITLE
Tweak logic for cbf-resources-free sensor

### DIFF
--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -1325,6 +1325,23 @@ class DeviceServer(aiokatcp.DeviceServer):
             port = data["address"]["port"]
             return yarl.URL.build(scheme="http", host=ip_addr, port=port)
 
+    @staticmethod
+    def _has_interfaces(interfaces_raw: Optional[str]) -> bool:
+        """Determine if the agent has any interfaces.
+
+        An empty list is a valid value for the interfaces attribute, and
+        indicates that the agent is likely used for other purposes, so we
+        ignore it.
+        """
+        if interfaces_raw is None:
+            return False
+        try:
+            interfaces = decode_json_base64(interfaces_raw)
+            return bool(interfaces)
+        except Exception:
+            # Lots of possible exceptions: bad base64, bad JSON...
+            return False
+
     async def _update_resource_sensors(self, zk: aiozk.ZKClient) -> None:
         try:
             cbf_resources_total = 0
@@ -1355,7 +1372,13 @@ class DeviceServer(aiokatcp.DeviceServer):
                         if not is_cbf:
                             continue
                         cbf_resources_total += 1
-                        if agent["hostname"] in draining_machines:
+                        # Empty list is a valid value for the interfaces attribute
+                        if not self._has_interfaces(
+                            attributes.get("katsdpcontroller.interfaces", None)
+                        ):
+                            # Agent is likely used for other purposes, so ignore it
+                            continue
+                        elif agent["hostname"] in draining_machines:
                             cbf_resources_maintenance += 1
                         elif agent["used_resources"]["cpus"] == 0:
                             cbf_resources_free += 1

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -1338,8 +1338,8 @@ class DeviceServer(aiokatcp.DeviceServer):
         try:
             interfaces = decode_json_base64(interfaces_raw)
             return bool(interfaces)
-        except Exception:
-            # Lots of possible exceptions: bad base64, bad JSON...
+        except ValueError:
+            # Lots of possible ValueErrors: bad base64, bad JSON...
             return False
 
     async def _update_resource_sensors(self, zk: aiozk.ZKClient) -> None:
@@ -1371,14 +1371,13 @@ class DeviceServer(aiokatcp.DeviceServer):
                             is_cbf = False
                         if not is_cbf:
                             continue
-                        cbf_resources_total += 1
-                        # Empty list is a valid value for the interfaces attribute
                         if not self._has_interfaces(
                             attributes.get("katsdpcontroller.interfaces", None)
                         ):
                             # Agent is likely used for other purposes, so ignore it
                             continue
-                        elif agent["hostname"] in draining_machines:
+                        cbf_resources_total += 1
+                        if agent["hostname"] in draining_machines:
                             cbf_resources_maintenance += 1
                         elif agent["used_resources"]["cpus"] == 0:
                             cbf_resources_free += 1

--- a/test/test_master_controller.py
+++ b/test/test_master_controller.py
@@ -37,6 +37,7 @@ import yarl
 from aiokatcp import Client, DeviceStatus, Sensor
 
 from katsdpcontroller import scheduler
+from katsdpcontroller.agent_mkconfig import encode
 from katsdpcontroller.controller import (
     ProductState,
     device_server_sockname,
@@ -1285,6 +1286,12 @@ class TestDeviceServerReal:
                 "draining_machines": [{"id": {"hostname": "machine2", "ip": "10.0.0.2"}}],
             },
         )
+
+        # A simple example of what is configured on Mesos agents
+        _katsdpcontroller_interfaces = [
+            {"ipv4_address": "11.22.33.44", "name": "enp193s0np0", "network": "gpucbf"}
+        ]
+        _katsdpcontroller_interfaces_encoded = encode(_katsdpcontroller_interfaces)
         # This is only a tiny subset of what is returned, sufficient for
         # what the code expects to find.
         rmock.get(
@@ -1293,7 +1300,10 @@ class TestDeviceServerReal:
                 "slaves": [
                     {
                         # Draining machine
-                        "attributes": {"katsdpcontroller.subsystems": "WyJjYmYiXSAg"},  # {"cbf"}
+                        "attributes": {
+                            "katsdpcontroller.subsystems": "WyJjYmYiXSAg",  # {"cbf"}
+                            "katsdpcontroller.interfaces": _katsdpcontroller_interfaces_encoded,
+                        },
                         "hostname": "machine2",
                         "used_resources": {"cpus": 0},
                     },
@@ -1312,7 +1322,10 @@ class TestDeviceServerReal:
                     },
                     {
                         # Machine that's usable but unused
-                        "attributes": {"katsdpcontroller.subsystems": "WyJjYmYiXSAg"},  # {"cbf"}
+                        "attributes": {
+                            "katsdpcontroller.subsystems": "WyJjYmYiXSAg",
+                            "katsdpcontroller.interfaces": _katsdpcontroller_interfaces_encoded,
+                        },  # {"cbf"}
                         "hostname": "machine5",
                         "used_resources": {"cpus": 0},
                     },
@@ -1322,12 +1335,22 @@ class TestDeviceServerReal:
                         "hostname": "machine6",
                         "used_resources": {"cpus": 16},
                     },
+                    {
+                        # Machine that is not usable for CBF, but is used for something else.
+                        # It is not counted.
+                        "attributes": {
+                            "katsdpcontroller.subsystems": "WyJjYmYiXSAg",
+                            "katsdpcontroller.interfaces": encode([]),
+                        },
+                        "hostname": "machine7",
+                        "used_resources": {"cpus": 0},
+                    },
                 ]
             },
         )
 
         await asyncio.sleep(5)  # Give the polling loop time to run
-        assert server.sensors["cbf-resources-total"].value == 3
+        assert server.sensors["cbf-resources-total"].value == 4
         assert server.sensors["cbf-resources-total"].status == Sensor.Status.NOMINAL
         assert server.sensors["cbf-resources-maintenance"].value == 1
         assert server.sensors["cbf-resources-maintenance"].status == Sensor.Status.NOMINAL

--- a/test/test_master_controller.py
+++ b/test/test_master_controller.py
@@ -1309,7 +1309,7 @@ class TestDeviceServerReal:
                     {
                         # CBF Machine, marked for maintenance
                         "attributes": {
-                            "katsdpcontroller.subsystems": cbf_subsystems_encoded,  # {"cbf"}
+                            "katsdpcontroller.subsystems": cbf_subsystems_encoded,
                             "katsdpcontroller.interfaces": katsdpcontroller_interfaces_encoded,
                         },
                         "hostname": "machine2",
@@ -1317,9 +1317,7 @@ class TestDeviceServerReal:
                     },
                     {
                         # Machine that's not marked for CBF
-                        "attributes": {
-                            "katsdpcontroller.subsystems": sdp_subsystems_encoded
-                        },  # {"sdp"}
+                        "attributes": {"katsdpcontroller.subsystems": sdp_subsystems_encoded},
                         "hostname": "machine3",
                         "used_resources": {"cpus": 0},
                     },
@@ -1333,7 +1331,7 @@ class TestDeviceServerReal:
                     {
                         # Machine that's usable for CBF and free
                         "attributes": {
-                            "katsdpcontroller.subsystems": cbf_subsystems_encoded,  # {"cbf"}
+                            "katsdpcontroller.subsystems": cbf_subsystems_encoded,
                             "katsdpcontroller.interfaces": katsdpcontroller_interfaces_encoded,
                         },
                         "hostname": "machine5",
@@ -1342,17 +1340,16 @@ class TestDeviceServerReal:
                     {
                         # CBF Machine that's usable and at least partly used
                         "attributes": {
-                            "katsdpcontroller.subsystems": cbf_subsystems_encoded,  # {"cbf"}
+                            "katsdpcontroller.subsystems": cbf_subsystems_encoded,
                             "katsdpcontroller.interfaces": katsdpcontroller_interfaces_encoded,
                         },
                         "hostname": "machine6",
                         "used_resources": {"cpus": 16},
                     },
                     {
-                        # Machine that is not usable for CBF, but is used for something else.
-                        # It is not counted.
+                        # Machine that is not usable for CBF engines
                         "attributes": {
-                            "katsdpcontroller.subsystems": cbf_subsystems_encoded,  # {"cbf"}
+                            "katsdpcontroller.subsystems": cbf_subsystems_encoded,
                             "katsdpcontroller.interfaces": encode([]),
                         },
                         "hostname": "machine7",

--- a/test/test_master_controller.py
+++ b/test/test_master_controller.py
@@ -1260,6 +1260,12 @@ class TestDeviceServerReal:
         rmock: aioresponses.aioresponses,
         mock_zk: Dict[Optional[str], fake_zk.ZKClient],
     ) -> None:
+        """Exercise logic populating cbf-resource-* sensors.
+
+        CBF does not count agents with an empty interfaces attribute, nor agents
+        marked for subsystems other than CBF. The test sets up a variety of agents to
+        verify that the counting logic is correct.
+        """
         # Let the loop run once. It should fail to populate the sensors because
         # it won't be able to find a Mesos master in zookeeper.
         await asyncio.sleep(1)
@@ -1288,10 +1294,12 @@ class TestDeviceServerReal:
         )
 
         # A simple example of what is configured on Mesos agents
-        _katsdpcontroller_interfaces = [
+        katsdpcontroller_interfaces = [
             {"ipv4_address": "11.22.33.44", "name": "enp193s0np0", "network": "gpucbf"}
         ]
-        _katsdpcontroller_interfaces_encoded = encode(_katsdpcontroller_interfaces)
+        katsdpcontroller_interfaces_encoded = encode(katsdpcontroller_interfaces)
+        cbf_subsystems_encoded = encode(["cbf"])
+        sdp_subsystems_encoded = encode(["sdp"])
         # This is only a tiny subset of what is returned, sufficient for
         # what the code expects to find.
         rmock.get(
@@ -1299,17 +1307,19 @@ class TestDeviceServerReal:
             payload={
                 "slaves": [
                     {
-                        # Draining machine
+                        # CBF Machine, marked for maintenance
                         "attributes": {
-                            "katsdpcontroller.subsystems": "WyJjYmYiXSAg",  # {"cbf"}
-                            "katsdpcontroller.interfaces": _katsdpcontroller_interfaces_encoded,
+                            "katsdpcontroller.subsystems": cbf_subsystems_encoded,  # {"cbf"}
+                            "katsdpcontroller.interfaces": katsdpcontroller_interfaces_encoded,
                         },
                         "hostname": "machine2",
                         "used_resources": {"cpus": 0},
                     },
                     {
                         # Machine that's not marked for CBF
-                        "attributes": {"katsdpcontroller.subsystems": "WyJzZHAiXSAg"},  # {"sdp"}
+                        "attributes": {
+                            "katsdpcontroller.subsystems": sdp_subsystems_encoded
+                        },  # {"sdp"}
                         "hostname": "machine3",
                         "used_resources": {"cpus": 0},
                     },
@@ -1321,17 +1331,20 @@ class TestDeviceServerReal:
                         "used_resources": {"cpus": 0},
                     },
                     {
-                        # Machine that's usable but unused
+                        # Machine that's usable for CBF and free
                         "attributes": {
-                            "katsdpcontroller.subsystems": "WyJjYmYiXSAg",
-                            "katsdpcontroller.interfaces": _katsdpcontroller_interfaces_encoded,
-                        },  # {"cbf"}
+                            "katsdpcontroller.subsystems": cbf_subsystems_encoded,  # {"cbf"}
+                            "katsdpcontroller.interfaces": katsdpcontroller_interfaces_encoded,
+                        },
                         "hostname": "machine5",
                         "used_resources": {"cpus": 0},
                     },
                     {
-                        # Machine that's usable and at least partly used
-                        "attributes": {"katsdpcontroller.subsystems": "WyJjYmYiXSAg"},  # {"cbf"}
+                        # CBF Machine that's usable and at least partly used
+                        "attributes": {
+                            "katsdpcontroller.subsystems": cbf_subsystems_encoded,  # {"cbf"}
+                            "katsdpcontroller.interfaces": katsdpcontroller_interfaces_encoded,
+                        },
                         "hostname": "machine6",
                         "used_resources": {"cpus": 16},
                     },
@@ -1339,7 +1352,7 @@ class TestDeviceServerReal:
                         # Machine that is not usable for CBF, but is used for something else.
                         # It is not counted.
                         "attributes": {
-                            "katsdpcontroller.subsystems": "WyJjYmYiXSAg",
+                            "katsdpcontroller.subsystems": cbf_subsystems_encoded,  # {"cbf"}
                             "katsdpcontroller.interfaces": encode([]),
                         },
                         "hostname": "machine7",
@@ -1350,7 +1363,7 @@ class TestDeviceServerReal:
         )
 
         await asyncio.sleep(5)  # Give the polling loop time to run
-        assert server.sensors["cbf-resources-total"].value == 4
+        assert server.sensors["cbf-resources-total"].value == 3
         assert server.sensors["cbf-resources-total"].status == Sensor.Status.NOMINAL
         assert server.sensors["cbf-resources-maintenance"].value == 1
         assert server.sensors["cbf-resources-maintenance"].status == Sensor.Status.NOMINAL


### PR DESCRIPTION
Specifically avoid counting agents without the mesos-agent interfaces (`katsdpcontroller.interfaces`) attribute, e.g. Product Controllers.

I know I seem to be in the habit of creating helper functions lately... It made sense at the time.

Ran on cbf-mc just now using `sdp_image_tag` NGC-1940-cbf-resources-free (I didn't want to fiddle with the lab).
```
$ ntsh cbf-mc.cbf.mkat.karoo.kat.ac.za:5001 -p katcp:unescape
< #version-connect katcp-protocol 5.1-MIB
< #version-connect katcp-library aiokatcp-2.2 aiokatcp-2.2.0
< #version-connect katcp-device sdpcontroller-3.3 katsdpcontroller-0.1.dev3416+head.0aad77a
> ?sensor-value cbf-resources-free
< #sensor-value 1782910778.1884959 1 cbf-resources-free nominal 43
< !sensor-value ok 1
```

Rolling back to the production tag
```
> ?sensor-value /cbf-resources/
< #sensor-value 1782911308.663972 1 cbf-resources-free nominal 44
< #sensor-value 1782911308.6638024 1 cbf-resources-maintenance nominal 3
< #sensor-value 1782911308.6635358 1 cbf-resources-total nominal 47
```

I realise I should've gotten the `cbf-resources-total` sensor value when testing earlier - will do so later tonight and update here accordingly.

Contributes to: NGC-1940.