### PR TITLE
Fix vgpu multicast_in

### DIFF
--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1632,7 +1632,9 @@ def _make_vgpu(
         scheduler.InterfaceRequest(
             "gpucbf",
             infiniband=ibv,
-            multicast_in={src_stream.name for src_stream in stream.src_streams},
+            multicast_in={
+                (src_stream.name, i) for src_stream in tacv for i in range(src_stream.n_substreams)
+            },
             multicast_out={stream.name},
         )
     ]

--- a/src/katsdpcontroller/generator.py
+++ b/src/katsdpcontroller/generator.py
@@ -1294,7 +1294,7 @@ def _make_xbgpu(
                 "gpucbf",
                 infiniband=ibv,
                 multicast_in={acv.name},
-                multicast_out={(stream, i) for stream in streams},
+                multicast_out={(stream.name, i) for stream in streams},
             )
         ]
         xbgpu.interfaces[0].bandwidth_in = acv.data_rate() / n_engines


### PR DESCRIPTION
It was specified with just the stream name, but the xb-engines
multicast_out has a separate entry for each substream, so they were not
matching. Also, xbgpu's multicast_out was accidentally using the stream object instead of the stream name.

Closes NGC-2091