### PR TITLE
Hide per-engine sensors that are only needed for aggregation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ aiohttp-jinja2==1.6
     # via katsdpcontroller (setup.cfg)
 aiohttp-retry==2.8.3
     # via katsdpmodels
-aiokatcp==2.2.0
+aiokatcp==2.3.0
     # via katsdpcontroller (setup.cfg)
 aiomonitor==0.7.0
     # via katsdpservices

--- a/scripts/sdp_master_controller.py
+++ b/scripts/sdp_master_controller.py
@@ -72,7 +72,7 @@ async def async_main(argv: List[str]) -> None:
             "no actual command logic will be enacted."
         )
 
-    rewrite_gui_urls: Optional[Callable[[aiokatcp.Sensor], bytes]]
+    rewrite_gui_urls: Optional[Callable[[aiokatcp.Sensor, aiokatcp.Reading], aiokatcp.Reading]]
     if args.haproxy:
         rewrite_gui_urls = functools.partial(web.rewrite_gui_urls, args.external_url)
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     addict!=2.0.*,!=2.4.0
     aiohttp~=3.9
     aiohttp-jinja2
-    aiokatcp>=2.1.0
+    aiokatcp>=2.3.0
     aiozk
     async_timeout
     dash>=1.18

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -950,7 +950,7 @@ def _make_fgpu(
 def _make_xbgpu(
     g: networkx.MultiDiGraph,
     configuration: Configuration,
-    sensors: SensorSet,
+    task_sensors: SensorSet,
     streams: Iterable[GpucbfXBStream],
 ) -> scheduler.LogicalNode:
     # Ensure that streams is a sequence, not just an iterable. Also put
@@ -976,8 +976,8 @@ def _make_xbgpu(
     ants = np.array(acv.input_labels).reshape(-1, 2)
     n_ants = ants.shape[0]
 
-    base_name = streams[0].name
-    xbgpu_group = LogicalGroup(f"xbgpu.{base_name}")
+    base_name = f"xb.{streams[0].name}"
+    xbgpu_group = LogicalGroup(base_name)
     g.add_node(xbgpu_group)
     dst_multicasts = []
     data_suspect_sensors = []
@@ -998,8 +998,8 @@ def _make_xbgpu(
             initial_status=Sensor.Status.NOMINAL,
         )
         data_suspect_sensors.append(data_suspect_sensor)
+        re_prefix = re.escape(f"{base_name}.") + "[0-9]+" + re.escape(f".{stream.name}.")
 
-        escaped_name = re.escape(stream.name)
         stream_sensors: List[Sensor] = [
             # The timestamps are simply ADC sample counts
             Sensor(
@@ -1125,20 +1125,20 @@ def _make_xbgpu(
                     initial_status=Sensor.Status.NOMINAL,
                 ),
                 SumSensor(
-                    sensors,
+                    task_sensors,
                     f"{stream.name}.xeng-clip-cnt",
                     "Number of visibilities that saturated",
-                    name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.xeng-clip-cnt"),
+                    name_regex=re.compile(rf"{re_prefix}xeng-clip-cnt"),
                     n_children=stream.n_substreams,
                     auto_strategy=SensorSampler.Strategy.EVENT_RATE,
                     auto_strategy_parameters=(FAST_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
                 SyncSensor(
-                    sensors,
+                    task_sensors,
                     f"{stream.name}.rx.synchronised",
                     "For the latest accumulation, was data present from all F-Engines "
                     "for all X-Engines",
-                    name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.rx.synchronised"),
+                    name_regex=re.compile(rf"{re_prefix}rx.synchronised"),
                     n_children=stream.n_substreams,
                 ),
             ]
@@ -1183,34 +1183,34 @@ def _make_xbgpu(
                     initial_status=Sensor.Status.NOMINAL,
                 ),
                 SumSensor(
-                    sensors,
+                    task_sensors,
                     f"{stream.name}.beng-clip-cnt",
                     "Number of complex samples that saturated",
-                    name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.beng-clip-cnt"),
+                    name_regex=re.compile(rf"{re_prefix}beng-clip-cnt"),
                     n_children=stream.n_substreams,
                     auto_strategy=SensorSampler.Strategy.EVENT_RATE,
                     auto_strategy_parameters=(FAST_SENSOR_UPDATE_PERIOD, math.inf),
                 ),
                 LatestSensor(
-                    sensors,
+                    task_sensors,
                     float,
                     f"{stream.name}.quantiser-gain",
                     "Non-complex post-summation quantiser gain applied to this beam",
-                    name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.quantiser-gain"),
+                    name_regex=re.compile(rf"{re_prefix}quantiser-gain"),
                 ),
                 LatestSensor(
-                    sensors,
+                    task_sensors,
                     bytes,
                     f"{stream.name}.delay",
                     "The delay settings of the inputs for this beam",
-                    name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.delay"),
+                    name_regex=re.compile(rf"{re_prefix}delay"),
                 ),
                 LatestSensor(
-                    sensors,
+                    task_sensors,
                     bytes,
                     f"{stream.name}.weight",
                     "The summing weights applied to all the inputs of this beam",
-                    name_regex=re.compile(rf"{escaped_name}\.[0-9]+\.weight"),
+                    name_regex=re.compile(rf"{re_prefix}weight"),
                 ),
             ]
             stream_sensors.extend(bstream_sensors)
@@ -1270,7 +1270,7 @@ def _make_xbgpu(
     task_names = []
     for i in range(n_engines):
         # One engine per section of the band
-        xbgpu = ProductLogicalTask(f"xb.{base_name}.{i}", streams=streams, index=i)
+        xbgpu = ProductLogicalTask(f"{base_name}.{i}", streams=streams, index=i)
         task_names.append(xbgpu.name)
         xbgpu.subsystem = "cbf"
         xbgpu.image = "katgpucbf"
@@ -1454,22 +1454,23 @@ def _make_xbgpu(
         ]:
             xbgpu.sensor_renames[name] = [f"{stream.name}.{i}.{name}" for stream in streams]
 
-        # Rename sensors that are relevant to the stream rather than the Pipeline
+        # Rename sensors that are relevant to the stream rather than the Pipeline,
+        # and hide sensors that are only used to create aggregates.
         for stream in streams:
             if isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
                 renames = ["chan-range", "rx.synchronised", "xeng-clip-cnt"]
+                hide = ["rx.synchronised", "xeng-clip-cnt"]
             elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
                 renames = [
                     "chan-range",
-                    "delay",
-                    "quantiser-gain",
-                    "weight",
-                    "beng-clip-cnt",
                     "tx.next-timestamp",
                     "dither-seed",
                 ]
+                hide = ["delay", "quantiser-gain", "weight", "beng-clip-cnt"]
             for name in renames:
                 xbgpu.sensor_renames[f"{stream.name}.{name}"] = f"{stream.name}.{i}.{name}"
+            for name in hide:
+                xbgpu.sensor_renames[f"{stream.name}.{name}"] = []
 
         xbgpu.static_gauges["xbgpu_expected_input_heaps_per_second"] = (
             acv.adc_sample_rate
@@ -2893,7 +2894,7 @@ def _groupby(items: Iterable[_T], key: Callable[[_T], Any]) -> Iterable[Iterable
 
 
 def build_logical_graph(
-    configuration: Configuration, config_dict: dict, sensors: SensorSet
+    configuration: Configuration, config_dict: dict, task_sensors: SensorSet
 ) -> networkx.MultiDiGraph:
     # We mutate the configuration to align output channels to requirements.
     configuration = copy.deepcopy(configuration)
@@ -2970,7 +2971,7 @@ def build_logical_graph(
             g,
             configuration,
             streams=xbgpu_streams,
-            sensors=sensors,
+            task_sensors=task_sensors,
         )
     for vgpu_stream in configuration.by_class(product_config.GpucbfTiedArrayResampledVoltageStream):
         _make_vgpu(g, configuration, vgpu_stream)

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1128,7 +1128,7 @@ def _make_xbgpu(
                     task_sensors,
                     f"{stream.name}.xeng-clip-cnt",
                     "Number of visibilities that saturated",
-                    name_regex=re.compile(rf"{re_prefix}xeng-clip-cnt"),
+                    name_regex=re.compile(f"{re_prefix}xeng-clip-cnt"),
                     n_children=stream.n_substreams,
                     auto_strategy=SensorSampler.Strategy.EVENT_RATE,
                     auto_strategy_parameters=(FAST_SENSOR_UPDATE_PERIOD, math.inf),
@@ -1138,7 +1138,7 @@ def _make_xbgpu(
                     f"{stream.name}.rx.synchronised",
                     "For the latest accumulation, was data present from all F-Engines "
                     "for all X-Engines",
-                    name_regex=re.compile(rf"{re_prefix}rx.synchronised"),
+                    name_regex=re.compile(rf"{re_prefix}rx\.synchronised"),
                     n_children=stream.n_substreams,
                 ),
             ]
@@ -1186,7 +1186,7 @@ def _make_xbgpu(
                     task_sensors,
                     f"{stream.name}.beng-clip-cnt",
                     "Number of complex samples that saturated",
-                    name_regex=re.compile(rf"{re_prefix}beng-clip-cnt"),
+                    name_regex=re.compile(f"{re_prefix}beng-clip-cnt"),
                     n_children=stream.n_substreams,
                     auto_strategy=SensorSampler.Strategy.EVENT_RATE,
                     auto_strategy_parameters=(FAST_SENSOR_UPDATE_PERIOD, math.inf),
@@ -1196,21 +1196,21 @@ def _make_xbgpu(
                     float,
                     f"{stream.name}.quantiser-gain",
                     "Non-complex post-summation quantiser gain applied to this beam",
-                    name_regex=re.compile(rf"{re_prefix}quantiser-gain"),
+                    name_regex=re.compile(f"{re_prefix}quantiser-gain"),
                 ),
                 LatestSensor(
                     task_sensors,
                     bytes,
                     f"{stream.name}.delay",
                     "The delay settings of the inputs for this beam",
-                    name_regex=re.compile(rf"{re_prefix}delay"),
+                    name_regex=re.compile(f"{re_prefix}delay"),
                 ),
                 LatestSensor(
                     task_sensors,
                     bytes,
                     f"{stream.name}.weight",
                     "The summing weights applied to all the inputs of this beam",
-                    name_regex=re.compile(rf"{re_prefix}weight"),
+                    name_regex=re.compile(f"{re_prefix}weight"),
                 ),
             ]
             stream_sensors.extend(bstream_sensors)

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1458,7 +1458,7 @@ def _make_xbgpu(
         # and hide sensors that are only used to create aggregates.
         for stream in streams:
             if isinstance(stream, product_config.GpucbfBaselineCorrelationProductsStream):
-                renames = ["chan-range", "rx.synchronised", "xeng-clip-cnt"]
+                renames = ["chan-range"]
                 hide = ["rx.synchronised", "xeng-clip-cnt"]
             elif isinstance(stream, product_config.GpucbfTiedArrayChannelisedVoltageStream):
                 renames = [

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -221,6 +221,7 @@ class Product:
                 rewrite_gui_urls=rewrite_gui_urls,
                 enum_types=(DeviceStatus,),
                 filter=self._mirror_filter if not mirror_sensors else None,
+                notify=lambda: server.mass_inform("interface-changed", "sensor-list"),
             )
         )
         self.katcp_conn.add_inform_callback("disconnect", self._disconnect_callback)

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -222,9 +222,23 @@ class Product:
                 enum_types=(DeviceStatus,),
                 filter=self._mirror_filter if not mirror_sensors else None,
                 notify=lambda: server.mass_inform("interface-changed", "sensor-list"),
-                orig_sensors=getattr(server, "orig_sensors", None),
             )
         )
+        # Make a copy of sensors without the effects of rewrite_gui_urls
+        # (used by web.py).
+        # TODO: improve the type annotations and the unit tests so that we don't
+        # need this to be conditional. It can probably also have a tighter filter
+        # since it's only needed for gui-urls sensors.
+        if hasattr(server, "orig_sensors"):
+            self.katcp_conn.add_sensor_watcher(
+                sensor_proxy.SensorWatcher(
+                    self.katcp_conn,
+                    server.orig_sensors,  # type: ignore
+                    f"{self.name}.",
+                    enum_types=(DeviceStatus,),
+                    filter=self._mirror_filter if not mirror_sensors else None,
+                )
+            )
         self.katcp_conn.add_inform_callback("disconnect", self._disconnect_callback)
         # TODO: start a watchdog
 

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -216,12 +216,13 @@ class Product:
         self.katcp_conn.add_sensor_watcher(
             sensor_proxy.SensorWatcher(
                 self.katcp_conn,
-                server,
+                server.sensors,
                 f"{self.name}.",
                 rewrite_gui_urls=rewrite_gui_urls,
                 enum_types=(DeviceStatus,),
                 filter=self._mirror_filter if not mirror_sensors else None,
                 notify=lambda: server.mass_inform("interface-changed", "sensor-list"),
+                orig_sensors=getattr(server, "orig_sensors", None),
             )
         )
         self.katcp_conn.add_inform_callback("disconnect", self._disconnect_callback)

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -61,7 +61,7 @@ import async_timeout
 import jsonschema
 import katsdpservices
 import yarl
-from aiokatcp import Address, DeviceStatus, FailReply, Sensor, SensorSet
+from aiokatcp import Address, DeviceStatus, FailReply, Reading, Sensor, SensorSet
 
 import katsdpcontroller
 
@@ -191,7 +191,7 @@ class Product:
     def connect(
         self,
         server: aiokatcp.DeviceServer,
-        rewrite_gui_urls: Optional[Callable[[Sensor], bytes]],
+        rewrite_gui_urls: Optional[Callable[[Sensor, Reading], Reading]],
         hostname: str,
         host: _IPAddress,
         ports: Dict[str, int],
@@ -335,7 +335,7 @@ class ProductManagerBase(Generic[_P]):
         args: argparse.Namespace,
         server: aiokatcp.DeviceServer,
         image_resolver_factory: scheduler.ImageResolverFactory,
-        rewrite_gui_urls: Optional[Callable[[Sensor], bytes]] = None,
+        rewrite_gui_urls: Optional[Callable[[Sensor, Reading], Reading]] = None,
     ) -> None:
         self._args = args
         self._multicast_network = ipaddress.IPv4Network(args.safe_multicast_cidr)
@@ -738,7 +738,7 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
         args: argparse.Namespace,
         server: aiokatcp.DeviceServer,
         image_resolver_factory: scheduler.ImageResolverFactory,
-        rewrite_gui_urls: Optional[Callable[[Sensor], bytes]] = None,
+        rewrite_gui_urls: Optional[Callable[[Sensor, Reading], Reading]] = None,
     ) -> None:
         super().__init__(args, server, image_resolver_factory, rewrite_gui_urls)
         self._request_id_prefix = args.name + "_product_"
@@ -1212,7 +1212,9 @@ class DeviceServer(aiokatcp.DeviceServer):
     _interface_changed_callbacks: List[Callable[[], None]]
 
     def __init__(
-        self, args: argparse.Namespace, rewrite_gui_urls: Optional[Callable[[Sensor], bytes]] = None
+        self,
+        args: argparse.Namespace,
+        rewrite_gui_urls: Optional[Callable[[Sensor, Reading], Reading]] = None,
     ) -> None:
         if args.no_pull or args.interface_mode:
             self._image_lookup = scheduler.SimpleImageLookup(args.registry)

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -1271,7 +1271,7 @@ class DeviceServer(aiokatcp.DeviceServer):
             )
         )
 
-        # Updated by SensorProxyClient with sensor values prior to gui-url rewriting
+        # Updated by SensorWatcher with sensor values prior to gui-url rewriting
         self.orig_sensors = SensorSet()
         for sensor in self.sensors.values():
             self.orig_sensors.add(sensor)

--- a/src/katsdpcontroller/master_controller.py
+++ b/src/katsdpcontroller/master_controller.py
@@ -191,7 +191,7 @@ class Product:
     def connect(
         self,
         server: aiokatcp.DeviceServer,
-        rewrite_gui_urls: Optional[Callable[[Sensor, Reading], Reading]],
+        rewrite_readings: Optional[Callable[[Sensor, Reading], Reading]],
         hostname: str,
         host: _IPAddress,
         ports: Dict[str, int],
@@ -218,13 +218,13 @@ class Product:
                 self.katcp_conn,
                 server.sensors,
                 f"{self.name}.",
-                rewrite_gui_urls=rewrite_gui_urls,
+                rewrite_readings=rewrite_readings,
                 enum_types=(DeviceStatus,),
                 filter=self._mirror_filter if not mirror_sensors else None,
                 notify=lambda: server.mass_inform("interface-changed", "sensor-list"),
             )
         )
-        # Make a copy of sensors without the effects of rewrite_gui_urls
+        # Make a copy of sensors without the effects of rewrite_readings
         # (used by web.py).
         # TODO: improve the type annotations and the unit tests so that we don't
         # need this to be conditional. It can probably also have a tighter filter
@@ -335,7 +335,7 @@ class ProductManagerBase(Generic[_P]):
         args: argparse.Namespace,
         server: aiokatcp.DeviceServer,
         image_resolver_factory: scheduler.ImageResolverFactory,
-        rewrite_gui_urls: Optional[Callable[[Sensor, Reading], Reading]] = None,
+        rewrite_readings: Optional[Callable[[Sensor, Reading], Reading]] = None,
     ) -> None:
         self._args = args
         self._multicast_network = ipaddress.IPv4Network(args.safe_multicast_cidr)
@@ -344,7 +344,7 @@ class ProductManagerBase(Generic[_P]):
         self._products: Dict[str, _P] = {}
         self._next_capture_block_id = 1
         self._image_resolver_factory = image_resolver_factory
-        self._rewrite_gui_urls = rewrite_gui_urls
+        self._rewrite_readings = rewrite_readings
 
     async def start(self) -> None:
         pass
@@ -558,7 +558,7 @@ class ProductManagerBase(Generic[_P]):
         `ports` must contain at least ``katcp``, but subclasses may include
         additional ports.
         """
-        product.connect(self._server, self._rewrite_gui_urls, hostname, host, ports)
+        product.connect(self._server, self._rewrite_readings, hostname, host, ports)
         assert product.katcp_conn is not None
         product.katcp_conn.add_sensor_watcher(DeviceStatusWatcher(self._update_device_status))
 
@@ -738,9 +738,9 @@ class SingularityProductManager(ProductManagerBase[SingularityProduct]):
         args: argparse.Namespace,
         server: aiokatcp.DeviceServer,
         image_resolver_factory: scheduler.ImageResolverFactory,
-        rewrite_gui_urls: Optional[Callable[[Sensor, Reading], Reading]] = None,
+        rewrite_readings: Optional[Callable[[Sensor, Reading], Reading]] = None,
     ) -> None:
-        super().__init__(args, server, image_resolver_factory, rewrite_gui_urls)
+        super().__init__(args, server, image_resolver_factory, rewrite_readings)
         self._request_id_prefix = args.name + "_product_"
         self._task_cache: Dict[str, dict] = {}  # Maps Singularity Task IDs to their info
         # Task IDs that we didn't expect to see, but have been seen once.

--- a/src/katsdpcontroller/product_controller.py
+++ b/src/katsdpcontroller/product_controller.py
@@ -497,7 +497,7 @@ class SubarrayProduct:
         self.subarray_product_id = subarray_product_id
         self.sdp_controller = sdp_controller
         self.logical_graph = generator.build_logical_graph(
-            configuration, config_dict, sdp_controller.sensors
+            configuration, config_dict, sdp_controller.task_sensors
         )
         self.telstate_endpoint = ""
         self.telstate: Optional[katsdptelstate.aio.TelescopeState] = None
@@ -1856,6 +1856,8 @@ class DeviceServer(aiokatcp.DeviceServer):
         self.master_controller = master_controller
         self.product: Optional[SubarrayProduct] = None
         self.shutdown_delay = shutdown_delay
+        #: Sensors from child tasks (prefixed but without any custom renaming)
+        self.task_sensors = aiokatcp.SensorSet()
 
         super().__init__(host, port, max_backlog=CONNECTION_MAX_BACKLOG)
         # setup sensors (note: ProductController adds other sensors)

--- a/src/katsdpcontroller/sensor_proxy.py
+++ b/src/katsdpcontroller/sensor_proxy.py
@@ -17,7 +17,6 @@
 """Class for katcp connections that proxies sensors into a server"""
 
 import enum
-import functools
 import logging
 from typing import (
     Any,
@@ -138,7 +137,7 @@ class SensorWatcher(aiokatcp.SensorWatcher):
         if notify is not None:
             self.notify = notify
         else:
-            self.notify = functools.partial(server.mass_inform, "interface-changed", "sensor-list")
+            self.notify = lambda: None
         # Whether we need to call notify at the end of the batch
         self._need_notify = False
         self._filter = filter

--- a/src/katsdpcontroller/sensor_proxy.py
+++ b/src/katsdpcontroller/sensor_proxy.py
@@ -107,9 +107,6 @@ class SensorWatcher(aiokatcp.SensorWatcher):
     filter
         Predicate used to decide which sensors are required. The default is
         to use all of them. See :meth:`aiokatcp.AbstractSensorWatcher.filter`.
-    orig_sensors
-        If provided, it will be populated similarly to `sensors`, except that
-        `rewrite_gui_urls` will not be applied.
     """
 
     def __init__(
@@ -123,7 +120,6 @@ class SensorWatcher(aiokatcp.SensorWatcher):
         close_action: CloseAction = CloseAction.REMOVE,
         notify: Optional[Callable[[], Any]] = None,
         filter: Optional[_FilterPredicate] = None,
-        orig_sensors: Optional[aiokatcp.SensorSet] = None,
     ) -> None:
         super().__init__(client, enum_types)
         self.prefix = prefix
@@ -131,12 +127,6 @@ class SensorWatcher(aiokatcp.SensorWatcher):
         # Note: cannot just be called sensors, because the base class already
         # uses that name for its internal mirror.
         self.target_sensors = sensors
-        # We keep track of the sensors after name rewriting but prior to gui-url rewriting
-        if orig_sensors is not None:
-            self.orig_sensors = orig_sensors
-        else:
-            self.orig_sensors = aiokatcp.SensorSet()
-
         self.rewrite_gui_urls = rewrite_gui_urls
         self.close_action = close_action
         if notify is not None:
@@ -165,7 +155,6 @@ class SensorWatcher(aiokatcp.SensorWatcher):
         super().sensor_added(name, description, units, type_name, *args)
         for rewritten_name in self.rewrite_name(name):
             sensor = self.sensors[rewritten_name]
-            self.orig_sensors.add(sensor)
             if (
                 self.rewrite_gui_urls is not None
                 and sensor.name.endswith(".gui-urls")
@@ -186,7 +175,6 @@ class SensorWatcher(aiokatcp.SensorWatcher):
     def _sensor_removed(self, name: str) -> None:
         """Like :meth:`sensor_removed`, but takes the rewritten name"""
         self.target_sensors.pop(name, None)
-        self.orig_sensors.pop(name, None)
         self._need_notify = True
 
     def sensor_removed(self, name: str) -> None:
@@ -240,7 +228,6 @@ class SensorWatcher(aiokatcp.SensorWatcher):
             for name in self.sensors.keys():
                 if self.close_action == CloseAction.UNREACHABLE:
                     self._mark_unreachable(self.target_sensors[name])
-                    self._mark_unreachable(self.orig_sensors[name])
                 elif self.close_action == CloseAction.REMOVE:
                     self._sensor_removed(name)
             self.batch_stop()

--- a/src/katsdpcontroller/sensor_proxy.py
+++ b/src/katsdpcontroller/sensor_proxy.py
@@ -97,8 +97,6 @@ class SensorWatcher(aiokatcp.SensorWatcher):
         `server`. Sensors found in this mapping do not have `prefix` applied.
         The values may also be lists of strings, in which case the sensor
         will be duplicated under each of these names.
-
-        This cannot be combined with `rewrite_readings`.
     close_action
         Defines what to do with the sensors when the connection is closed.
     notify
@@ -124,8 +122,6 @@ class SensorWatcher(aiokatcp.SensorWatcher):
         notify: Optional[Callable[[], Any]] = None,
         filter: Optional[_FilterPredicate] = None,
     ) -> None:
-        if renames is not None and rewrite_readings is not None:
-            raise ValueError("cannot specify both renames and rewrite_readings")
         super().__init__(client, enum_types)
         self.prefix = prefix
         self.renames = renames if renames is not None else {}
@@ -173,23 +169,15 @@ class SensorWatcher(aiokatcp.SensorWatcher):
         for rewritten_name in self.rewrite_name(name):
             self._sensor_removed(rewritten_name)
 
-    def sensor_updated(
-        self, name: str, value: bytes, status: aiokatcp.Sensor.Status, timestamp: float
+    def set_sensor_value(
+        self, sensor: aiokatcp.Sensor, value: Any, status: aiokatcp.Sensor.Status, timestamp: float
     ) -> None:
         if self.rewrite_readings is not None:
-            # We don't allow custom renames, so this is guaranteed to
-            # have one exactly element.
-            rewritten_name = self.rewrite_name(name)[0]
-            sensor = self.sensors[rewritten_name]
-            decoded_value = aiokatcp.decode(sensor.stype, value)
-            reading = aiokatcp.Reading(timestamp=timestamp, status=status, value=decoded_value)
+            reading = aiokatcp.Reading(timestamp=timestamp, status=status, value=value)
             reading = self.rewrite_readings(sensor, reading)
-            # TODO: move this functionality into aiokatcp so that we don't need
-            # to re-encode the value just for aiokatcp to decode it again.
-            value = aiokatcp.encode(reading.value)
-            status = reading.status
-            timestamp = reading.timestamp
-        super().sensor_updated(name, value, status, timestamp)
+            super().set_sensor_value(sensor, reading.value, reading.status, reading.timestamp)
+        else:
+            super().set_sensor_value(sensor, value, status, timestamp)
 
     def batch_stop(self) -> None:
         super().batch_stop()

--- a/src/katsdpcontroller/sensor_proxy.py
+++ b/src/katsdpcontroller/sensor_proxy.py
@@ -80,7 +80,34 @@ class _FilterPredicate(Protocol):
 class SensorWatcher(aiokatcp.SensorWatcher):
     """Mirrors sensors from a client into a server.
 
-    See :class:`SensorProxyClient` for an explanation of the parameters.
+    Parameters
+    ----------
+    client
+        Client to watch
+    server
+        Server to which sensors will be added
+    prefix
+        String prepended to the remote server's sensor names to obtain names
+        used on `server`. These should be unique per `server` to avoid
+        collisions.
+    rewrite_gui_urls
+        If given, a function that is given a ``.gui-urls`` sensor and returns a
+        replacement value. Note that the function is responsible for decoding
+        and encoding between JSON and :class:`bytes`.
+    renames
+        Mapping from the remote server's sensor names to sensor names for
+        `server`. Sensors found in this mapping do not have `prefix` applied.
+        The values may also be lists of strings, in which case the sensor
+        will be duplicated under each of these names.
+    close_action
+        Defines what to do with the sensors when the connection is closed.
+    notify
+        Callback which is called when there are changes to the sensor list.
+        If not specified, it defaults to sending an ``interface-changed``
+        inform to all clients of the server.
+    filter
+        Predicate used to decide which sensors are required. The default is
+        to use all of them. See :meth:`aiokatcp.AbstractSensorWatcher.filter`.
     """
 
     def __init__(
@@ -213,69 +240,6 @@ class SensorWatcher(aiokatcp.SensorWatcher):
                 elif self.close_action == CloseAction.REMOVE:
                     self._sensor_removed(name)
             self.batch_stop()
-
-
-class SensorProxyClient(aiokatcp.Client):
-    """Client that mirrors sensors into a device server.
-
-    Parameters
-    ----------
-    server
-        Server to which sensors will be added
-    prefix
-        String prepended to the remote server's sensor names to obtain names
-        used on `server`. These should be unique per `server` to avoid
-        collisions.
-    rewrite_gui_urls
-        If given, a function that is given a ``.gui-urls`` sensor and returns a
-        replacement value. Note that the function is responsible for decoding
-        and encoding between JSON and :class:`bytes`.
-    renames
-        Mapping from the remote server's sensor names to sensor names for
-        `server`. Sensors found in this mapping do not have `prefix` applied.
-        The values may also be lists of strings, in which case the sensor
-        will be duplicated under each of these names.
-    close_action
-        Defines what to do with the sensors when the connection is closed.
-    notify
-        Callback which is called when there are changes to the sensor list.
-        If not specified, it defaults to sending an ``interface-changed``
-        inform to all clients of the server.
-    filter
-        Predicate used to decide which sensors are required. The default is
-        to use all of them. See :meth:`aiokatcp.AbstractSensorWatcher.filter`.
-    kwargs
-        Passed to the base class
-    """
-
-    def __init__(
-        self,
-        server: aiokatcp.DeviceServer,
-        prefix: str,
-        rewrite_gui_urls: Optional[Callable[[aiokatcp.Sensor], bytes]] = None,
-        enum_types: Sequence[Type[enum.Enum]] = (),
-        renames: Optional[Mapping[str, Union[str, Sequence[str]]]] = None,
-        close_action: CloseAction = CloseAction.REMOVE,
-        notify: Optional[Callable[[], Any]] = None,
-        filter: Optional[_FilterPredicate] = None,
-        **kwargs,
-    ) -> None:
-        super().__init__(**kwargs)
-        watcher = SensorWatcher(
-            self,
-            server,
-            prefix,
-            rewrite_gui_urls,
-            renames=renames,
-            close_action=close_action,
-            notify=notify,
-            filter=filter,
-        )
-        self._synced = watcher.synced
-        self.add_sensor_watcher(watcher)
-
-    async def wait_synced(self) -> None:
-        await self._synced.wait()
 
 
 class PrometheusInfo:

--- a/src/katsdpcontroller/sensor_proxy.py
+++ b/src/katsdpcontroller/sensor_proxy.py
@@ -90,14 +90,16 @@ class SensorWatcher(aiokatcp.SensorWatcher):
         used on `server`. These should be unique per `server` to avoid
         collisions.
     rewrite_gui_urls
-        If given, a function that is given a ``.gui-urls`` sensor and returns a
-        replacement value. Note that the function is responsible for decoding
-        and encoding between JSON and :class:`bytes`.
+        If given, a function that is given a ``.gui-urls`` sensor and new reading
+        and returns a replacement reading. Note that the function is responsible
+        for decoding and encoding between JSON and :class:`bytes`.
     renames
         Mapping from the remote server's sensor names to sensor names for
         `server`. Sensors found in this mapping do not have `prefix` applied.
         The values may also be lists of strings, in which case the sensor
         will be duplicated under each of these names.
+
+        This cannot be combined with `rewrite_gui_urls`.
     close_action
         Defines what to do with the sensors when the connection is closed.
     notify
@@ -114,13 +116,17 @@ class SensorWatcher(aiokatcp.SensorWatcher):
         client: aiokatcp.Client,
         sensors: aiokatcp.SensorSet,
         prefix: str,
-        rewrite_gui_urls: Optional[Callable[[aiokatcp.Sensor], bytes]] = None,
+        rewrite_gui_urls: Optional[
+            Callable[[aiokatcp.Sensor, aiokatcp.Reading], aiokatcp.Reading]
+        ] = None,
         enum_types: Sequence[Type[enum.Enum]] = (),
         renames: Optional[Mapping[str, Union[str, Sequence[str]]]] = None,
         close_action: CloseAction = CloseAction.REMOVE,
         notify: Optional[Callable[[], Any]] = None,
         filter: Optional[_FilterPredicate] = None,
     ) -> None:
+        if renames is not None and rewrite_gui_urls is not None:
+            raise ValueError("cannot specify both renames and rewrite_gui_urls")
         super().__init__(client, enum_types)
         self.prefix = prefix
         self.renames = renames if renames is not None else {}
@@ -155,22 +161,8 @@ class SensorWatcher(aiokatcp.SensorWatcher):
         super().sensor_added(name, description, units, type_name, *args)
         for rewritten_name in self.rewrite_name(name):
             sensor = self.sensors[rewritten_name]
-            if (
-                self.rewrite_gui_urls is not None
-                and sensor.name.endswith(".gui-urls")
-                and sensor.stype is bytes
-            ):
-                new_value = self.rewrite_gui_urls(sensor)
-                sensor = aiokatcp.Sensor(
-                    sensor.stype,
-                    sensor.name,
-                    sensor.description,
-                    sensor.units,
-                    new_value,
-                    sensor.status,
-                )
             self.target_sensors.add(sensor)
-        self._need_notify = True
+            self._need_notify = True
 
     def _sensor_removed(self, name: str) -> None:
         """Like :meth:`sensor_removed`, but takes the rewritten name"""
@@ -185,16 +177,15 @@ class SensorWatcher(aiokatcp.SensorWatcher):
     def sensor_updated(
         self, name: str, value: bytes, status: aiokatcp.Sensor.Status, timestamp: float
     ) -> None:
-        super().sensor_updated(name, value, status, timestamp)
-        for rewritten_name in self.rewrite_name(name):
+        reading = aiokatcp.Reading(timestamp=timestamp, status=status, value=value)
+        if self.rewrite_gui_urls is not None:
+            # We don't allow custom renames, so this is guaranteed to
+            # have one exactly element.
+            rewritten_name = self.rewrite_name(name)[0]
             sensor = self.sensors[rewritten_name]
-            if (
-                self.rewrite_gui_urls is not None
-                and rewritten_name.endswith(".gui-urls")
-                and sensor.stype is bytes
-            ):
-                value = self.rewrite_gui_urls(sensor)
-                self.target_sensors[rewritten_name].set_value(value, status, timestamp)
+            if rewritten_name.endswith(".gui-urls") and sensor.stype is bytes:
+                reading = self.rewrite_gui_urls(sensor, reading)
+        super().sensor_updated(name, reading.value, reading.status, reading.timestamp)
 
     def batch_stop(self) -> None:
         super().batch_stop()

--- a/src/katsdpcontroller/sensor_proxy.py
+++ b/src/katsdpcontroller/sensor_proxy.py
@@ -89,17 +89,16 @@ class SensorWatcher(aiokatcp.SensorWatcher):
         String prepended to the remote server's sensor names to obtain names
         used on `server`. These should be unique per `server` to avoid
         collisions.
-    rewrite_gui_urls
-        If given, a function that is given a ``.gui-urls`` sensor and new reading
-        and returns a replacement reading. Note that the function is responsible
-        for decoding and encoding between JSON and :class:`bytes`.
+    rewrite_readings
+        If given, a function that is given a sensor and new reading from the
+        server, and returns a replacement reading.
     renames
         Mapping from the remote server's sensor names to sensor names for
         `server`. Sensors found in this mapping do not have `prefix` applied.
         The values may also be lists of strings, in which case the sensor
         will be duplicated under each of these names.
 
-        This cannot be combined with `rewrite_gui_urls`.
+        This cannot be combined with `rewrite_readings`.
     close_action
         Defines what to do with the sensors when the connection is closed.
     notify
@@ -116,7 +115,7 @@ class SensorWatcher(aiokatcp.SensorWatcher):
         client: aiokatcp.Client,
         sensors: aiokatcp.SensorSet,
         prefix: str,
-        rewrite_gui_urls: Optional[
+        rewrite_readings: Optional[
             Callable[[aiokatcp.Sensor, aiokatcp.Reading], aiokatcp.Reading]
         ] = None,
         enum_types: Sequence[Type[enum.Enum]] = (),
@@ -125,15 +124,15 @@ class SensorWatcher(aiokatcp.SensorWatcher):
         notify: Optional[Callable[[], Any]] = None,
         filter: Optional[_FilterPredicate] = None,
     ) -> None:
-        if renames is not None and rewrite_gui_urls is not None:
-            raise ValueError("cannot specify both renames and rewrite_gui_urls")
+        if renames is not None and rewrite_readings is not None:
+            raise ValueError("cannot specify both renames and rewrite_readings")
         super().__init__(client, enum_types)
         self.prefix = prefix
         self.renames = renames if renames is not None else {}
         # Note: cannot just be called sensors, because the base class already
         # uses that name for its internal mirror.
         self.target_sensors = sensors
-        self.rewrite_gui_urls = rewrite_gui_urls
+        self.rewrite_readings = rewrite_readings
         self.close_action = close_action
         if notify is not None:
             self.notify = notify
@@ -177,15 +176,20 @@ class SensorWatcher(aiokatcp.SensorWatcher):
     def sensor_updated(
         self, name: str, value: bytes, status: aiokatcp.Sensor.Status, timestamp: float
     ) -> None:
-        reading = aiokatcp.Reading(timestamp=timestamp, status=status, value=value)
-        if self.rewrite_gui_urls is not None:
+        if self.rewrite_readings is not None:
             # We don't allow custom renames, so this is guaranteed to
             # have one exactly element.
             rewritten_name = self.rewrite_name(name)[0]
             sensor = self.sensors[rewritten_name]
-            if rewritten_name.endswith(".gui-urls") and sensor.stype is bytes:
-                reading = self.rewrite_gui_urls(sensor, reading)
-        super().sensor_updated(name, reading.value, reading.status, reading.timestamp)
+            decoded_value = aiokatcp.decode(sensor.stype, value)
+            reading = aiokatcp.Reading(timestamp=timestamp, status=status, value=decoded_value)
+            reading = self.rewrite_readings(sensor, reading)
+            # TODO: move this functionality into aiokatcp so that we don't need
+            # to re-encode the value just for aiokatcp to decode it again.
+            value = aiokatcp.encode(reading.value)
+            status = reading.status
+            timestamp = reading.timestamp
+        super().sensor_updated(name, value, status, timestamp)
 
     def batch_stop(self) -> None:
         super().batch_stop()

--- a/src/katsdpcontroller/sensor_proxy.py
+++ b/src/katsdpcontroller/sensor_proxy.py
@@ -77,14 +77,14 @@ class _FilterPredicate(Protocol):
 
 
 class SensorWatcher(aiokatcp.SensorWatcher):
-    """Mirrors sensors from a client into a server.
+    """Mirrors sensors from a client into a sensor set.
 
     Parameters
     ----------
     client
         Client to watch
-    server
-        Server to which sensors will be added
+    sensors
+        Sensor set which will be updated
     prefix
         String prepended to the remote server's sensor names to obtain names
         used on `server`. These should be unique per `server` to avoid
@@ -107,12 +107,15 @@ class SensorWatcher(aiokatcp.SensorWatcher):
     filter
         Predicate used to decide which sensors are required. The default is
         to use all of them. See :meth:`aiokatcp.AbstractSensorWatcher.filter`.
+    orig_sensors
+        If provided, it will be populated similarly to `sensors`, except that
+        `rewrite_gui_urls` will not be applied.
     """
 
     def __init__(
         self,
         client: aiokatcp.Client,
-        server: aiokatcp.DeviceServer,
+        sensors: aiokatcp.SensorSet,
         prefix: str,
         rewrite_gui_urls: Optional[Callable[[aiokatcp.Sensor], bytes]] = None,
         enum_types: Sequence[Type[enum.Enum]] = (),
@@ -120,16 +123,18 @@ class SensorWatcher(aiokatcp.SensorWatcher):
         close_action: CloseAction = CloseAction.REMOVE,
         notify: Optional[Callable[[], Any]] = None,
         filter: Optional[_FilterPredicate] = None,
+        orig_sensors: Optional[aiokatcp.SensorSet] = None,
     ) -> None:
         super().__init__(client, enum_types)
         self.prefix = prefix
         self.renames = renames if renames is not None else {}
-        self.server = server
+        # Note: cannot just be called sensors, because the base class already
+        # uses that name for its internal mirror.
+        self.target_sensors = sensors
         # We keep track of the sensors after name rewriting but prior to gui-url rewriting
-        self.orig_sensors: aiokatcp.SensorSet
-        try:
-            self.orig_sensors = self.server.orig_sensors  # type: ignore
-        except AttributeError:
+        if orig_sensors is not None:
+            self.orig_sensors = orig_sensors
+        else:
             self.orig_sensors = aiokatcp.SensorSet()
 
         self.rewrite_gui_urls = rewrite_gui_urls
@@ -175,12 +180,12 @@ class SensorWatcher(aiokatcp.SensorWatcher):
                     new_value,
                     sensor.status,
                 )
-            self.server.sensors.add(sensor)
+            self.target_sensors.add(sensor)
         self._need_notify = True
 
     def _sensor_removed(self, name: str) -> None:
         """Like :meth:`sensor_removed`, but takes the rewritten name"""
-        self.server.sensors.pop(name, None)
+        self.target_sensors.pop(name, None)
         self.orig_sensors.pop(name, None)
         self._need_notify = True
 
@@ -201,7 +206,7 @@ class SensorWatcher(aiokatcp.SensorWatcher):
                 and sensor.stype is bytes
             ):
                 value = self.rewrite_gui_urls(sensor)
-                self.server.sensors[rewritten_name].set_value(value, status, timestamp)
+                self.target_sensors[rewritten_name].set_value(value, status, timestamp)
 
     def batch_stop(self) -> None:
         super().batch_stop()
@@ -234,7 +239,7 @@ class SensorWatcher(aiokatcp.SensorWatcher):
             self.batch_start()
             for name in self.sensors.keys():
                 if self.close_action == CloseAction.UNREACHABLE:
-                    self._mark_unreachable(self.server.sensors[name])
+                    self._mark_unreachable(self.target_sensors[name])
                     self._mark_unreachable(self.orig_sensors[name])
                 elif self.close_action == CloseAction.REMOVE:
                     self._sensor_removed(name)

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -510,17 +510,18 @@ class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
                     self.name,
                 )
                 prefix = self.name + "."
-                self.katcp_connection = sensor_proxy.SensorProxyClient(
+                self.katcp_connection = aiokatcp.Client(self.address, self.ports["port"])
+                sensor_watcher = sensor_proxy.SensorWatcher(
+                    self.katcp_connection,
                     self.sdp_controller,
                     prefix,
                     renames=self.logical_node.sensor_renames,
                     close_action=sensor_proxy.CloseAction.UNREACHABLE,
-                    host=self.address,
-                    port=self.ports["port"],
                     notify=self.subarray_product.notify_sensors_changed,
                 )
+                self.katcp_connection.add_sensor_watcher(sensor_watcher)
                 try:
-                    await self.katcp_connection.wait_synced()
+                    await sensor_watcher.synced.wait()
                     self.logger.info(
                         "Connected to %s:%s for node %s",
                         self.address,

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -513,7 +513,7 @@ class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
                 self.katcp_connection = aiokatcp.Client(self.address, self.ports["port"])
                 sensor_watcher = sensor_proxy.SensorWatcher(
                     self.katcp_connection,
-                    self.sdp_controller,
+                    self.sdp_controller.sensors,
                     prefix,
                     renames=self.logical_node.sensor_renames,
                     close_action=sensor_proxy.CloseAction.UNREACHABLE,

--- a/src/katsdpcontroller/tasks.py
+++ b/src/katsdpcontroller/tasks.py
@@ -511,17 +511,30 @@ class ProductPhysicalTaskMixin(scheduler.PhysicalNode):
                 )
                 prefix = self.name + "."
                 self.katcp_connection = aiokatcp.Client(self.address, self.ports["port"])
-                sensor_watcher = sensor_proxy.SensorWatcher(
-                    self.katcp_connection,
-                    self.sdp_controller.sensors,
-                    prefix,
-                    renames=self.logical_node.sensor_renames,
-                    close_action=sensor_proxy.CloseAction.UNREACHABLE,
-                    notify=self.subarray_product.notify_sensors_changed,
-                )
-                self.katcp_connection.add_sensor_watcher(sensor_watcher)
+                sensor_watchers = [
+                    # Main sensor watcher, that mirrors into the device server's sensors
+                    sensor_proxy.SensorWatcher(
+                        self.katcp_connection,
+                        self.sdp_controller.sensors,
+                        prefix,
+                        renames=self.logical_node.sensor_renames,
+                        close_action=sensor_proxy.CloseAction.UNREACHABLE,
+                        notify=self.subarray_product.notify_sensors_changed,
+                    ),
+                    # Sensor watcher that bypasses renames; these are available
+                    # for aggregate sensors to aggregate for example.
+                    sensor_proxy.SensorWatcher(
+                        self.katcp_connection,
+                        self.sdp_controller.task_sensors,
+                        prefix,
+                        close_action=sensor_proxy.CloseAction.UNREACHABLE,
+                    ),
+                ]
+                for sensor_watcher in sensor_watchers:
+                    self.katcp_connection.add_sensor_watcher(sensor_watcher)
                 try:
-                    await sensor_watcher.synced.wait()
+                    for sensor_watcher in sensor_watchers:
+                        await sensor_watcher.synced.wait()
                     self.logger.info(
                         "Connected to %s:%s for node %s",
                         self.address,

--- a/src/katsdpcontroller/web.py
+++ b/src/katsdpcontroller/web.py
@@ -321,7 +321,11 @@ def gui_label(gui: dict) -> str:
 
 
 def rewrite_gui_urls(external_url: yarl.URL, sensor: Sensor, reading: Reading) -> Reading:
-    if reading.status != Sensor.Status.NOMINAL:
+    if (
+        not sensor.name.endswith(".gui-urls")
+        or sensor.stype is not bytes
+        or reading.status != Sensor.Status.NOMINAL
+    ):
         return reading
     parts = sensor.name.split(".")
     product = parts[0]

--- a/src/katsdpcontroller/web.py
+++ b/src/katsdpcontroller/web.py
@@ -320,16 +320,16 @@ def gui_label(gui: dict) -> str:
     return re.sub(r"[^a-z0-9_-]", "-", gui["title"].lower())
 
 
-def rewrite_gui_urls(external_url: yarl.URL, sensor: Sensor) -> bytes:
-    if sensor.status != Sensor.Status.NOMINAL:
-        return sensor.value
+def rewrite_gui_urls(external_url: yarl.URL, sensor: Sensor, reading: Reading) -> Reading:
+    if reading.status != Sensor.Status.NOMINAL:
+        return reading
     parts = sensor.name.split(".")
     product = parts[0]
     service = ".".join(parts[1:-1])
     if service == "":
         service = "product"
     try:
-        value = json.loads(sensor.value)
+        value = json.loads(reading.value)
         for gui in value:
             label = gui_label(gui)
             prefix = f"gui/{product}/{service}/{label}/"
@@ -342,10 +342,12 @@ def rewrite_gui_urls(external_url: yarl.URL, sensor: Sensor) -> bytes:
             if orig_path.startswith(prefix):
                 prefix = orig_path
             gui["href"] = str(external_url / prefix)
-        return json.dumps(value).encode()
+        return Reading(
+            value=json.dumps(value).encode(), timestamp=reading.timestamp, status=reading.status
+        )
     except (TypeError, ValueError, KeyError) as exc:
         logger.warning("Invalid gui-url in %s: %s", sensor.name, exc)
-        return sensor.value
+        return reading
 
 
 def make_app(

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -932,7 +932,7 @@ class TestControllerInterface(BaseTestController):
         # Check that the engine's sensors have been modified appropriately
         await assert_sensor_value(
             client,
-            "gpucbf_baseline_correlation_products.1.xeng-clip-cnt",
+            "gpucbf_baseline_correlation_products.1.rx.timestamp",
             mock.ANY,
             status=Sensor.Status.UNREACHABLE,
         )

--- a/test/test_product_controller.py
+++ b/test/test_product_controller.py
@@ -58,7 +58,10 @@ import pymesos
 import pytest
 import yarl
 from addict import Dict
-from aiokatcp import FailReply, Message, Sensor
+
+# Note: use Client from this module when you need to refer to the real
+# class. aiokatcp.Client may be mocked.
+from aiokatcp import Client, FailReply, Message, Sensor
 from aioresponses import aioresponses
 from katsdptelstate.endpoint import Endpoint
 from prometheus_client import CollectorRegistry
@@ -463,7 +466,7 @@ class BaseTestController:
     @pytest.fixture
     async def mc_client(self, mc_server) -> AsyncGenerator[aiokatcp.Client, None]:
         mc_address = device_server_sockname(mc_server)
-        mc_client = await aiokatcp.Client.connect(mc_address[0], mc_address[1])
+        mc_client = await Client.connect(mc_address[0], mc_address[1])
         yield mc_client
         mc_client.close()
         await mc_client.wait_closed()
@@ -508,7 +511,7 @@ class BaseTestController:
     @pytest.fixture
     async def client(self, server: DeviceServer) -> AsyncGenerator[aiokatcp.Client, None]:
         bind_address = device_server_sockname(server)
-        client = await aiokatcp.Client.connect(bind_address[0], bind_address[1])
+        client = await Client.connect(bind_address[0], bind_address[1])
         yield client
         client.close()
         await client.wait_closed()
@@ -1096,10 +1099,8 @@ class TestController(BaseTestController):
         used to block it from completing.
         """
         # grab the mock
-        sensor_proxy_client = sensor_proxy.SensorProxyClient.return_value  # type: ignore
-        return DelayedManager(
-            client.request(name, *args), sensor_proxy_client.request, ([], []), cancelled
-        )
+        task_client = aiokatcp.Client.return_value  # type: ignore
+        return DelayedManager(client.request(name, *args), task_client.request, ([], []), cancelled)
 
     def _capture_init_slow(
         self, client: aiokatcp.Client, capture_block: str, cancelled: bool = False
@@ -1125,10 +1126,10 @@ class TestController(BaseTestController):
         product-configure in progress.
         """
         # grab the mock
-        sensor_proxy_client = sensor_proxy.SensorProxyClient.return_value  # type: ignore
+        watcher = sensor_proxy.SensorWatcher.return_value  # type: ignore
         return DelayedManager(
             client.request(*self._configure_args(subarray_product)),
-            sensor_proxy_client.wait_synced,
+            watcher.synced.wait,
             None,
             cancelled,
         )
@@ -1163,20 +1164,24 @@ class TestController(BaseTestController):
         return DummyClient()
 
     @pytest.fixture(autouse=True)
-    def sensor_proxy_client(self, dummy_client: DummyClient, mocker) -> mock.MagicMock:
+    def task_client(self, dummy_client: DummyClient, mocker) -> mock.MagicMock:
         # Future that is already resolved with no return value
         done_future: asyncio.Future[None] = asyncio.Future()
         done_future.set_result(None)
 
-        sensor_proxy_client_class = mocker.patch(
-            "katsdpcontroller.sensor_proxy.SensorProxyClient", autospec=True
-        )
-        sensor_proxy_client = sensor_proxy_client_class.return_value
-        sensor_proxy_client.wait_connected.return_value = done_future
-        sensor_proxy_client.wait_synced.return_value = done_future
-        sensor_proxy_client.wait_closed.return_value = done_future
-        sensor_proxy_client.request.side_effect = dummy_client.request
-        return sensor_proxy_client
+        client_class = mocker.patch("aiokatcp.Client", autospec=True)
+        client = client_class.return_value
+        client.wait_connected.return_value = done_future
+        client.wait_closed.return_value = done_future
+        client.request.side_effect = dummy_client.request
+
+        watcher_class = mocker.patch("katsdpcontroller.sensor_proxy.SensorWatcher", autospec=True)
+        watcher = watcher_class.return_value
+        # autospec can't see that SensorWatcher.__init__ creates this attribute
+        watcher.synced = mock.MagicMock(spec=asyncio.Event)
+        watcher.synced.wait.return_value = done_future
+
+        return client
 
     @pytest.fixture
     def server_kwargs(self, sched: mock.MagicMock) -> dict:
@@ -1569,7 +1574,7 @@ class TestController(BaseTestController):
         assert server.product is None
 
     async def test_capture_init(
-        self, client: aiokatcp.Client, server: DeviceServer, sensor_proxy_client
+        self, client: aiokatcp.Client, server: DeviceServer, task_client: mock.MagicMock
     ) -> None:
         """Checks that capture-init succeeds and sets appropriate state"""
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
@@ -1583,8 +1588,7 @@ class TestController(BaseTestController):
         # multiple times, depending on the number of instances of each child.
         # We thus collapse them into groups of equal calls and don't worry
         # about the number, which would otherwise make the test fragile.
-        katcp_client = sensor_proxy_client
-        sorted_calls = sorted(katcp_client.request.mock_calls, key=lambda call: call[1])
+        sorted_calls = sorted(task_client.request.mock_calls, key=lambda call: call[1])
         grouped_calls = [k for k, g in itertools.groupby(sorted_calls)]
         expected_calls = [
             mock.call("capture-init", CAPTURE_BLOCK),
@@ -1647,7 +1651,7 @@ class TestController(BaseTestController):
         client: aiokatcp.Client,
         server: DeviceServer,
         dummy_client: DummyClient,
-        sensor_proxy_client,
+        task_client: mock.MagicMock,
     ) -> None:
         """Capture-done fails on some task"""
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
@@ -1655,11 +1659,10 @@ class TestController(BaseTestController):
         reply, informs = await client.request("capture-init", CAPTURE_BLOCK)
         await assert_request_fails(client, "capture-done")
         # check that the subsequent transitions still run
-        katcp_client = sensor_proxy_client
-        katcp_client.request.assert_called_with("write-meta", CAPTURE_BLOCK, True)
+        task_client.request.assert_called_with("write-meta", CAPTURE_BLOCK, True)
         # check that postprocessing transitions still run.
         await exhaust_callbacks()
-        katcp_client.request.assert_called_with("write-meta", CAPTURE_BLOCK, False)
+        task_client.request.assert_called_with("write-meta", CAPTURE_BLOCK, False)
         # check that the subarray is in an appropriate state
         product = server.product
         assert product is not None
@@ -1729,7 +1732,7 @@ class TestController(BaseTestController):
         self,
         client: aiokatcp.Client,
         server: DeviceServer,
-        sensor_proxy_client,
+        task_client: mock.MagicMock,
         dummy_sched: DummyScheduler,
     ) -> None:
         """Checks that capture-done succeeds and sets appropriate state"""
@@ -1744,14 +1747,13 @@ class TestController(BaseTestController):
         assert not product.async_busy
         assert product.state == ProductState.IDLE
         # Check that the graph transitions succeeded
-        katcp_client = sensor_proxy_client
-        katcp_client.request.assert_any_call("capture-done")
-        katcp_client.request.assert_called_with("write-meta", CAPTURE_BLOCK, True)
+        task_client.request.assert_any_call("capture-done")
+        task_client.request.assert_called_with("write-meta", CAPTURE_BLOCK, True)
         # Now simulate cal finishing with the capture block
         cal_sensor.value = b"{}"
         await exhaust_callbacks()
         # write-meta full dump must be last, hence assert_called_with not assert_any_call
-        katcp_client.request.assert_called_with("write-meta", CAPTURE_BLOCK, False)
+        task_client.request.assert_called_with("write-meta", CAPTURE_BLOCK, False)
 
         # Check that postprocessing ran and didn't fail
         assert product.capture_blocks == {}
@@ -1778,7 +1780,7 @@ class TestController(BaseTestController):
         self,
         client: aiokatcp.Client,
         server: DeviceServer,
-        sensor_proxy_client,
+        task_client: mock.MagicMock,
         failfunc: Callable[[SubarrayProduct], None],
     ) -> None:
         await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
@@ -1792,28 +1794,25 @@ class TestController(BaseTestController):
         # In the background it will terminate the capture block
         await exhaust_callbacks()
         assert product.capture_blocks == {}
-        katcp_client = sensor_proxy_client
-        katcp_client.request.assert_called_with("write-meta", CAPTURE_BLOCK, False)
+        task_client.request.assert_called_with("write-meta", CAPTURE_BLOCK, False)
 
     async def test_process_dies_while_capturing(
-        self, client: aiokatcp.Client, server: DeviceServer, sensor_proxy_client
+        self, client: aiokatcp.Client, server: DeviceServer, task_client: mock.MagicMock
     ) -> None:
-        await self._test_failure_while_capturing(
-            client, server, sensor_proxy_client, self._ingest_died
-        )
+        await self._test_failure_while_capturing(client, server, task_client, self._ingest_died)
 
     async def test_bad_device_status_while_capturing(
-        self, client: aiokatcp.Client, server: DeviceServer, sensor_proxy_client
+        self, client: aiokatcp.Client, server: DeviceServer, task_client: mock.MagicMock
     ) -> None:
         await self._test_failure_while_capturing(
             client,
             server,
-            sensor_proxy_client,
+            task_client,
             functools.partial(self._ingest_bad_device_status, server),
         )
 
     async def test_capture_done_process_dies(
-        self, client: aiokatcp.Client, server: DeviceServer, sensor_proxy_client
+        self, client: aiokatcp.Client, server: DeviceServer, task_client: mock.MagicMock
     ) -> None:
         """Capture-done fails if a child dies half-way through."""
         await client.request("product-configure", SUBARRAY_PRODUCT, CONFIG)
@@ -1829,21 +1828,20 @@ class TestController(BaseTestController):
         # writeback occurred.
         assert product.state == ProductState.ERROR
         await exhaust_callbacks()
-        katcp_client = sensor_proxy_client
-        katcp_client.request.assert_called_with("write-meta", CAPTURE_BLOCK, False)
+        task_client.request.assert_called_with("write-meta", CAPTURE_BLOCK, False)
         assert product.capture_blocks == {}
 
     async def test_deconfigure_on_stop(
-        self, client: aiokatcp.Client, server: DeviceServer, sensor_proxy_client, sched
+        self, client: aiokatcp.Client, server: DeviceServer, task_client: mock.MagicMock, sched
     ) -> None:
         """Calling stop will force-deconfigure existing subarrays, even if capturing."""
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await client.request("capture-init", CAPTURE_BLOCK)
         await server.stop()
 
-        sensor_proxy_client.request.assert_any_call("capture-done")
+        task_client.request.assert_any_call("capture-done")
         # Forced deconfigure, so we only get the light dump
-        sensor_proxy_client.request.assert_called_with("write-meta", mock.ANY, True)
+        task_client.request.assert_called_with("write-meta", mock.ANY, True)
         sched.kill.assert_called_with(mock.ANY, capture_blocks=mock.ANY, force=True)
 
     async def test_deconfigure_on_stop_busy(
@@ -1970,7 +1968,7 @@ class TestController(BaseTestController):
         await assert_request_fails(client, *katcp_request)
 
     async def test_gain_single(
-        self, client: aiokatcp.Client, dummy_client: DummyClient, sensor_proxy_client
+        self, client: aiokatcp.Client, dummy_client: DummyClient, task_client: mock.MagicMock
     ) -> None:
         """Test gain with a single gain to apply to all channels."""
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
@@ -1979,14 +1977,11 @@ class TestController(BaseTestController):
             "gain", "gpucbf_antenna_channelised_voltage", "gpucbf_m901h", "1+2j"
         )
         # TODO: this doesn't check that it goes to the correct node
-        katcp_client = sensor_proxy_client
-        katcp_client.request.assert_any_call(
-            "gain", "gpucbf_antenna_channelised_voltage", 1, "1+2j"
-        )
+        task_client.request.assert_any_call("gain", "gpucbf_antenna_channelised_voltage", 1, "1+2j")
         assert reply == [b"1+2j"]
 
     async def test_gain_multi(
-        self, client: aiokatcp.Client, dummy_client: DummyClient, sensor_proxy_client
+        self, client: aiokatcp.Client, dummy_client: DummyClient, task_client: mock.MagicMock
     ) -> None:
         """Test gain with a different gain for each channel."""
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
@@ -1996,44 +1991,48 @@ class TestController(BaseTestController):
             "gain", "gpucbf_antenna_channelised_voltage", "gpucbf_m901h", *gains
         )
         # TODO: this doesn't check that it goes to the correct node
-        katcp_client = sensor_proxy_client
-        katcp_client.request.assert_any_call(
+        task_client.request.assert_any_call(
             "gain", "gpucbf_antenna_channelised_voltage", 1, *[g.decode() for g in gains]
         )
         assert reply == gains
 
-    async def test_gain_all_single(self, client: aiokatcp.Client, sensor_proxy_client) -> None:
+    async def test_gain_all_single(
+        self, client: aiokatcp.Client, task_client: mock.MagicMock
+    ) -> None:
         """Test gain-all with a single gain to apply to all channels."""
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await client.request("gain-all", "gpucbf_antenna_channelised_voltage", "1+2j")
         # TODO: this doesn't check that it goes to the correct nodes
-        katcp_client = sensor_proxy_client
-        katcp_client.request.assert_any_call(
+        task_client.request.assert_any_call(
             "gain-all", "gpucbf_antenna_channelised_voltage", "1+2j"
         )
 
-    async def test_gain_all_multi(self, client: aiokatcp.Client, sensor_proxy_client) -> None:
+    async def test_gain_all_multi(
+        self, client: aiokatcp.Client, task_client: mock.MagicMock
+    ) -> None:
         """Test gain-all with a different gain for each channel."""
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
         gains = [b"%d+2j" % i for i in range(4096)]
         await client.request("gain-all", "gpucbf_antenna_channelised_voltage", *gains)
         # TODO: this doesn't check that it goes to the correct nodes
-        katcp_client = sensor_proxy_client
-        katcp_client.request.assert_any_call(
+        task_client.request.assert_any_call(
             "gain-all", "gpucbf_antenna_channelised_voltage", *[g.decode() for g in gains]
         )
 
-    async def test_gain_all_default(self, client: aiokatcp.Client, sensor_proxy_client) -> None:
+    async def test_gain_all_default(
+        self, client: aiokatcp.Client, task_client: mock.MagicMock
+    ) -> None:
         """Test setting gains to default with gain-all."""
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await client.request("gain-all", "gpucbf_antenna_channelised_voltage", "default")
         # TODO: this doesn't check that it goes to the correct nodes
-        katcp_client = sensor_proxy_client
-        katcp_client.request.assert_any_call(
+        task_client.request.assert_any_call(
             "gain-all", "gpucbf_antenna_channelised_voltage", "default"
         )
 
-    async def test_delays_success(self, client: aiokatcp.Client, sensor_proxy_client) -> None:
+    async def test_delays_success(
+        self, client: aiokatcp.Client, task_client: mock.MagicMock
+    ) -> None:
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await client.request(
             "delays",
@@ -2044,13 +2043,12 @@ class TestController(BaseTestController):
             "0,1:0,0",
             "0,1:0,1",
         )
-        katcp_client = sensor_proxy_client
         # TODO: this doesn't check that the requests are going to the correct
         # nodes.
-        katcp_client.request.assert_any_call(
+        task_client.request.assert_any_call(
             "delays", "gpucbf_antenna_channelised_voltage", 1234567890.0, "0,0:0,0", "0,0:0,1"
         )
-        katcp_client.request.assert_any_call(
+        task_client.request.assert_any_call(
             "delays", "gpucbf_antenna_channelised_voltage", 1234567890.0, "0,1:0,0", "0,1:0,1"
         )
 
@@ -2062,7 +2060,7 @@ class TestController(BaseTestController):
         assert informs[0].arguments[2].decode() == desired_state
 
     async def test_capture_start(
-        self, client: aiokatcp.Client, server: DeviceServer, sensor_proxy_client
+        self, client: aiokatcp.Client, server: DeviceServer, task_client: mock.MagicMock
     ) -> None:
         """Test capture-start in the success case."""
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
@@ -2085,29 +2083,27 @@ class TestController(BaseTestController):
 
         await self._verify_capture_call(client, "gpucbf_baseline_correlation_products", "up")
         await self._verify_capture_call(client, "gpucbf_tied_array_resampled_voltage", "up")
-        katcp_client = sensor_proxy_client
         # TODO: this doesn't check that the requests are going to the correct
         # nodes.
-        katcp_client.request.assert_any_call(
+        task_client.request.assert_any_call(
             "capture-start", "gpucbf_baseline_correlation_products", 12345
         )
         # NOTE: Underlying V-engine does not require a stream-name in the
         # capture-start request.
-        katcp_client.request.assert_any_call("capture-start", 23456)
+        task_client.request.assert_any_call("capture-start", 23456)
 
-    async def test_capture_stop(self, client: aiokatcp.Client, sensor_proxy_client) -> None:
+    async def test_capture_stop(self, client: aiokatcp.Client, task_client: mock.MagicMock) -> None:
         # Note: most of the code for capture-stop is shared with capture-start,
         # so the testing does not need to be as thorough.
         await self._configure_subarray(client, SUBARRAY_PRODUCT)
         await client.request("capture-stop", "gpucbf_baseline_correlation_products")
         await client.request("capture-stop", "gpucbf_tied_array_resampled_voltage")
-        katcp_client = sensor_proxy_client
         # TODO: this doesn't check that the requests are going to the correct
         # nodes.
-        katcp_client.request.assert_any_call("capture-stop", "gpucbf_baseline_correlation_products")
+        task_client.request.assert_any_call("capture-stop", "gpucbf_baseline_correlation_products")
         # TODO: Problem is FakeVgpuDeviceServer doesn't use stream-name
         # This is not the most robust assertion
-        katcp_client.request.assert_called_with("capture-stop")
+        task_client.request.assert_called_with("capture-stop")
         # Check that the state changed to down in capture-list
         await self._verify_capture_call(client, "gpucbf_baseline_correlation_products", "down")
         await self._verify_capture_call(client, "gpucbf_tied_array_resampled_voltage", "down")
@@ -2198,7 +2194,7 @@ class TestResources:
     @pytest.fixture
     async def mc_client(self, mc_server) -> AsyncGenerator[aiokatcp.Client, None]:
         mc_address = device_server_sockname(mc_server)
-        mc_client = await aiokatcp.Client.connect(mc_address[0], mc_address[1])
+        mc_client = await Client.connect(mc_address[0], mc_address[1])
         yield mc_client
         mc_client.close()
         await mc_client.wait_closed()

--- a/test/test_sensor_proxy.py
+++ b/test/test_sensor_proxy.py
@@ -28,7 +28,6 @@ import asyncio
 import enum
 import functools
 from typing import Any, AsyncGenerator, Dict, Mapping, Optional, Tuple
-from unittest import mock
 
 import aiokatcp
 import pytest
@@ -102,10 +101,8 @@ class FutureObserver:
 @pytest.mark.timeout(5)
 class TestSensorWatcher:
     @pytest.fixture
-    def mirror(self, mocker) -> mock.MagicMock:
-        mirror = mocker.create_autospec(aiokatcp.DeviceServer, instance=True)
-        mirror.sensors = aiokatcp.SensorSet()
-        return mirror
+    def mirror(self) -> aiokatcp.SensorSet:
+        return aiokatcp.SensorSet()
 
     @pytest.fixture
     async def server(self) -> AsyncGenerator[DummyServer, None]:
@@ -120,7 +117,7 @@ class TestSensorWatcher:
 
     @pytest.fixture(autouse=True)
     async def client_and_watcher(
-        self, mirror, server: DummyServer, close_action: CloseAction
+        self, mirror: aiokatcp.SensorSet, server: DummyServer, close_action: CloseAction
     ) -> AsyncGenerator[Tuple[aiokatcp.Client, SensorWatcher], None]:
         port = device_server_sockname(server)[1]
         client = aiokatcp.Client("127.0.0.1", port)
@@ -149,7 +146,7 @@ class TestSensorWatcher:
     def watcher(self, client_and_watcher: Tuple[aiokatcp.Client, SensorWatcher]) -> SensorWatcher:
         return client_and_watcher[1]
 
-    def _check_sensors(self, mirror, server: DummyServer) -> None:
+    def _check_sensors(self, mirror: aiokatcp.SensorSet, server: DummyServer) -> None:
         """Compare the upstream sensors against the mirror"""
         for sensor in server.sensors.values():
             qualnames = ["prefix-" + sensor.name]
@@ -158,8 +155,8 @@ class TestSensorWatcher:
             elif sensor.name == "broadcast-sensor":
                 qualnames = ["copy01-broadcast-sensor", "copy02-broadcast-sensor"]
             for qualname in qualnames:
-                assert qualname in mirror.sensors
-                sensor2 = mirror.sensors[qualname]
+                assert qualname in mirror
+                sensor2 = mirror[qualname]
                 assert sensor.description == sensor2.description
                 assert sensor.type_name == sensor2.type_name
                 assert sensor.units == sensor2.units
@@ -170,7 +167,7 @@ class TestSensorWatcher:
                 assert sensor.timestamp == sensor2.timestamp
                 assert sensor.status == sensor2.status
         # Check that we don't have any we shouldn't
-        for sensor2 in mirror.sensors.values():
+        for sensor2 in mirror.values():
             assert sensor2.name.startswith("prefix-") or sensor2.name in {
                 "custom-bytes-sensor",
                 "copy01-broadcast-sensor",
@@ -178,25 +175,31 @@ class TestSensorWatcher:
             }
             base_name = sensor2.name[7:]
             assert base_name in server.sensors
-        assert "prefix-bytes-sensor" not in mirror.sensors
+        assert "prefix-bytes-sensor" not in mirror
 
-    async def test_init(self, mirror, server: DummyServer) -> None:
+    async def test_init(self, mirror: aiokatcp.SensorSet, server: DummyServer) -> None:
         self._check_sensors(mirror, server)
 
-    async def _set(self, mirror, server: DummyServer, name: str, value: Any, **kwargs) -> None:
+    async def _set(
+        self, mirror: aiokatcp.SensorSet, server: DummyServer, name: str, value: Any, **kwargs
+    ) -> None:
         """Set a sensor on the server and wait for the mirror to observe it"""
         observer = FutureObserver()
-        mirror.sensors["prefix-" + name].attach(observer)
+        mirror["prefix-" + name].attach(observer)
         server.sensors[name].set_value(value, **kwargs)
         await observer.future
-        mirror.sensors["prefix-" + name].detach(observer)
+        mirror["prefix-" + name].detach(observer)
 
-    async def test_set_value(self, mirror, server: DummyServer) -> None:
+    async def test_set_value(self, mirror: aiokatcp.SensorSet, server: DummyServer) -> None:
         await self._set(mirror, server, "int-sensor", 2, timestamp=123456790.0)
         self._check_sensors(mirror, server)
 
     async def test_add_sensor(
-        self, mirror, server: DummyServer, client: aiokatcp.Client, watcher: SensorWatcher
+        self,
+        mirror: aiokatcp.SensorSet,
+        server: DummyServer,
+        client: aiokatcp.Client,
+        watcher: SensorWatcher,
     ) -> None:
         server.sensors.add(Sensor(int, "another", "another sensor", "", 234))
         # Rather than having server send an interface-changed inform, we invoke
@@ -207,7 +210,11 @@ class TestSensorWatcher:
         self._check_sensors(mirror, server)
 
     async def test_remove_sensor(
-        self, mirror, server: DummyServer, client: aiokatcp.Client, watcher: SensorWatcher
+        self,
+        mirror: aiokatcp.SensorSet,
+        server: DummyServer,
+        client: aiokatcp.Client,
+        watcher: SensorWatcher,
     ) -> None:
         del server.sensors["int-sensor"]
         changed = aiokatcp.Message.inform("interface-changed", b"sensor-list")
@@ -216,7 +223,11 @@ class TestSensorWatcher:
         self._check_sensors(mirror, server)
 
     async def test_replace_sensor(
-        self, mirror, server: DummyServer, client: aiokatcp.Client, watcher: SensorWatcher
+        self,
+        mirror: aiokatcp.SensorSet,
+        server: DummyServer,
+        client: aiokatcp.Client,
+        watcher: SensorWatcher,
     ) -> None:
         server.sensors.add(Sensor(bool, "int-sensor", "Replaced by bool"))
         changed = aiokatcp.Message.inform("interface-changed", b"sensor-list")
@@ -225,7 +236,11 @@ class TestSensorWatcher:
         self._check_sensors(mirror, server)
 
     async def test_reconnect(
-        self, mirror, server: DummyServer, client: aiokatcp.Client, watcher: SensorWatcher
+        self,
+        mirror: aiokatcp.SensorSet,
+        server: DummyServer,
+        client: aiokatcp.Client,
+        watcher: SensorWatcher,
     ) -> None:
         # Cheat: the client will disconnect if given a #disconnect inform, and
         # we don't actually need to kill the server.
@@ -234,16 +249,20 @@ class TestSensorWatcher:
         await watcher.synced.wait()
         self._check_sensors(mirror, server)
 
-    async def test_close_action_remove(self, client: aiokatcp.Client, mirror) -> None:
+    async def test_close_action_remove(
+        self, client: aiokatcp.Client, mirror: aiokatcp.SensorSet
+    ) -> None:
         client.close()
-        assert list(mirror.sensors) == []
+        assert list(mirror) == []
 
     @pytest.mark.parametrize("close_action", [CloseAction.UNREACHABLE])
-    async def test_close_action_unreachable(self, client: aiokatcp.Client, mirror) -> None:
+    async def test_close_action_unreachable(
+        self, client: aiokatcp.Client, mirror: aiokatcp.SensorSet
+    ) -> None:
         client.close()
-        assert mirror.sensors["custom-bytes-sensor"].status == Sensor.Status.UNREACHABLE
-        assert mirror.sensors["prefix-device-status"].status == Sensor.Status.ERROR
-        assert mirror.sensors["prefix-device-status"].value.value == b"fail"
+        assert mirror["custom-bytes-sensor"].status == Sensor.Status.UNREACHABLE
+        assert mirror["prefix-device-status"].status == Sensor.Status.ERROR
+        assert mirror["prefix-device-status"].value.value == b"fail"
 
 
 class TestPrometheusWatcher:

--- a/test/test_sensor_proxy.py
+++ b/test/test_sensor_proxy.py
@@ -27,7 +27,7 @@ Still TODO:
 import asyncio
 import enum
 import functools
-from typing import Any, AsyncGenerator, Dict, Mapping, Optional, Tuple
+from typing import Any, AsyncGenerator, Callable, Dict, Mapping, Optional, Tuple
 
 import aiokatcp
 import pytest
@@ -41,6 +41,16 @@ from katsdpcontroller.sensor_proxy import (
     PrometheusWatcher,
     SensorWatcher,
 )
+
+
+def _rewrite_readings(sensor: aiokatcp.Sensor, reading: aiokatcp.Reading):
+    if sensor.name == "prefix-int-sensor":
+        return aiokatcp.Reading(
+            timestamp=reading.timestamp + 0.5,
+            status=aiokatcp.Sensor.Status.WARN,
+            value=reading.value + 1,
+        )
+    return reading
 
 
 class MyEnum(enum.Enum):
@@ -115,9 +125,19 @@ class TestSensorWatcher:
     def close_action(self) -> CloseAction:
         return CloseAction.REMOVE
 
+    @pytest.fixture
+    def rewrite_readings(
+        self,
+    ) -> Optional[Callable[[aiokatcp.Sensor, aiokatcp.Reading], aiokatcp.Reading]]:
+        return None
+
     @pytest.fixture(autouse=True)
     async def client_and_watcher(
-        self, mirror: aiokatcp.SensorSet, server: DummyServer, close_action: CloseAction
+        self,
+        mirror: aiokatcp.SensorSet,
+        server: DummyServer,
+        close_action: CloseAction,
+        rewrite_readings: Optional[Callable[[aiokatcp.Sensor, aiokatcp.Reading], aiokatcp.Reading]],
     ) -> AsyncGenerator[Tuple[aiokatcp.Client, SensorWatcher], None]:
         port = device_server_sockname(server)[1]
         client = aiokatcp.Client("127.0.0.1", port)
@@ -128,7 +148,10 @@ class TestSensorWatcher:
             renames={
                 "bytes-sensor": "custom-bytes-sensor",
                 "broadcast-sensor": ["copy01-broadcast-sensor", "copy02-broadcast-sensor"],
-            },
+            }
+            if not rewrite_readings
+            else None,
+            rewrite_readings=rewrite_readings,
             close_action=close_action,
         )
         client.add_sensor_watcher(watcher)
@@ -234,6 +257,18 @@ class TestSensorWatcher:
         client.handle_inform(changed)
         await watcher.synced.wait()
         self._check_sensors(mirror, server)
+
+    @pytest.mark.parametrize("rewrite_readings", [_rewrite_readings])
+    async def test_rewrite_readings(
+        self,
+        mirror: aiokatcp.SensorSet,
+        server: DummyServer,
+        client: aiokatcp.Client,
+    ) -> None:
+        await self._set(mirror, server, "int-sensor", 3, timestamp=1234567890.0)
+        assert mirror["prefix-int-sensor"].value == 4
+        assert mirror["prefix-int-sensor"].timestamp == 1234567890.5
+        assert mirror["prefix-int-sensor"].status == aiokatcp.Sensor.Status.WARN
 
     async def test_reconnect(
         self,

--- a/test/test_sensor_proxy.py
+++ b/test/test_sensor_proxy.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 ################################################################################
 
-"""Unit tests for :class:`katsdpcontroller.sensor_proxy_client`.
+"""Unit tests for :class:`katsdpcontroller.sensor_proxy`.
 
 Still TODO:
 
@@ -27,7 +27,7 @@ Still TODO:
 import asyncio
 import enum
 import functools
-from typing import Any, AsyncGenerator, Dict, Mapping, Optional
+from typing import Any, AsyncGenerator, Dict, Mapping, Optional, Tuple
 from unittest import mock
 
 import aiokatcp
@@ -40,7 +40,7 @@ from katsdpcontroller.sensor_proxy import (
     CloseAction,
     PrometheusInfo,
     PrometheusWatcher,
-    SensorProxyClient,
+    SensorWatcher,
 )
 
 
@@ -100,7 +100,7 @@ class FutureObserver:
 
 
 @pytest.mark.timeout(5)
-class TestSensorProxyClient:
+class TestSensorWatcher:
     @pytest.fixture
     def mirror(self, mocker) -> mock.MagicMock:
         mirror = mocker.create_autospec(aiokatcp.DeviceServer, instance=True)
@@ -119,11 +119,13 @@ class TestSensorProxyClient:
         return CloseAction.REMOVE
 
     @pytest.fixture(autouse=True)
-    async def client(
+    async def client_and_watcher(
         self, mirror, server: DummyServer, close_action: CloseAction
-    ) -> AsyncGenerator[SensorProxyClient, None]:
+    ) -> AsyncGenerator[Tuple[aiokatcp.Client, SensorWatcher], None]:
         port = device_server_sockname(server)[1]
-        client = SensorProxyClient(
+        client = aiokatcp.Client("127.0.0.1", port)
+        watcher = SensorWatcher(
+            client,
             mirror,
             "prefix-",
             renames={
@@ -131,14 +133,21 @@ class TestSensorProxyClient:
                 "broadcast-sensor": ["copy01-broadcast-sensor", "copy02-broadcast-sensor"],
             },
             close_action=close_action,
-            host="127.0.0.1",
-            port=port,
         )
-        await client.wait_synced()
-        yield client
+        client.add_sensor_watcher(watcher)
+        await watcher.synced.wait()
+        yield client, watcher
 
         client.close()
         await client.wait_closed()
+
+    @pytest.fixture
+    def client(self, client_and_watcher: Tuple[aiokatcp.Client, SensorWatcher]) -> aiokatcp.Client:
+        return client_and_watcher[0]
+
+    @pytest.fixture
+    def watcher(self, client_and_watcher: Tuple[aiokatcp.Client, SensorWatcher]) -> SensorWatcher:
+        return client_and_watcher[1]
 
     def _check_sensors(self, mirror, server: DummyServer) -> None:
         """Compare the upstream sensors against the mirror"""
@@ -186,47 +195,51 @@ class TestSensorProxyClient:
         await self._set(mirror, server, "int-sensor", 2, timestamp=123456790.0)
         self._check_sensors(mirror, server)
 
-    async def test_add_sensor(self, mirror, server: DummyServer, client: SensorProxyClient) -> None:
+    async def test_add_sensor(
+        self, mirror, server: DummyServer, client: aiokatcp.Client, watcher: SensorWatcher
+    ) -> None:
         server.sensors.add(Sensor(int, "another", "another sensor", "", 234))
         # Rather than having server send an interface-changed inform, we invoke
         # it directly on the client so that we don't need to worry about timing.
         changed = aiokatcp.Message.inform("interface-changed", b"sensor-list")
         client.handle_inform(changed)
-        await client.wait_synced()
+        await watcher.synced.wait()
         self._check_sensors(mirror, server)
 
     async def test_remove_sensor(
-        self, mirror, server: DummyServer, client: SensorProxyClient
+        self, mirror, server: DummyServer, client: aiokatcp.Client, watcher: SensorWatcher
     ) -> None:
         del server.sensors["int-sensor"]
         changed = aiokatcp.Message.inform("interface-changed", b"sensor-list")
         client.handle_inform(changed)
-        await client.wait_synced()
+        await watcher.synced.wait()
         self._check_sensors(mirror, server)
 
     async def test_replace_sensor(
-        self, mirror, server: DummyServer, client: SensorProxyClient
+        self, mirror, server: DummyServer, client: aiokatcp.Client, watcher: SensorWatcher
     ) -> None:
         server.sensors.add(Sensor(bool, "int-sensor", "Replaced by bool"))
         changed = aiokatcp.Message.inform("interface-changed", b"sensor-list")
         client.handle_inform(changed)
-        await client.wait_synced()
+        await watcher.synced.wait()
         self._check_sensors(mirror, server)
 
-    async def test_reconnect(self, mirror, server: DummyServer, client: SensorProxyClient) -> None:
+    async def test_reconnect(
+        self, mirror, server: DummyServer, client: aiokatcp.Client, watcher: SensorWatcher
+    ) -> None:
         # Cheat: the client will disconnect if given a #disconnect inform, and
         # we don't actually need to kill the server.
         client.inform_disconnect("Test")
         await client.wait_disconnected()
-        await client.wait_synced()
+        await watcher.synced.wait()
         self._check_sensors(mirror, server)
 
-    async def test_close_action_remove(self, client: SensorProxyClient, mirror) -> None:
+    async def test_close_action_remove(self, client: aiokatcp.Client, mirror) -> None:
         client.close()
         assert list(mirror.sensors) == []
 
     @pytest.mark.parametrize("close_action", [CloseAction.UNREACHABLE])
-    async def test_close_action_unreachable(self, client: SensorProxyClient, mirror) -> None:
+    async def test_close_action_unreachable(self, client: aiokatcp.Client, mirror) -> None:
         client.close()
         assert mirror.sensors["custom-bytes-sensor"].status == Sensor.Status.UNREACHABLE
         assert mirror.sensors["prefix-device-status"].status == Sensor.Status.ERROR

--- a/test/test_sensor_proxy.py
+++ b/test/test_sensor_proxy.py
@@ -43,7 +43,7 @@ from katsdpcontroller.sensor_proxy import (
 )
 
 
-def _rewrite_readings(sensor: aiokatcp.Sensor, reading: aiokatcp.Reading):
+def _rewrite_readings(sensor: aiokatcp.Sensor, reading: aiokatcp.Reading) -> aiokatcp.Reading:
     if sensor.name == "prefix-int-sensor":
         return aiokatcp.Reading(
             timestamp=reading.timestamp + 0.5,

--- a/test/test_sensor_proxy.py
+++ b/test/test_sensor_proxy.py
@@ -19,7 +19,7 @@
 Still TODO:
 
 - tests for Prometheus wrapping
-- test that mirror.mass_inform is called
+- test notify functionality
 - test for the server removing a sensor before we can subscribe to it
 - test for cancellation of the update in various cases
 """

--- a/test/test_sensor_proxy.py
+++ b/test/test_sensor_proxy.py
@@ -111,7 +111,7 @@ class FutureObserver:
 @pytest.mark.timeout(5)
 class TestSensorWatcher:
     @pytest.fixture
-    def mirror(self) -> aiokatcp.SensorSet:
+    def mirrored_sensors(self) -> aiokatcp.SensorSet:
         return aiokatcp.SensorSet()
 
     @pytest.fixture
@@ -134,7 +134,7 @@ class TestSensorWatcher:
     @pytest.fixture(autouse=True)
     async def client_and_watcher(
         self,
-        mirror: aiokatcp.SensorSet,
+        mirrored_sensors: aiokatcp.SensorSet,
         server: DummyServer,
         close_action: CloseAction,
         rewrite_readings: Optional[Callable[[aiokatcp.Sensor, aiokatcp.Reading], aiokatcp.Reading]],
@@ -143,7 +143,7 @@ class TestSensorWatcher:
         client = aiokatcp.Client("127.0.0.1", port)
         watcher = SensorWatcher(
             client,
-            mirror,
+            mirrored_sensors,
             "prefix-",
             renames={
                 "bytes-sensor": "custom-bytes-sensor",
@@ -169,8 +169,8 @@ class TestSensorWatcher:
     def watcher(self, client_and_watcher: Tuple[aiokatcp.Client, SensorWatcher]) -> SensorWatcher:
         return client_and_watcher[1]
 
-    def _check_sensors(self, mirror: aiokatcp.SensorSet, server: DummyServer) -> None:
-        """Compare the upstream sensors against the mirror"""
+    def _check_sensors(self, mirrored_sensors: aiokatcp.SensorSet, server: DummyServer) -> None:
+        """Compare the upstream sensors against the mirrored sensors."""
         for sensor in server.sensors.values():
             qualnames = ["prefix-" + sensor.name]
             if sensor.name == "bytes-sensor":
@@ -178,8 +178,8 @@ class TestSensorWatcher:
             elif sensor.name == "broadcast-sensor":
                 qualnames = ["copy01-broadcast-sensor", "copy02-broadcast-sensor"]
             for qualname in qualnames:
-                assert qualname in mirror
-                sensor2 = mirror[qualname]
+                assert qualname in mirrored_sensors
+                sensor2 = mirrored_sensors[qualname]
                 assert sensor.description == sensor2.description
                 assert sensor.type_name == sensor2.type_name
                 assert sensor.units == sensor2.units
@@ -190,7 +190,7 @@ class TestSensorWatcher:
                 assert sensor.timestamp == sensor2.timestamp
                 assert sensor.status == sensor2.status
         # Check that we don't have any we shouldn't
-        for sensor2 in mirror.values():
+        for sensor2 in mirrored_sensors.values():
             assert sensor2.name.startswith("prefix-") or sensor2.name in {
                 "custom-bytes-sensor",
                 "copy01-broadcast-sensor",
@@ -198,28 +198,35 @@ class TestSensorWatcher:
             }
             base_name = sensor2.name[7:]
             assert base_name in server.sensors
-        assert "prefix-bytes-sensor" not in mirror
+        assert "prefix-bytes-sensor" not in mirrored_sensors
 
-    async def test_init(self, mirror: aiokatcp.SensorSet, server: DummyServer) -> None:
-        self._check_sensors(mirror, server)
+    async def test_init(self, mirrored_sensors: aiokatcp.SensorSet, server: DummyServer) -> None:
+        self._check_sensors(mirrored_sensors, server)
 
     async def _set(
-        self, mirror: aiokatcp.SensorSet, server: DummyServer, name: str, value: Any, **kwargs
+        self,
+        mirrored_sensors: aiokatcp.SensorSet,
+        server: DummyServer,
+        name: str,
+        value: Any,
+        **kwargs,
     ) -> None:
-        """Set a sensor on the server and wait for the mirror to observe it"""
+        """Set a sensor on the server and wait for the mirrored sensors to observe it."""
         observer = FutureObserver()
-        mirror["prefix-" + name].attach(observer)
+        mirrored_sensors["prefix-" + name].attach(observer)
         server.sensors[name].set_value(value, **kwargs)
         await observer.future
-        mirror["prefix-" + name].detach(observer)
+        mirrored_sensors["prefix-" + name].detach(observer)
 
-    async def test_set_value(self, mirror: aiokatcp.SensorSet, server: DummyServer) -> None:
-        await self._set(mirror, server, "int-sensor", 2, timestamp=123456790.0)
-        self._check_sensors(mirror, server)
+    async def test_set_value(
+        self, mirrored_sensors: aiokatcp.SensorSet, server: DummyServer
+    ) -> None:
+        await self._set(mirrored_sensors, server, "int-sensor", 2, timestamp=123456790.0)
+        self._check_sensors(mirrored_sensors, server)
 
     async def test_add_sensor(
         self,
-        mirror: aiokatcp.SensorSet,
+        mirrored_sensors: aiokatcp.SensorSet,
         server: DummyServer,
         client: aiokatcp.Client,
         watcher: SensorWatcher,
@@ -230,11 +237,11 @@ class TestSensorWatcher:
         changed = aiokatcp.Message.inform("interface-changed", b"sensor-list")
         client.handle_inform(changed)
         await watcher.synced.wait()
-        self._check_sensors(mirror, server)
+        self._check_sensors(mirrored_sensors, server)
 
     async def test_remove_sensor(
         self,
-        mirror: aiokatcp.SensorSet,
+        mirrored_sensors: aiokatcp.SensorSet,
         server: DummyServer,
         client: aiokatcp.Client,
         watcher: SensorWatcher,
@@ -243,11 +250,11 @@ class TestSensorWatcher:
         changed = aiokatcp.Message.inform("interface-changed", b"sensor-list")
         client.handle_inform(changed)
         await watcher.synced.wait()
-        self._check_sensors(mirror, server)
+        self._check_sensors(mirrored_sensors, server)
 
     async def test_replace_sensor(
         self,
-        mirror: aiokatcp.SensorSet,
+        mirrored_sensors: aiokatcp.SensorSet,
         server: DummyServer,
         client: aiokatcp.Client,
         watcher: SensorWatcher,
@@ -256,23 +263,23 @@ class TestSensorWatcher:
         changed = aiokatcp.Message.inform("interface-changed", b"sensor-list")
         client.handle_inform(changed)
         await watcher.synced.wait()
-        self._check_sensors(mirror, server)
+        self._check_sensors(mirrored_sensors, server)
 
     @pytest.mark.parametrize("rewrite_readings", [_rewrite_readings])
     async def test_rewrite_readings(
         self,
-        mirror: aiokatcp.SensorSet,
+        mirrored_sensors: aiokatcp.SensorSet,
         server: DummyServer,
         client: aiokatcp.Client,
     ) -> None:
-        await self._set(mirror, server, "int-sensor", 3, timestamp=1234567890.0)
-        assert mirror["prefix-int-sensor"].value == 4
-        assert mirror["prefix-int-sensor"].timestamp == 1234567890.5
-        assert mirror["prefix-int-sensor"].status == aiokatcp.Sensor.Status.WARN
+        await self._set(mirrored_sensors, server, "int-sensor", 3, timestamp=1234567890.0)
+        assert mirrored_sensors["prefix-int-sensor"].value == 4
+        assert mirrored_sensors["prefix-int-sensor"].timestamp == 1234567890.5
+        assert mirrored_sensors["prefix-int-sensor"].status == aiokatcp.Sensor.Status.WARN
 
     async def test_reconnect(
         self,
-        mirror: aiokatcp.SensorSet,
+        mirrored_sensors: aiokatcp.SensorSet,
         server: DummyServer,
         client: aiokatcp.Client,
         watcher: SensorWatcher,
@@ -282,22 +289,22 @@ class TestSensorWatcher:
         client.inform_disconnect("Test")
         await client.wait_disconnected()
         await watcher.synced.wait()
-        self._check_sensors(mirror, server)
+        self._check_sensors(mirrored_sensors, server)
 
     async def test_close_action_remove(
-        self, client: aiokatcp.Client, mirror: aiokatcp.SensorSet
+        self, client: aiokatcp.Client, mirrored_sensors: aiokatcp.SensorSet
     ) -> None:
         client.close()
-        assert list(mirror) == []
+        assert list(mirrored_sensors) == []
 
     @pytest.mark.parametrize("close_action", [CloseAction.UNREACHABLE])
     async def test_close_action_unreachable(
-        self, client: aiokatcp.Client, mirror: aiokatcp.SensorSet
+        self, client: aiokatcp.Client, mirrored_sensors: aiokatcp.SensorSet
     ) -> None:
         client.close()
-        assert mirror["custom-bytes-sensor"].status == Sensor.Status.UNREACHABLE
-        assert mirror["prefix-device-status"].status == Sensor.Status.ERROR
-        assert mirror["prefix-device-status"].value.value == b"fail"
+        assert mirrored_sensors["custom-bytes-sensor"].status == Sensor.Status.UNREACHABLE
+        assert mirrored_sensors["prefix-device-status"].status == Sensor.Status.ERROR
+        assert mirrored_sensors["prefix-device-status"].value.value == b"fail"
 
 
 class TestPrometheusWatcher:

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -255,9 +255,11 @@ class TestWeb:
         )
         for sensor in mc_server.orig_sensors.values():
             if use_haproxy and sensor.name.endswith(".gui-urls"):
-                new_value = web.rewrite_gui_urls(EXTERNAL_URL, sensor)
+                new_reading = web.rewrite_gui_urls(EXTERNAL_URL, sensor, sensor.reading)
                 new_sensor = Sensor(sensor.stype, sensor.name, sensor.description, sensor.units)
-                new_sensor.set_value(new_value, timestamp=sensor.timestamp, status=sensor.status)
+                new_sensor.set_value(
+                    new_reading.value, timestamp=new_reading.timestamp, status=new_reading.status
+                )
                 mc_server.sensors.add(new_sensor)
             else:
                 mc_server.sensors.add(sensor)


### PR DESCRIPTION
This prevents them appearing in the device server's sensor list.

Most of the commits are refactoring of the SensorWatcher framework to replace one very complicated SensorWatcher with a simpler implementation which then gets used multiple times with different to achieve different things. I kept the history reasonably clean to aid piecemeal reviewing.

Closes NGC-2042

- [ ] Run qualification test to ensure they don't depend on any of these sensors.